### PR TITLE
M1: Auth + D1 + Base API

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,20 @@
+# Copy this file to `.dev.vars` (gitignored) for `wrangler dev`.
+#
+#   cp .dev.vars.example .dev.vars
+#
+# Wrangler reads `.dev.vars`, not `.env`. Real Access deployments override
+# these via the dashboard or a wrangler `env` block — these defaults exist
+# only so `pnpm dev` can boot without an Access tenant.
+
+# Set to your real Cloudflare Access team subdomain in production.
+ACCESS_TEAM=loomwiki-dev
+
+# Set to your real Cloudflare Access application AUD tag in production.
+ACCESS_AUD=loomwiki-dev-aud
+
+# When "true", the worker accepts an `X-Local-Dev-Email` header in place of
+# a Cloudflare Access JWT — *only* if the request also passes the IP gate
+# (127.0.0.1 / ::1) and the runtime is non-production. Triple-gated; see
+# apps/worker/src/middleware/auth.ts.
+ALLOW_LOCAL_DEV_AUTH=true
+LOCAL_DEV_EMAIL=cory@example.com

--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,52 @@
-# Loomwiki environment variables and Wrangler secrets reference
+# Loomwiki environment variables.
 #
-# Wrangler secrets — set per environment with: wrangler secret put <NAME>
-# Never commit real values. .env / .dev.vars are gitignored.
+# This file documents the names of vars and secrets read by the worker. Copy
+# the auth keys you need into `.dev.vars` (NOT .env) for `wrangler dev` —
+# wrangler loads `.dev.vars`, not `.env`. `.dev.vars` is gitignored.
+#
+# Never commit real values to this file.
 
-# Sentry DSN (M8). Worker reports to Sentry when set.
+# ---- Wrangler secrets (set in production via `wrangler secret put`) ----
+
+# Sentry project DSN. Wired in M8.
 SENTRY_DSN=
 
-# 32-byte base64-encoded key for envelope-encrypting BYOK provider keys (M8).
-# Generate with: openssl rand -base64 32
+# 32-byte base64 key used to envelope-encrypt BYOK keys. Generate with:
+#   openssl rand -base64 32
+# Wired in M8.
 BYOK_ENCRYPTION_KEY=
 
-# Token for the Cloudflare Artifacts API (M4). Replaced with a binding once Artifacts
-# ships its Worker binding GA — see SPEC §5 Q-bindings.
+# Cloudflare Artifacts API token. Used by M4+ wiki commit path.
 ARTIFACTS_TOKEN=
 
-# AI Gateway proxy token (M6/M8). Used to route Workers AI calls through AI Gateway
-# for caching and observability.
+# AI Gateway proxy token. Used by M6+ LLM calls.
 AI_GATEWAY_TOKEN=
 
-# Build-time only — populated by CI. Surfaced via /api/health.commit. Optional in dev.
+# ---- Cloudflare Access auth (M1) ----
+
+# Access team subdomain (the part before `.cloudflareaccess.com`). Look it
+# up in the Cloudflare dashboard under Zero Trust → Settings → Custom Pages.
+ACCESS_TEAM=
+
+# Access application AUD tag. Look it up in the Cloudflare dashboard under
+# Zero Trust → Access → Applications → <your app> → Overview.
+ACCESS_AUD=
+
+# Local-dev auth bypass (X-Local-Dev-Email header). Triple-gated; defaults to
+# off. ONLY enable for `wrangler dev` on your laptop. Setting to "true" in a
+# deployed environment is a security regression — the request must also come
+# from 127.0.0.1 / ::1 to be honored, but operators must keep this off in
+# anything reachable from the public internet.
+ALLOW_LOCAL_DEV_AUTH=false
+
+# Default email for the local-dev bypass UI. Optional convenience for `pnpm
+# dev` workflows; the actual email is supplied per-request via the
+# X-Local-Dev-Email header.
+LOCAL_DEV_EMAIL=
+
+# ---- CI ----
+
+# Populated by GitHub Actions from ${{ github.sha }}. Surfaced via /api/health
+# when CF_VERSION_METADATA is unavailable (i.e., in dev). Operators can also
+# set this manually in `.dev.vars` to verify the fallback path.
 GIT_COMMIT=

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pnpm-debug.log*
 .wrangler/
 .dev.vars
 .dev.vars.*
+!.dev.vars.example
 wrangler.toml.bak
 
 # Build outputs

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,180 @@
+# Loomwiki — Deployment
+
+> Operator guide for self-hosting Loomwiki on a Cloudflare account. The full
+> deploy story rounds out across M1–M8; this file grows with each milestone.
+> M1 covers auth + the data layer.
+
+## Prerequisites
+
+- A Cloudflare account (free tier is fine for the dogfood deploy).
+- `wrangler` CLI authenticated (`wrangler login`).
+- pnpm 10.x and Node 22.x.
+
+## One-time setup
+
+### 1. Create the D1 database and KV namespace
+
+```sh
+wrangler d1 create loomwiki
+wrangler kv namespace create CACHE
+```
+
+Copy the `database_id` and `id` values into `wrangler.jsonc` (replace the
+`<TBD>` placeholders).
+
+### 2. Set up Cloudflare Access
+
+Loomwiki's auth is Cloudflare Access (free tier, email OTP). The worker
+verifies the `CF-Access-Jwt-Assertion` header on every authenticated request
+(see `apps/worker/src/lib/auth.ts`). Without Access in front, the worker is
+inaccessible — **the local-dev bypass is the only escape hatch and is
+disabled by default**.
+
+#### a. Create the Zero Trust team
+
+If you don't already have one: open the Cloudflare dashboard → **Zero Trust**
+→ accept the free plan. Pick a team name; the resulting subdomain is
+`<team>.cloudflareaccess.com`. That `<team>` value is your `ACCESS_TEAM`.
+
+#### b. Create the Access application
+
+In **Zero Trust → Access → Applications → Add an application**:
+
+- **Type**: Self-hosted.
+- **Application domain**: the public domain you'll route the worker on (per
+  `wrangler.jsonc` `routes`, e.g. `api.loomwiki.com`).
+- **Identity providers**: enable **One-time PIN** for the simplest setup. Add
+  GitHub OAuth or Google Workspace if you want SSO.
+- **Policy**: create one **Allow** policy with the email addresses (or
+  domains) you want to grant access. Service tokens, if any, must use the
+  separate **Service Auth** policy action — never **Allow**.
+
+Save. On the application overview, copy the **Application Audience (AUD)**
+tag — that's your `ACCESS_AUD`.
+
+#### c. Plumb the values into the worker
+
+Two options:
+
+- **Recommended (production)**: set `ACCESS_TEAM` and `ACCESS_AUD` as vars in
+  the Cloudflare dashboard under **Workers → loomwiki-api → Settings →
+  Variables**. They override the defaults in `wrangler.jsonc`.
+- **Alternative (single-deploy fork)**: edit the `vars` block in
+  `wrangler.jsonc` to replace the dev placeholders. Commit only if your fork
+  is private — these aren't secrets but they identify your tenant.
+
+The dev placeholders in `wrangler.jsonc` (`loomwiki-dev`, `loomwiki-dev-aud`)
+are wrong on purpose: a fresh deploy fails closed if the operator forgets to
+set real values.
+
+### 3. Apply the D1 migrations
+
+```sh
+pnpm migrate:remote      # against the production DB
+```
+
+Run this once at deploy time and again whenever you pull new migrations.
+Migrations are forward-only — a new migration is a new file in
+`packages/schema/d1-migrations/`, never an edit to a committed file.
+
+For local development:
+
+```sh
+pnpm migrate:local       # against the local miniflare DB at .wrangler/state/v3/d1
+```
+
+To verify the schema applied:
+
+```sh
+wrangler d1 execute loomwiki --local --config wrangler.jsonc \
+  --command "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+```
+
+You should see `byok_keys, ingest_runs, messages, proposals, room_members, rooms, users, workspaces` (plus the wrangler-internal `d1_migrations` and `sqlite_*`).
+
+### 4. Set Worker secrets (M8 will use these; M1 doesn't)
+
+```sh
+wrangler secret put SENTRY_DSN
+wrangler secret put BYOK_ENCRYPTION_KEY     # openssl rand -base64 32
+wrangler secret put ARTIFACTS_TOKEN
+wrangler secret put AI_GATEWAY_TOKEN
+```
+
+### 5. Deploy
+
+```sh
+pnpm deploy
+```
+
+## Local development
+
+```sh
+cp .dev.vars.example .dev.vars
+# edit .dev.vars — set LOCAL_DEV_EMAIL, leave ALLOW_LOCAL_DEV_AUTH=true
+pnpm dev
+```
+
+The worker boots on `http://127.0.0.1:8788`. Hit `/api/me` with the
+`X-Local-Dev-Email` header instead of an Access JWT:
+
+```sh
+curl -s -H "X-Local-Dev-Email: cory@example.com" http://127.0.0.1:8788/api/me | jq .
+```
+
+### How the local-dev bypass is gated
+
+The `X-Local-Dev-Email` header is honored only when **all three** conditions
+hold:
+
+1. `process.env.NODE_ENV !== "production"` — symbolic check; `NODE_ENV` is
+   undefined in the production Workers runtime, so this passes by default.
+   Mostly a tripwire for accidental builds-with-NODE_ENV-set.
+2. `env.ALLOW_LOCAL_DEV_AUTH === "true"` — operator must explicitly opt in.
+   Default is `"false"` in `wrangler.jsonc`. Production deployments must
+   leave it that way.
+3. `CF-Connecting-IP` is absent or one of `127.0.0.1` / `::1`. In production
+   Cloudflare always sets this header to the real client IP, so the bypass
+   is unreachable from the public internet.
+
+Failing any one gate causes the worker to fall back to JWT validation, which
+then fails closed with `AUTH_REQUIRED` since no Access JWT was supplied.
+There is no single-flag bypass.
+
+If you suspect the bypass is leaking in production, search `wrangler tail`
+for `LOCAL DEV AUTH ENABLED` — the worker logs that warning the first time
+the gate trips per isolate.
+
+### Invalidating the JWKS cache during dev
+
+The Access JWKS is cached in KV for 24 hours. If you rotate Access keys
+(rare) and want to force a refresh:
+
+```sh
+curl -X POST http://127.0.0.1:8788/api/_debug/invalidate-jwks
+```
+
+This route returns `404` unless `ALLOW_LOCAL_DEV_AUTH=true`.
+
+## Migration runbook (operator)
+
+```sh
+# Add a new migration:
+pnpm migrate:new add_audit_log
+
+# Apply locally:
+pnpm migrate:local
+
+# Apply to production after the change merges:
+pnpm migrate:remote
+```
+
+Migrations are idempotent: re-running `migrate:remote` after a successful
+apply is a no-op. To roll back, write a forward migration that undoes the
+change — never edit a committed migration file (CLAUDE.md "Do not touch").
+
+## Right-to-deletion (operator note)
+
+Chat messages can be soft-deleted from D1 and the live DO. They cannot be
+removed from the Artifacts repo (the wiki + chat-log committed history is
+git, immutable by design). This is documented in `docs/SECURITY.md` §M25.

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -12,8 +12,10 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@loomwiki/schema": "workspace:*",
     "@loomwiki/shared": "workspace:*",
-    "hono": "^4.6.14"
+    "hono": "^4.6.14",
+    "jose": "^5.9.6"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.15.2",

--- a/apps/worker/src/__tests__/__fixtures__/db.ts
+++ b/apps/worker/src/__tests__/__fixtures__/db.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Migration + reset helpers for tests. Apply once per test file in beforeAll;
+// reset between tests so state does not leak.
+
+import { applyD1Migrations, env } from "cloudflare:test";
+
+export async function applyMigrations(): Promise<void> {
+  if (!env.TEST_MIGRATIONS) {
+    throw new Error(
+      "TEST_MIGRATIONS binding missing — vitest.config.ts must read packages/schema/d1-migrations",
+    );
+  }
+  await applyD1Migrations(env.DB, env.TEST_MIGRATIONS);
+}
+
+// Truncate the application tables. Order respects FK references.
+const TRUNCATE_ORDER = [
+  "byok_keys",
+  "proposals",
+  "ingest_runs",
+  "messages",
+  "room_members",
+  "rooms",
+  "workspaces",
+  "users",
+];
+
+export async function resetDb(): Promise<void> {
+  for (const table of TRUNCATE_ORDER) {
+    await env.DB.prepare(`DELETE FROM ${table}`).run();
+  }
+}
+
+export async function clearJwksCache(): Promise<void> {
+  // KV in miniflare-test mode persists across tests in a file unless cleared.
+  // Each test that mutates JWKS state should call this in beforeEach.
+  const list = await env.CACHE.list({ prefix: "access-jwks:" });
+  for (const key of list.keys) {
+    await env.CACHE.delete(key.name);
+  }
+}

--- a/apps/worker/src/__tests__/__fixtures__/jwt.ts
+++ b/apps/worker/src/__tests__/__fixtures__/jwt.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// JWT fixture for auth tests. Generates an RSA keypair at fixture-load time
+// and exposes a `mintTestJwt` helper. Tests seed the public key into KV
+// (`access-jwks:<team>`) so verifyAccessJwt() reads from cache and never
+// fetches the real Access JWKS endpoint.
+
+import * as jose from "jose";
+
+const KID = "loomwiki-test-key";
+
+export interface MintOptions {
+  email: string;
+  sub?: string;
+  audience?: string;
+  issuer?: string;
+  /** Pass an absolute epoch (seconds) to make the token expired or far-future. */
+  expSeconds?: number;
+  /** Override `kid` to test the wrong-key path. */
+  kid?: string;
+}
+
+export interface JwtFixture {
+  jwks: jose.JSONWebKeySet;
+  mint(opts: MintOptions): Promise<string>;
+  /** Sign with a different (untrusted) keypair; useful for invalid-signature tests. */
+  mintWithRogueKey(opts: MintOptions): Promise<string>;
+}
+
+async function exportPublicJwk(publicKey: jose.KeyLike, kid: string): Promise<jose.JWK> {
+  const jwk = await jose.exportJWK(publicKey);
+  jwk.kid = kid;
+  jwk.alg = "RS256";
+  jwk.use = "sig";
+  return jwk;
+}
+
+export async function makeJwtFixture(): Promise<JwtFixture> {
+  const trusted = await jose.generateKeyPair("RS256", { extractable: true });
+  const rogue = await jose.generateKeyPair("RS256", { extractable: true });
+  const trustedJwk = await exportPublicJwk(trusted.publicKey, KID);
+  const jwks: jose.JSONWebKeySet = { keys: [trustedJwk] };
+
+  function buildBuilder(opts: MintOptions): jose.SignJWT {
+    const issuer = opts.issuer ?? "https://loomwiki-dev.cloudflareaccess.com";
+    const audience = opts.audience ?? "loomwiki-dev-aud";
+    const sub = opts.sub ?? "test-sub";
+    const builder = new jose.SignJWT({ email: opts.email })
+      .setProtectedHeader({ alg: "RS256", kid: opts.kid ?? KID })
+      .setIssuer(issuer)
+      .setAudience(audience)
+      .setSubject(sub)
+      .setIssuedAt();
+    if (opts.expSeconds !== undefined) builder.setExpirationTime(opts.expSeconds);
+    else builder.setExpirationTime("5m");
+    return builder;
+  }
+
+  return {
+    jwks,
+    async mint(opts) {
+      return buildBuilder(opts).sign(trusted.privateKey);
+    },
+    async mintWithRogueKey(opts) {
+      return buildBuilder(opts).sign(rogue.privateKey);
+    },
+  };
+}

--- a/apps/worker/src/__tests__/auth.test.ts
+++ b/apps/worker/src/__tests__/auth.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { SELF, env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, clearJwksCache, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+interface ErrBody {
+  ok: false;
+  error: { code: string; message: string };
+}
+
+async function readErr(res: Response): Promise<ErrBody> {
+  return (await res.json()) as ErrBody;
+}
+
+describe("auth middleware", () => {
+  it("rejects requests with no JWT (AUTH_REQUIRED, 401)", async () => {
+    const res = await SELF.fetch("https://api.local/api/me");
+    expect(res.status).toBe(401);
+    const body = await readErr(res);
+    expect(body.ok).toBe(false);
+    expect(body.error.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("accepts a valid JWT and returns 200 on /api/me", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const res = await SELF.fetch("https://api.local/api/me", {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects a JWT signed with the wrong key (AUTH_INVALID_JWT, 401)", async () => {
+    const jwt = await fixture.mintWithRogueKey({ email: "bob@example.com" });
+    const res = await SELF.fetch("https://api.local/api/me", {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(res.status).toBe(401);
+    const body = await readErr(res);
+    expect(body.error.code).toBe("AUTH_INVALID_JWT");
+  });
+
+  it("rejects an expired JWT (AUTH_EXPIRED, 401)", async () => {
+    const past = Math.floor(Date.now() / 1000) - 60;
+    const jwt = await fixture.mint({ email: "carol@example.com", expSeconds: past });
+    const res = await SELF.fetch("https://api.local/api/me", {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(res.status).toBe(401);
+    const body = await readErr(res);
+    expect(body.error.code).toBe("AUTH_EXPIRED");
+  });
+
+  it("rejects a JWT with the wrong audience (AUTH_INVALID_JWT, 401)", async () => {
+    const jwt = await fixture.mint({
+      email: "dave@example.com",
+      audience: "not-the-real-aud",
+    });
+    const res = await SELF.fetch("https://api.local/api/me", {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(res.status).toBe(401);
+    const body = await readErr(res);
+    expect(body.error.code).toBe("AUTH_INVALID_JWT");
+  });
+
+  it("rejects a JWT with the wrong issuer (AUTH_INVALID_JWT, 401)", async () => {
+    const jwt = await fixture.mint({
+      email: "eve@example.com",
+      issuer: "https://attacker.cloudflareaccess.com",
+    });
+    const res = await SELF.fetch("https://api.local/api/me", {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(res.status).toBe(401);
+    const body = await readErr(res);
+    expect(body.error.code).toBe("AUTH_INVALID_JWT");
+  });
+
+  it("rejects a malformed JWT (AUTH_INVALID_JWT, 401)", async () => {
+    const res = await SELF.fetch("https://api.local/api/me", {
+      headers: { "CF-Access-Jwt-Assertion": "not-a-real-jwt" },
+    });
+    expect(res.status).toBe(401);
+    const body = await readErr(res);
+    expect(body.error.code).toBe("AUTH_INVALID_JWT");
+  });
+});
+
+describe("local-dev auth bypass", () => {
+  beforeEach(() => {
+    env.ALLOW_LOCAL_DEV_AUTH = "false";
+  });
+
+  it("ignores X-Local-Dev-Email when ALLOW_LOCAL_DEV_AUTH is not 'true'", async () => {
+    env.ALLOW_LOCAL_DEV_AUTH = "false";
+    const res = await SELF.fetch("https://api.local/api/me", {
+      headers: { "X-Local-Dev-Email": "alice@example.com" },
+    });
+    expect(res.status).toBe(401);
+    const body = await readErr(res);
+    expect(body.error.code).toBe("AUTH_REQUIRED");
+  });
+
+  it("accepts X-Local-Dev-Email when the flag is on and CF-Connecting-IP is missing", async () => {
+    env.ALLOW_LOCAL_DEV_AUTH = "true";
+    const res = await SELF.fetch("https://api.local/api/me", {
+      headers: { "X-Local-Dev-Email": "alice@example.com" },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("accepts X-Local-Dev-Email when CF-Connecting-IP is 127.0.0.1", async () => {
+    env.ALLOW_LOCAL_DEV_AUTH = "true";
+    const res = await SELF.fetch("https://api.local/api/me", {
+      headers: {
+        "X-Local-Dev-Email": "alice@example.com",
+        "CF-Connecting-IP": "127.0.0.1",
+      },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects X-Local-Dev-Email when CF-Connecting-IP is not localhost (8.8.8.8)", async () => {
+    env.ALLOW_LOCAL_DEV_AUTH = "true";
+    const res = await SELF.fetch("https://api.local/api/me", {
+      headers: {
+        "X-Local-Dev-Email": "alice@example.com",
+        "CF-Connecting-IP": "8.8.8.8",
+      },
+    });
+    expect(res.status).toBe(401);
+    const body = await readErr(res);
+    expect(body.error.code).toBe("AUTH_REQUIRED");
+  });
+});
+
+describe("debug invalidate-jwks", () => {
+  it("returns 404 when ALLOW_LOCAL_DEV_AUTH is off", async () => {
+    env.ALLOW_LOCAL_DEV_AUTH = "false";
+    const res = await SELF.fetch("https://api.local/api/_debug/invalidate-jwks", {
+      method: "POST",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("invalidates the cached JWKS when ALLOW_LOCAL_DEV_AUTH is on", async () => {
+    env.ALLOW_LOCAL_DEV_AUTH = "true";
+    await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+    expect(await env.CACHE.get(`access-jwks:${env.ACCESS_TEAM}`)).not.toBeNull();
+
+    const res = await SELF.fetch("https://api.local/api/_debug/invalidate-jwks", {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+
+    expect(await env.CACHE.get(`access-jwks:${env.ACCESS_TEAM}`)).toBeNull();
+
+    // Re-seed for downstream tests.
+    await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+  });
+
+  it("returns 404 when the IP gate fails (CF-Connecting-IP=8.8.8.8) even with the flag on", async () => {
+    env.ALLOW_LOCAL_DEV_AUTH = "true";
+    const res = await SELF.fetch("https://api.local/api/_debug/invalidate-jwks", {
+      method: "POST",
+      headers: { "CF-Connecting-IP": "8.8.8.8" },
+    });
+    expect(res.status).toBe(404);
+  });
+});
+
+// Reference clearJwksCache so the import isn't dead — exercised by tests
+// that run after this suite if needed.
+void clearJwksCache;

--- a/apps/worker/src/__tests__/health.test.ts
+++ b/apps/worker/src/__tests__/health.test.ts
@@ -24,6 +24,6 @@ describe("GET /api/health", () => {
     expect(res.status).toBe(404);
     const body = (await res.json()) as { ok: boolean; error?: { code: string } };
     expect(body.ok).toBe(false);
-    expect(body.error?.code).toBe("not_found");
+    expect(body.error?.code).toBe("NOT_FOUND");
   });
 });

--- a/apps/worker/src/__tests__/me.test.ts
+++ b/apps/worker/src/__tests__/me.test.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { SELF, env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+interface OkBody<T> {
+  ok: true;
+  data: T;
+}
+
+interface MeBody {
+  user: { id: string; email: string; display_name: string; created_at: string };
+  workspace: { id: string; name: string; owner_id: string; created_at: string };
+  rooms: { id: string; slug: string }[];
+}
+
+async function fetchMe(jwt: string): Promise<OkBody<MeBody>> {
+  const res = await SELF.fetch("https://api.local/api/me", {
+    headers: { "CF-Access-Jwt-Assertion": jwt },
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as OkBody<MeBody>;
+}
+
+describe("GET /api/me", () => {
+  it("JIT-creates a user on first call and is idempotent on subsequent calls", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+
+    const first = await fetchMe(jwt);
+    expect(first.data.user.email).toBe("alice@example.com");
+    expect(first.data.user.display_name).toBe("Alice"); // local-part, capitalized
+    expect(first.data.rooms).toEqual([]);
+    const userId = first.data.user.id;
+    const workspaceId = first.data.workspace.id;
+
+    const second = await fetchMe(jwt);
+    expect(second.data.user.id).toBe(userId);
+    expect(second.data.workspace.id).toBe(workspaceId);
+  });
+
+  it("returns ISO-8601 timestamps for created_at", async () => {
+    const jwt = await fixture.mint({ email: "bob@example.com" });
+    const body = await fetchMe(jwt);
+    expect(body.data.user.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    expect(body.data.workspace.created_at).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("makes the first authenticated user the workspace owner", async () => {
+    const jwt = await fixture.mint({ email: "first@example.com" });
+    const body = await fetchMe(jwt);
+    expect(body.data.workspace.owner_id).toBe(body.data.user.id);
+
+    // A second user should see the existing workspace, not become a new owner.
+    const jwt2 = await fixture.mint({ email: "second@example.com" });
+    const body2 = await fetchMe(jwt2);
+    expect(body2.data.workspace.id).toBe(body.data.workspace.id);
+    expect(body2.data.workspace.owner_id).toBe(body.data.user.id);
+    expect(body2.data.user.id).not.toBe(body.data.user.id);
+  });
+
+  it("normalizes email casing — JIT for ALICE@example.com matches alice@example.com", async () => {
+    const jwt1 = await fixture.mint({ email: "Mixed@Example.COM" });
+    const body1 = await fetchMe(jwt1);
+    const jwt2 = await fixture.mint({ email: "mixed@example.com" });
+    const body2 = await fetchMe(jwt2);
+    expect(body2.data.user.id).toBe(body1.data.user.id);
+  });
+});

--- a/apps/worker/src/__tests__/rooms.test.ts
+++ b/apps/worker/src/__tests__/rooms.test.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { SELF, env } from "cloudflare:test";
+import { id } from "@loomwiki/shared";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+interface Bootstrap {
+  jwt: string;
+  workspaceId: string;
+  userId: string;
+  roomId: string;
+  roomSlug: string;
+}
+
+async function bootstrapAliceWithRoom(): Promise<Bootstrap> {
+  const jwt = await fixture.mint({ email: "alice@example.com" });
+  const me = await SELF.fetch("https://api.local/api/me", {
+    headers: { "CF-Access-Jwt-Assertion": jwt },
+  });
+  const meBody = (await me.json()) as {
+    data: { user: { id: string }; workspace: { id: string } };
+  };
+
+  const create = await SELF.fetch(
+    `https://api.local/api/workspaces/${meBody.data.workspace.id}/rooms`,
+    {
+      method: "POST",
+      headers: {
+        "CF-Access-Jwt-Assertion": jwt,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ slug: "general", name: "General" }),
+    },
+  );
+  const room = (await create.json()) as { data: { room: { id: string; slug: string } } };
+
+  return {
+    jwt,
+    workspaceId: meBody.data.workspace.id,
+    userId: meBody.data.user.id,
+    roomId: room.data.room.id,
+    roomSlug: room.data.room.slug,
+  };
+}
+
+describe("rooms routes", () => {
+  it("GET /api/rooms/:rid returns the room for a member", async () => {
+    const { jwt, roomId, roomSlug } = await bootstrapAliceWithRoom();
+    const res = await SELF.fetch(`https://api.local/api/rooms/${roomId}`, {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { room: { id: string; slug: string } } };
+    expect(body.data.room.id).toBe(roomId);
+    expect(body.data.room.slug).toBe(roomSlug);
+  });
+
+  it("GET /api/rooms/:rid returns 404 for an unknown room id", async () => {
+    const { jwt } = await bootstrapAliceWithRoom();
+    const res = await SELF.fetch(`https://api.local/api/rooms/${id()}`, {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("GET /api/rooms/:rid returns 403 for a non-member", async () => {
+    const { roomId } = await bootstrapAliceWithRoom();
+    // A different authenticated user who hasn't joined Alice's room.
+    const bobJwt = await fixture.mint({ email: "bob@example.com" });
+    // Bob hits /api/me first to JIT-create his row.
+    await SELF.fetch("https://api.local/api/me", {
+      headers: { "CF-Access-Jwt-Assertion": bobJwt },
+    });
+
+    const res = await SELF.fetch(`https://api.local/api/rooms/${roomId}`, {
+      headers: { "CF-Access-Jwt-Assertion": bobJwt },
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+});

--- a/apps/worker/src/__tests__/workspaces.test.ts
+++ b/apps/worker/src/__tests__/workspaces.test.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { SELF, env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+async function bootstrapAlice(): Promise<{ jwt: string; workspaceId: string; userId: string }> {
+  const jwt = await fixture.mint({ email: "alice@example.com" });
+  const res = await SELF.fetch("https://api.local/api/me", {
+    headers: { "CF-Access-Jwt-Assertion": jwt },
+  });
+  const body = (await res.json()) as {
+    data: { user: { id: string }; workspace: { id: string } };
+  };
+  return { jwt, workspaceId: body.data.workspace.id, userId: body.data.user.id };
+}
+
+describe("workspaces routes", () => {
+  it("GET /api/workspaces/:wid returns the workspace for a member", async () => {
+    const { jwt, workspaceId } = await bootstrapAlice();
+    const res = await SELF.fetch(`https://api.local/api/workspaces/${workspaceId}`, {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { data: { workspace: { id: string } } };
+    expect(body.data.workspace.id).toBe(workspaceId);
+  });
+
+  it("GET /api/workspaces/:wid returns 404 for an unknown workspace id", async () => {
+    const { jwt } = await bootstrapAlice();
+    const res = await SELF.fetch(
+      "https://api.local/api/workspaces/00000000-0000-7000-8000-deadbeefdead",
+      { headers: { "CF-Access-Jwt-Assertion": jwt } },
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("NOT_FOUND");
+  });
+
+  it("GET /api/workspaces/:wid/rooms returns the rooms the user belongs to", async () => {
+    const { jwt, workspaceId } = await bootstrapAlice();
+
+    // Create a room.
+    const create = await SELF.fetch(`https://api.local/api/workspaces/${workspaceId}/rooms`, {
+      method: "POST",
+      headers: {
+        "CF-Access-Jwt-Assertion": jwt,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ slug: "ops-cyber", name: "Ops Cyber", topic: "security incidents" }),
+    });
+    expect(create.status).toBe(201);
+    const created = (await create.json()) as { data: { room: { id: string; slug: string } } };
+    expect(created.data.room.slug).toBe("ops-cyber");
+
+    const list = await SELF.fetch(`https://api.local/api/workspaces/${workspaceId}/rooms`, {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    const listBody = (await list.json()) as { data: { rooms: { id: string; slug: string }[] } };
+    expect(listBody.data.rooms.map((r) => r.slug)).toEqual(["ops-cyber"]);
+  });
+
+  it("POST /api/workspaces/:wid/rooms with a duplicate slug returns 409 CONFLICT", async () => {
+    const { jwt, workspaceId } = await bootstrapAlice();
+    const body = JSON.stringify({ slug: "general", name: "General" });
+    const headers = {
+      "CF-Access-Jwt-Assertion": jwt,
+      "content-type": "application/json",
+    };
+
+    const first = await SELF.fetch(`https://api.local/api/workspaces/${workspaceId}/rooms`, {
+      method: "POST",
+      headers,
+      body,
+    });
+    expect(first.status).toBe(201);
+
+    const second = await SELF.fetch(`https://api.local/api/workspaces/${workspaceId}/rooms`, {
+      method: "POST",
+      headers,
+      body,
+    });
+    expect(second.status).toBe(409);
+    const errBody = (await second.json()) as { error: { code: string } };
+    expect(errBody.error.code).toBe("CONFLICT");
+  });
+
+  it("POST /api/workspaces/:wid/rooms validates the slug format (400 VALIDATION_FAILED)", async () => {
+    const { jwt, workspaceId } = await bootstrapAlice();
+    const res = await SELF.fetch(`https://api.local/api/workspaces/${workspaceId}/rooms`, {
+      method: "POST",
+      headers: {
+        "CF-Access-Jwt-Assertion": jwt,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ slug: "Has Spaces!", name: "Bad Slug" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("POST /api/workspaces/:wid/rooms auto-adds creator as room admin", async () => {
+    const { jwt, workspaceId, userId } = await bootstrapAlice();
+    const create = await SELF.fetch(`https://api.local/api/workspaces/${workspaceId}/rooms`, {
+      method: "POST",
+      headers: {
+        "CF-Access-Jwt-Assertion": jwt,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ slug: "general", name: "General" }),
+    });
+    const created = (await create.json()) as { data: { room: { id: string } } };
+
+    const member = await env.DB.prepare(
+      "SELECT role FROM room_members WHERE room_id = ? AND user_id = ?",
+    )
+      .bind(created.data.room.id, userId)
+      .first<{ role: string }>();
+    expect(member?.role).toBe("admin");
+  });
+});

--- a/apps/worker/src/cloudflare-test.d.ts
+++ b/apps/worker/src/cloudflare-test.d.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Tells `cloudflare:test` (and the `cloudflare:workers` env binding) that
+// `Cloudflare.Env` matches our typed Env. Without this, `env` from
+// `cloudflare:test` is loosely typed and tests can't access bindings without
+// casting.
+
+import type { D1Migration } from "@cloudflare/vitest-pool-workers";
+import type { Env as WorkerEnv } from "./env.js";
+
+declare global {
+  namespace Cloudflare {
+    interface Env extends WorkerEnv {
+      // Test-only binding: list of D1 migrations injected via vitest.config.ts
+      // (see vitest.config.ts → miniflare.bindings.TEST_MIGRATIONS).
+      TEST_MIGRATIONS?: D1Migration[];
+    }
+  }
+}

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -46,6 +46,16 @@ export interface Env {
   AI_SEARCH_INSTANCE: string;
   GIT_COMMIT?: string;
 
+  // Cloudflare Access — operator must override these in production via the
+  // dashboard or a wrangler env section. Defaults in wrangler.jsonc are dev
+  // placeholders that tests exercise via mocked JWKS in KV.
+  ACCESS_TEAM: string;
+  ACCESS_AUD: string;
+
+  // Local-dev auth bypass. Triple-gated; see middleware/auth.ts. Default off.
+  ALLOW_LOCAL_DEV_AUTH: string;
+  LOCAL_DEV_EMAIL: string;
+
   // Secrets — undefined locally unless set via .dev.vars
   SENTRY_DSN?: string;
   BYOK_ENCRYPTION_KEY?: string;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,21 +1,38 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { apiErr } from "@loomwiki/shared";
+import { ErrorCodes, apiErr } from "@loomwiki/shared";
 import { Hono } from "hono";
 import type { Env } from "./env.js";
+import { type AuthEnv, authMiddleware } from "./middleware/auth.js";
+import { registerErrorHandler } from "./middleware/error.js";
+import { debugRoute } from "./routes/_debug.js";
 import { healthRoute } from "./routes/health.js";
+import { meRoute } from "./routes/me.js";
+import { roomsRoute } from "./routes/rooms.js";
+import { workspacesRoute } from "./routes/workspaces.js";
 
 export { ChatRoom } from "./do/ChatRoom.js";
 
-const app = new Hono<{ Bindings: Env }>();
+const app = new Hono<AuthEnv>();
 
+// Open routes (no auth required).
 app.route("/api/health", healthRoute);
+app.route("/api/_debug", debugRoute);
 
-app.notFound((c) => c.json(apiErr("not_found", `No route for ${c.req.method} ${c.req.path}`), 404));
+// Authenticated routes.
+app.use("/api/me/*", authMiddleware);
+app.use("/api/me", authMiddleware);
+app.use("/api/workspaces/*", authMiddleware);
+app.use("/api/rooms/*", authMiddleware);
 
-app.onError((err, c) => {
-  console.error("worker error", err);
-  return c.json(apiErr("internal_error", "Internal server error"), 500);
-});
+app.route("/api/me", meRoute);
+app.route("/api/workspaces", workspacesRoute);
+app.route("/api/rooms", roomsRoute);
+
+app.notFound((c) =>
+  c.json(apiErr(ErrorCodes.NOT_FOUND, `No route for ${c.req.method} ${c.req.path}`), 404),
+);
+
+registerErrorHandler(app);
 
 export default app;

--- a/apps/worker/src/lib/auth.ts
+++ b/apps/worker/src/lib/auth.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Cloudflare Access JWT verification.
+//
+// Cache JWKS in KV for 24h (M1 prompt's resolved decision). Without the cache
+// every authenticated request blocks on a fetch to cloudflareaccess.com — with
+// it, validation is sub-millisecond.
+//
+// Reference: https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/validating-json/
+
+import { ErrorCodes, LoomwikiError } from "@loomwiki/shared";
+import * as jose from "jose";
+import type { Env } from "../env.js";
+
+const JWKS_TTL_SECONDS = 60 * 60 * 24; // 24h
+const JWKS_KV_KEY_PREFIX = "access-jwks:";
+
+export interface AccessClaims {
+  email: string;
+  sub: string;
+  exp: number;
+}
+
+function teamIssuer(team: string): string {
+  return `https://${team}.cloudflareaccess.com`;
+}
+
+function jwksUrl(team: string): string {
+  return `${teamIssuer(team)}/cdn-cgi/access/certs`;
+}
+
+/**
+ * Returns the team's JWKS, reading from KV cache when fresh and falling back
+ * to a network fetch otherwise. Errors throw `INTERNAL_ERROR` (500) — these
+ * are misconfigurations or upstream outages, not client problems.
+ */
+export async function getAccessJwks(env: Env): Promise<jose.JSONWebKeySet> {
+  const team = env.ACCESS_TEAM;
+  if (!team) {
+    throw new LoomwikiError(ErrorCodes.INTERNAL_ERROR, "ACCESS_TEAM env var is not set", {
+      status: 500,
+    });
+  }
+
+  const cacheKey = `${JWKS_KV_KEY_PREFIX}${team}`;
+  const cached = await env.CACHE.get(cacheKey, "json");
+  if (cached) return cached as jose.JSONWebKeySet;
+
+  const res = await fetch(jwksUrl(team), { headers: { accept: "application/json" } });
+  if (!res.ok) {
+    throw new LoomwikiError(
+      ErrorCodes.INTERNAL_ERROR,
+      `Failed to fetch Access JWKS (HTTP ${res.status})`,
+      { status: 500 },
+    );
+  }
+  const jwks = (await res.json()) as jose.JSONWebKeySet;
+  await env.CACHE.put(cacheKey, JSON.stringify(jwks), { expirationTtl: JWKS_TTL_SECONDS });
+  return jwks;
+}
+
+export async function invalidateAccessJwks(env: Env): Promise<void> {
+  const team = env.ACCESS_TEAM;
+  if (!team) return;
+  await env.CACHE.delete(`${JWKS_KV_KEY_PREFIX}${team}`);
+}
+
+/**
+ * Verifies a Cloudflare Access JWT against the team's JWKS.
+ *
+ * Distinguishes expired (`AUTH_EXPIRED`) from other invalid-JWT cases
+ * (`AUTH_INVALID_JWT`) so the client can surface different UX (silently
+ * re-auth on expired vs. show an error on tampered).
+ */
+export async function verifyAccessJwt(env: Env, token: string): Promise<AccessClaims> {
+  const team = env.ACCESS_TEAM;
+  const aud = env.ACCESS_AUD;
+  if (!team || !aud) {
+    throw new LoomwikiError(ErrorCodes.INTERNAL_ERROR, "Access auth not configured", {
+      status: 500,
+    });
+  }
+
+  const jwks = await getAccessJwks(env);
+  const resolver = jose.createLocalJWKSet(jwks);
+
+  let payload: jose.JWTPayload;
+  try {
+    const result = await jose.jwtVerify(token, resolver, {
+      audience: aud,
+      issuer: teamIssuer(team),
+    });
+    payload = result.payload;
+  } catch (cause) {
+    if (cause instanceof jose.errors.JWTExpired) {
+      throw new LoomwikiError(ErrorCodes.AUTH_EXPIRED, "JWT has expired", {
+        status: 401,
+        cause,
+      });
+    }
+    throw new LoomwikiError(ErrorCodes.AUTH_INVALID_JWT, "Invalid Access JWT", {
+      status: 401,
+      cause,
+    });
+  }
+
+  const email = typeof payload.email === "string" ? payload.email : null;
+  if (!email) {
+    throw new LoomwikiError(ErrorCodes.AUTH_INVALID_JWT, "JWT missing email claim", {
+      status: 401,
+    });
+  }
+  const sub = typeof payload.sub === "string" ? payload.sub : null;
+  if (!sub) {
+    throw new LoomwikiError(ErrorCodes.AUTH_INVALID_JWT, "JWT missing sub claim", {
+      status: 401,
+    });
+  }
+
+  return { email, sub, exp: typeof payload.exp === "number" ? payload.exp : 0 };
+}

--- a/apps/worker/src/lib/serialize.ts
+++ b/apps/worker/src/lib/serialize.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// D1 stores times as unix epoch seconds (CLAUDE.md). Routes return ISO-8601
+// strings — convert here, in one place, so wire format never drifts from
+// internal representation.
+
+import type { Room, User, Workspace } from "@loomwiki/schema/parsers";
+
+export function epochToIso(seconds: number): string {
+  return new Date(seconds * 1000).toISOString();
+}
+
+export interface SerializedUser {
+  id: string;
+  email: string;
+  display_name: string;
+  avatar_url: string | null;
+  created_at: string;
+}
+
+export interface SerializedWorkspace {
+  id: string;
+  name: string;
+  owner_id: string;
+  vault_repo: string;
+  ai_search_id: string | null;
+  created_at: string;
+}
+
+export interface SerializedRoom {
+  id: string;
+  workspace_id: string;
+  slug: string;
+  name: string;
+  topic: string | null;
+  created_by: string;
+  created_at: string;
+}
+
+export function serializeUser(u: User): SerializedUser {
+  return {
+    id: u.id,
+    email: u.email,
+    display_name: u.display_name,
+    avatar_url: u.avatar_url,
+    created_at: epochToIso(u.created_at),
+  };
+}
+
+export function serializeWorkspace(w: Workspace): SerializedWorkspace {
+  return {
+    id: w.id,
+    name: w.name,
+    owner_id: w.owner_id,
+    vault_repo: w.vault_repo,
+    ai_search_id: w.ai_search_id,
+    created_at: epochToIso(w.created_at),
+  };
+}
+
+export function serializeRoom(r: Room): SerializedRoom {
+  return {
+    id: r.id,
+    workspace_id: r.workspace_id,
+    slug: r.slug,
+    name: r.name,
+    topic: r.topic,
+    created_by: r.created_by,
+    created_at: epochToIso(r.created_at),
+  };
+}

--- a/apps/worker/src/lib/users.ts
+++ b/apps/worker/src/lib/users.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// JIT user provisioning. The first time we see a verified email claim we
+// create a row in `users`; subsequent requests resolve to the same row.
+//
+// Idempotency under race: two simultaneous first-time requests for the same
+// email must not produce two users. SQLite's `INSERT ... ON CONFLICT(email)
+// DO NOTHING` followed by a `SELECT` is atomic enough — `users.email` has a
+// UNIQUE constraint (see d1-migrations/0001_init.sql). We do not check-then-
+// insert.
+
+import { type User, parseUserRow } from "@loomwiki/schema/parsers";
+import { ErrorCodes, LoomwikiError, id } from "@loomwiki/shared";
+import type { Env } from "../env.js";
+
+function deriveDisplayName(email: string): string {
+  const local = email.split("@")[0] ?? "";
+  if (local.length === 0) return "User";
+  const first = local[0] ?? "";
+  return first.toUpperCase() + local.slice(1);
+}
+
+export async function getOrCreateUser(
+  env: Env,
+  email: string,
+  displayName?: string,
+): Promise<User> {
+  const normalized = email.trim().toLowerCase();
+
+  // Hot path: user already exists. Skip the insert round-trip when possible.
+  const existing = await env.DB.prepare("SELECT * FROM users WHERE email = ?")
+    .bind(normalized)
+    .first();
+  if (existing) return parseUserRow(existing);
+
+  // Cold path: race-safe upsert + re-select.
+  const newId = id();
+  const dn = displayName ?? deriveDisplayName(normalized);
+  await env.DB.prepare(
+    "INSERT INTO users (id, email, display_name) VALUES (?, ?, ?) ON CONFLICT(email) DO NOTHING",
+  )
+    .bind(newId, normalized, dn)
+    .run();
+
+  const row = await env.DB.prepare("SELECT * FROM users WHERE email = ?").bind(normalized).first();
+  if (!row) {
+    throw new LoomwikiError(ErrorCodes.INTERNAL_ERROR, "User upsert failed", { status: 500 });
+  }
+  return parseUserRow(row);
+}
+
+export async function getUserById(env: Env, userId: string): Promise<User | null> {
+  const row = await env.DB.prepare("SELECT * FROM users WHERE id = ?").bind(userId).first();
+  return row ? parseUserRow(row) : null;
+}

--- a/apps/worker/src/lib/workspace.ts
+++ b/apps/worker/src/lib/workspace.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Single-tenant workspace bootstrap (SPEC §16, Q19 = solo).
+//
+// v0.0.1 deploys host exactly one workspace per Worker. Rather than add a
+// UNIQUE on workspaces.name (which would deviate from SPEC §7.1), we key the
+// single row by a constant UUIDv7-formatted ID and let `INSERT ... ON
+// CONFLICT(id) DO NOTHING` handle racing first-time requests atomically.
+//
+// When v0.1 ships multi-workspace, this constant goes away and each workspace
+// is created with a fresh UUIDv7 from id().
+
+import { type Workspace, parseWorkspaceRow } from "@loomwiki/schema/parsers";
+import { ErrorCodes, LoomwikiError } from "@loomwiki/shared";
+import type { Env } from "../env.js";
+
+// UUIDv7-formatted constant (version nibble = 7, variant nibble = 8).
+// Reserved for the v0.0.1 single-tenant default workspace.
+export const DEFAULT_WORKSPACE_ID = "00000000-0000-7000-8000-000000000000";
+
+export async function getOrBootstrapWorkspace(env: Env, ownerId: string): Promise<Workspace> {
+  const existing = await env.DB.prepare("SELECT * FROM workspaces WHERE id = ?")
+    .bind(DEFAULT_WORKSPACE_ID)
+    .first();
+  if (existing) return parseWorkspaceRow(existing);
+
+  const name = env.WORKSPACE_NAME && env.WORKSPACE_NAME.length > 0 ? env.WORKSPACE_NAME : "default";
+  const vaultRepo =
+    env.ARTIFACTS_REPO && env.ARTIFACTS_REPO.length > 0 ? env.ARTIFACTS_REPO : "loomwiki-vault";
+
+  await env.DB.prepare(
+    "INSERT INTO workspaces (id, name, owner_id, vault_repo) VALUES (?, ?, ?, ?) ON CONFLICT(id) DO NOTHING",
+  )
+    .bind(DEFAULT_WORKSPACE_ID, name, ownerId, vaultRepo)
+    .run();
+
+  const row = await env.DB.prepare("SELECT * FROM workspaces WHERE id = ?")
+    .bind(DEFAULT_WORKSPACE_ID)
+    .first();
+  if (!row) {
+    throw new LoomwikiError(ErrorCodes.INTERNAL_ERROR, "Workspace bootstrap failed", {
+      status: 500,
+    });
+  }
+  return parseWorkspaceRow(row);
+}

--- a/apps/worker/src/middleware/auth.ts
+++ b/apps/worker/src/middleware/auth.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Hono auth middleware. Validates a Cloudflare Access JWT, JIT-provisions the
+// user and the single-tenant workspace, and exposes both via `c.var`.
+//
+// Local-dev bypass (`X-Local-Dev-Email`) is **triple-gated**:
+//   1. process.env.NODE_ENV !== "production"
+//   2. env.ALLOW_LOCAL_DEV_AUTH === "true"
+//   3. CF-Connecting-IP is absent or 127.0.0.1 / ::1
+// All three must hold; fail any one and the bypass header is ignored. The
+// IP gate is the load-bearing one (1) is mostly symbolic in Workers since
+// process.env.NODE_ENV is undefined in production runtime).
+//
+// Reference: docs/SECURITY.md §6.
+
+import type { User, Workspace } from "@loomwiki/schema/parsers";
+import { ErrorCodes, LoomwikiError } from "@loomwiki/shared";
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../env.js";
+import { verifyAccessJwt } from "../lib/auth.js";
+import { getOrCreateUser } from "../lib/users.js";
+import { getOrBootstrapWorkspace } from "../lib/workspace.js";
+
+export type AuthVariables = { user: User; workspace: Workspace };
+export type AuthEnv = { Bindings: Env; Variables: AuthVariables };
+
+const LOCALHOST_IPS = new Set(["127.0.0.1", "::1"]);
+
+let warnedLocalDev = false;
+function warnLocalDevOnce(): void {
+  if (warnedLocalDev) return;
+  warnedLocalDev = true;
+  console.warn("[loomwiki] LOCAL DEV AUTH ENABLED — ABORT IF YOU SEE THIS IN PRODUCTION.");
+}
+
+export function isLocalDevAuthAllowed(env: Env, request: Request): boolean {
+  if (env.ALLOW_LOCAL_DEV_AUTH !== "true") return false;
+
+  // Workers expose process.env via nodejs_compat. NODE_ENV is undefined in
+  // production runtime, so this gate is mostly symbolic — the IP check is the
+  // real defense — but the M1 prompt mandates it.
+  const nodeEnv = typeof process !== "undefined" && process.env ? process.env.NODE_ENV : undefined;
+  if (nodeEnv === "production") return false;
+
+  const cfIp = request.headers.get("CF-Connecting-IP");
+  if (cfIp !== null && !LOCALHOST_IPS.has(cfIp)) return false;
+
+  return true;
+}
+
+export const authMiddleware: MiddlewareHandler<AuthEnv> = async (c, next) => {
+  const env = c.env;
+
+  let email: string | null = null;
+
+  const localDevHeader = c.req.header("X-Local-Dev-Email");
+  if (localDevHeader && isLocalDevAuthAllowed(env, c.req.raw)) {
+    warnLocalDevOnce();
+    email = localDevHeader.trim().toLowerCase();
+    if (!email) {
+      throw new LoomwikiError(ErrorCodes.AUTH_REQUIRED, "X-Local-Dev-Email header is empty", {
+        status: 401,
+      });
+    }
+  } else {
+    const jwt = c.req.header("CF-Access-Jwt-Assertion");
+    if (!jwt) {
+      throw new LoomwikiError(ErrorCodes.AUTH_REQUIRED, "Missing Access JWT", {
+        status: 401,
+      });
+    }
+    const claims = await verifyAccessJwt(env, jwt);
+    email = claims.email.toLowerCase();
+  }
+
+  const user = await getOrCreateUser(env, email);
+  const workspace = await getOrBootstrapWorkspace(env, user.id);
+
+  c.set("user", user);
+  c.set("workspace", workspace);
+  await next();
+};

--- a/apps/worker/src/middleware/error.ts
+++ b/apps/worker/src/middleware/error.ts
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Centralized error → ApiResult mapping. Routes throw LoomwikiError; this
+// middleware translates `code` + `status` to the wire format. Unknown errors
+// log to console and return INTERNAL_ERROR with `cause` redacted from the
+// response.
+
+import { ErrorCodes, apiErr, isLoomwikiError } from "@loomwiki/shared";
+import type { Hono } from "hono";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+import type { Env } from "../env.js";
+import type { AuthEnv } from "./auth.js";
+
+export function registerErrorHandler(app: Hono<AuthEnv> | Hono<{ Bindings: Env }>): void {
+  app.onError((err, c) => {
+    if (isLoomwikiError(err)) {
+      console.warn("[loomwiki] handled error", {
+        code: err.code,
+        message: err.message,
+        status: err.status,
+      });
+      return c.json(apiErr(err.code, err.message), err.status as ContentfulStatusCode);
+    }
+    console.error("[loomwiki] unhandled error", err);
+    return c.json(apiErr(ErrorCodes.INTERNAL_ERROR, "Internal server error"), 500);
+  });
+}

--- a/apps/worker/src/routes/_debug.ts
+++ b/apps/worker/src/routes/_debug.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Dev-only debug endpoints. Hard-gated on ALLOW_LOCAL_DEV_AUTH=true; all
+// requests return 404 in production deployments where the flag is false (the
+// default). No auth requirement because the gate itself is the entire
+// security boundary — operators who flip ALLOW_LOCAL_DEV_AUTH to true must
+// also keep the deployment off the public internet.
+
+import { ErrorCodes, LoomwikiError, apiOk } from "@loomwiki/shared";
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import { invalidateAccessJwks } from "../lib/auth.js";
+
+function assertDevModeEnabled(env: Env): void {
+  if (env.ALLOW_LOCAL_DEV_AUTH !== "true") {
+    throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Not found", { status: 404 });
+  }
+}
+
+export const debugRoute = new Hono<{ Bindings: Env }>().post("/invalidate-jwks", async (c) => {
+  assertDevModeEnabled(c.env);
+  await invalidateAccessJwks(c.env);
+  return c.json(apiOk({ invalidated: true }));
+});

--- a/apps/worker/src/routes/_debug.ts
+++ b/apps/worker/src/routes/_debug.ts
@@ -10,15 +10,21 @@ import { ErrorCodes, LoomwikiError, apiOk } from "@loomwiki/shared";
 import { Hono } from "hono";
 import type { Env } from "../env.js";
 import { invalidateAccessJwks } from "../lib/auth.js";
+import { isLocalDevAuthAllowed } from "../middleware/auth.js";
 
-function assertDevModeEnabled(env: Env): void {
-  if (env.ALLOW_LOCAL_DEV_AUTH !== "true") {
+function assertDevModeEnabled(env: Env, request: Request): void {
+  // Defense-in-depth: reuse the full local-dev triple-gate (env flag +
+  // non-production runtime + localhost CF-Connecting-IP) rather than just the
+  // env flag. If an operator accidentally flips ALLOW_LOCAL_DEV_AUTH=true on
+  // a public deployment, the IP gate still keeps these endpoints unreachable
+  // from the internet.
+  if (!isLocalDevAuthAllowed(env, request)) {
     throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Not found", { status: 404 });
   }
 }
 
 export const debugRoute = new Hono<{ Bindings: Env }>().post("/invalidate-jwks", async (c) => {
-  assertDevModeEnabled(c.env);
+  assertDevModeEnabled(c.env, c.req.raw);
   await invalidateAccessJwks(c.env);
   return c.json(apiOk({ invalidated: true }));
 });

--- a/apps/worker/src/routes/me.ts
+++ b/apps/worker/src/routes/me.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { parseRoomRow } from "@loomwiki/schema/parsers";
+import { apiOk } from "@loomwiki/shared";
+import { Hono } from "hono";
+import { serializeRoom, serializeUser, serializeWorkspace } from "../lib/serialize.js";
+import type { AuthEnv } from "../middleware/auth.js";
+
+export const meRoute = new Hono<AuthEnv>().get("/", async (c) => {
+  const user = c.var.user;
+  const workspace = c.var.workspace;
+
+  const result = await c.env.DB.prepare(
+    `SELECT r.* FROM rooms r
+     INNER JOIN room_members m ON m.room_id = r.id
+     WHERE m.user_id = ? AND r.workspace_id = ?
+     ORDER BY r.created_at DESC`,
+  )
+    .bind(user.id, workspace.id)
+    .all();
+
+  const rooms = result.results.map(parseRoomRow).map(serializeRoom);
+
+  return c.json(
+    apiOk({
+      user: serializeUser(user),
+      workspace: serializeWorkspace(workspace),
+      rooms,
+    }),
+  );
+});

--- a/apps/worker/src/routes/rooms.ts
+++ b/apps/worker/src/routes/rooms.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { parseRoomRow } from "@loomwiki/schema/parsers";
+import { ErrorCodes, LoomwikiError, apiOk } from "@loomwiki/shared";
+import { Hono } from "hono";
+import { serializeRoom } from "../lib/serialize.js";
+import type { AuthEnv } from "../middleware/auth.js";
+
+export const roomsRoute = new Hono<AuthEnv>().get("/:rid", async (c) => {
+  const rid = c.req.param("rid");
+
+  const row = await c.env.DB.prepare("SELECT * FROM rooms WHERE id = ?").bind(rid).first();
+  if (!row) {
+    throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Room not found", { status: 404 });
+  }
+  const room = parseRoomRow(row);
+
+  // Cross-workspace defense in depth: even if a user knows a room ID outside
+  // their workspace, they get a 404 (not a 403, which would confirm existence).
+  if (room.workspace_id !== c.var.workspace.id) {
+    throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Room not found", { status: 404 });
+  }
+
+  const member = await c.env.DB.prepare(
+    "SELECT 1 FROM room_members WHERE room_id = ? AND user_id = ? LIMIT 1",
+  )
+    .bind(rid, c.var.user.id)
+    .first();
+  if (!member) {
+    throw new LoomwikiError(ErrorCodes.FORBIDDEN, "Not a member of this room", { status: 403 });
+  }
+
+  return c.json(apiOk({ room: serializeRoom(room) }));
+});

--- a/apps/worker/src/routes/workspaces.ts
+++ b/apps/worker/src/routes/workspaces.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { CreateRoomRequestSchema } from "@loomwiki/schema";
+import { parseRoomRow } from "@loomwiki/schema/parsers";
+import { ErrorCodes, LoomwikiError, apiOk, id } from "@loomwiki/shared";
+import { Hono } from "hono";
+import { serializeRoom, serializeWorkspace } from "../lib/serialize.js";
+import type { AuthEnv } from "../middleware/auth.js";
+
+function assertWorkspaceMatch(workspaceId: string, paramId: string): void {
+  // v0.0.1 is single-tenant — any wid that isn't the bootstrapped workspace
+  // is a 404 from this user's perspective.
+  if (workspaceId !== paramId) {
+    throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Workspace not found", { status: 404 });
+  }
+}
+
+export const workspacesRoute = new Hono<AuthEnv>()
+  .get("/:wid", (c) => {
+    const wid = c.req.param("wid");
+    assertWorkspaceMatch(c.var.workspace.id, wid);
+    return c.json(apiOk({ workspace: serializeWorkspace(c.var.workspace) }));
+  })
+  .get("/:wid/rooms", async (c) => {
+    const wid = c.req.param("wid");
+    assertWorkspaceMatch(c.var.workspace.id, wid);
+
+    const result = await c.env.DB.prepare(
+      `SELECT r.* FROM rooms r
+       INNER JOIN room_members m ON m.room_id = r.id
+       WHERE m.user_id = ? AND r.workspace_id = ?
+       ORDER BY r.created_at DESC`,
+    )
+      .bind(c.var.user.id, wid)
+      .all();
+
+    const rooms = result.results.map(parseRoomRow).map(serializeRoom);
+    return c.json(apiOk({ rooms }));
+  })
+  .post("/:wid/rooms", async (c) => {
+    const wid = c.req.param("wid");
+    assertWorkspaceMatch(c.var.workspace.id, wid);
+
+    const body = await c.req.json().catch(() => null);
+    const parsed = CreateRoomRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "Invalid room request body", {
+        status: 400,
+        details: parsed.error.issues,
+      });
+    }
+
+    const roomId = id();
+    try {
+      await c.env.DB.prepare(
+        "INSERT INTO rooms (id, workspace_id, slug, name, topic, created_by) VALUES (?, ?, ?, ?, ?, ?)",
+      )
+        .bind(
+          roomId,
+          wid,
+          parsed.data.slug,
+          parsed.data.name,
+          parsed.data.topic ?? null,
+          c.var.user.id,
+        )
+        .run();
+    } catch (cause) {
+      if (cause instanceof Error && /UNIQUE/i.test(cause.message)) {
+        throw new LoomwikiError(ErrorCodes.CONFLICT, "Room slug already exists in this workspace", {
+          status: 409,
+          cause,
+        });
+      }
+      throw cause;
+    }
+
+    // Auto-add creator as admin (M1 prompt's resolved decision).
+    await c.env.DB.prepare(
+      "INSERT INTO room_members (room_id, user_id, role) VALUES (?, ?, 'admin')",
+    )
+      .bind(roomId, c.var.user.id)
+      .run();
+
+    const row = await c.env.DB.prepare("SELECT * FROM rooms WHERE id = ?").bind(roomId).first();
+    if (!row) {
+      throw new LoomwikiError(ErrorCodes.INTERNAL_ERROR, "Room creation failed", {
+        status: 500,
+      });
+    }
+    return c.json(apiOk({ room: serializeRoom(parseRoomRow(row)) }), 201);
+  });

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,19 +1,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import path from "node:path";
+import { cloudflareTest, readD1Migrations } from "@cloudflare/vitest-pool-workers";
 import { defineConfig } from "vitest/config";
 
-export default defineConfig({
-  plugins: [
-    cloudflareTest({
-      wrangler: { configPath: "../../wrangler.jsonc" },
-      // Run tests fully offline. Without this the AI binding (which only has a
-      // remote implementation) forces wrangler into remote mode and CI fails
-      // with "You must be logged in to use wrangler dev in remote mode."
-      remoteBindings: false,
-    }),
-  ],
-  test: {
-    include: ["src/**/__tests__/**/*.test.ts"],
-  },
+const migrationsPath = path.resolve(__dirname, "../../packages/schema/d1-migrations");
+
+export default defineConfig(async () => {
+  const migrations = await readD1Migrations(migrationsPath);
+
+  return {
+    plugins: [
+      cloudflareTest({
+        wrangler: { configPath: "../../wrangler.jsonc" },
+        // Run tests fully offline. Without this the AI binding (which only
+        // has a remote implementation) forces wrangler into remote mode and
+        // CI fails with "You must be logged in to use wrangler dev in remote
+        // mode."
+        remoteBindings: false,
+        miniflare: {
+          // Expose the migration array as a binding so tests can call
+          // applyD1Migrations(env.DB, env.TEST_MIGRATIONS) in beforeAll.
+          bindings: { TEST_MIGRATIONS: migrations },
+        },
+      }),
+    ],
+    test: {
+      include: ["src/**/__tests__/**/*.test.ts"],
+    },
+  };
 });

--- a/docs/ADR/0002-no-orm.md
+++ b/docs/ADR/0002-no-orm.md
@@ -1,0 +1,100 @@
+# ADR 0002 — No ORM for D1 access
+
+- **Status**: Accepted
+- **Date**: 2026-05-03
+- **Milestone**: M1
+
+## Context
+
+M1 introduces the first D1 reads and writes in the worker (`/api/me`,
+`/api/workspaces/:wid/rooms`, JIT user provisioning). At this point we choose
+how queries are constructed and how rows become typed objects. Three options
+were on the table:
+
+1. **Raw `env.DB.prepare(sql).bind(...).run()`** + Zod-validated row parsers
+   in `@loomwiki/schema/parsers`. No code generation, no schema-as-code, no
+   query builder.
+2. **Drizzle** — TypeScript schema declared in code, query builder generates
+   SQL, `drizzle-kit` generates migrations. Mature D1 adapter.
+3. **Kysely** — type-safe query builder over the existing schema. No
+   migration story; introspection-only types via `kysely-codegen`.
+
+A fourth option, an OO ORM (Prisma, Sequelize), is excluded — neither runs
+well in Workers and both impose abstractions that would dwarf v0.0.1's data
+needs.
+
+## Decision
+
+Use **option 1: raw prepared statements + Zod row parsers** for v0.0.1.
+
+The data layer at this size is:
+
+- 8 tables.
+- Routes that touch ≤ 3 tables each.
+- No joins more complex than `rooms ⋈ room_members`.
+
+Drizzle and Kysely both shine when joins, partial selects, and dynamic
+predicates start eating route code. Loomwiki isn't there yet. The friction
+they would *add* in v0.0.1 — a second source of truth for the schema, a
+build-time codegen step, learning-curve overhead for self-hosters reading
+the worker — outweighs the ergonomics they would *give*.
+
+Migrations stay in `packages/schema/d1-migrations/*.sql` and apply via
+`wrangler d1 migrations apply` (Cloudflare-native; covered by ADR-0001's
+"Cloudflare-only" posture). Forward-only — to roll back, write a new
+migration.
+
+Type safety lives in `@loomwiki/schema`:
+
+- Zod schemas describe each table's row shape.
+- `parseUserRow(row)` etc. wrap `schema.safeParse` and throw a typed
+  `LoomwikiError` (`code: "DB_PARSE_ERROR"`, status 500) on drift.
+- Routes always parse rows before returning them; raw `env.DB` results never
+  hit the API surface unvalidated.
+
+This means:
+
+- Schema drift between migration SQL and TS types **fails loudly** the first
+  time a route reads the affected column, instead of silently leaking bad
+  shapes into responses.
+- The wire format (ISO-8601 strings) and the storage format (epoch seconds)
+  are explicitly converted at the route layer (`apps/worker/src/lib/serialize.ts`).
+
+## Consequences
+
+**Positive:**
+
+- One source of truth: the SQL migration. Operators reading the repo see
+  exactly what their D1 holds without reading a second TS schema file.
+- Zero codegen. CI runs the migration in `--local` mode for tests; nothing
+  else generates files into the tree.
+- Tiny dependency footprint. No drizzle/kysely in the worker bundle.
+
+**Negative / accepted trade-offs:**
+
+- Manual SQL means typos in column names surface only when the query runs.
+  Mitigated by the Zod parser (drift on read fails loudly) and by route
+  integration tests.
+- Hand-writing parameterized queries means hand-writing every `bind()` call.
+  At v0.0.1's route count this is fine; if M7 (ingest) starts assembling
+  complex predicates, revisit.
+- No automatic `WHERE workspace_id = ?` scoping helper. We rely on every
+  route writing the scope explicitly. The `assertWorkspaceMatch()` pattern
+  (workspaces.ts) is the M1 convention; later milestones should keep it.
+
+## Revisit when
+
+- A single route exceeds ~30 lines of SQL juggling, or writes the same join
+  three times across the codebase.
+- M7 (ingest agent) starts dynamically composing `SELECT messages WHERE …`
+  predicates from user filters.
+- Any route needs to combine results from > 3 tables in a single query.
+- A self-hoster reports that hand-rolled SQL is hard to extend in their
+  fork.
+
+## Alternatives revisited
+
+If we revisit, **Drizzle** is the leading candidate. It has the best D1
+adapter, codegen ergonomics that match the migration file format, and a
+mature TS surface. Kysely would require us to add a migration story it
+doesn't ship.

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "lint": "biome check .",
     "format": "biome format --write .",
     "deploy": "pnpm --filter @loomwiki/worker deploy",
-    "migrate:new": "echo 'migrate:new lands in M1 along with packages/schema/d1-migrations' && exit 1",
-    "seed": "echo 'seed lands in M1 with the D1 schema' && exit 1"
+    "migrate:local": "pnpm --filter @loomwiki/worker exec wrangler d1 migrations apply loomwiki --local --config ../../wrangler.jsonc",
+    "migrate:remote": "pnpm --filter @loomwiki/worker exec wrangler d1 migrations apply loomwiki --remote --config ../../wrangler.jsonc",
+    "migrate:new": "pnpm --filter @loomwiki/worker exec wrangler d1 migrations create loomwiki --config ../../wrangler.jsonc",
+    "seed": "echo 'seed lands in M2/M3 with chat fixtures' && exit 1"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",

--- a/packages/schema/d1-migrations/0001_init.sql
+++ b/packages/schema/d1-migrations/0001_init.sql
@@ -1,0 +1,103 @@
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Loomwiki D1 schema (SPEC §7.1). Forward-only — to roll back, write a new
+-- migration; never edit this file once it has been applied to a deployed DB.
+--
+-- All `*_at` columns are unix epoch seconds (per CLAUDE.md "Times: store as
+-- unix epoch seconds (integer) in D1. Convert at the edge.").
+
+-- Users (created via JIT on first authenticated request)
+CREATE TABLE users (
+  id            TEXT PRIMARY KEY,            -- UUIDv7
+  email         TEXT NOT NULL UNIQUE,
+  display_name  TEXT NOT NULL,
+  avatar_url    TEXT,
+  created_at    INTEGER NOT NULL DEFAULT (unixepoch())
+);
+CREATE INDEX idx_users_email ON users(email);
+
+-- Workspaces (POC has exactly one per deploy — see SPEC §16, Q19)
+CREATE TABLE workspaces (
+  id            TEXT PRIMARY KEY,
+  name          TEXT NOT NULL,
+  owner_id      TEXT NOT NULL REFERENCES users(id),
+  vault_repo    TEXT NOT NULL,               -- Artifacts repo identifier
+  ai_search_id  TEXT,                        -- AI Search instance id
+  created_at    INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+-- Rooms
+CREATE TABLE rooms (
+  id            TEXT PRIMARY KEY,
+  workspace_id  TEXT NOT NULL REFERENCES workspaces(id),
+  slug          TEXT NOT NULL,               -- url-safe; unique per workspace
+  name          TEXT NOT NULL,
+  topic         TEXT,
+  created_by    TEXT NOT NULL REFERENCES users(id),
+  created_at    INTEGER NOT NULL DEFAULT (unixepoch()),
+  UNIQUE (workspace_id, slug)
+);
+
+-- Room membership (POC: every workspace member is in every room they join)
+CREATE TABLE room_members (
+  room_id       TEXT NOT NULL REFERENCES rooms(id),
+  user_id       TEXT NOT NULL REFERENCES users(id),
+  role          TEXT NOT NULL CHECK (role IN ('admin', 'member', 'viewer')),
+  joined_at     INTEGER NOT NULL DEFAULT (unixepoch()),
+  PRIMARY KEY (room_id, user_id)
+);
+
+-- Messages (also lived in DO SQLite; D1 is the queryable mirror — see SPEC §9)
+CREATE TABLE messages (
+  id            TEXT PRIMARY KEY,            -- UUIDv7 — sortable
+  room_id       TEXT NOT NULL REFERENCES rooms(id),
+  user_id       TEXT NOT NULL REFERENCES users(id),
+  body          TEXT NOT NULL,               -- markdown
+  parent_id     TEXT REFERENCES messages(id),
+  created_at    INTEGER NOT NULL DEFAULT (unixepoch()),
+  edited_at     INTEGER,
+  deleted_at    INTEGER
+);
+CREATE INDEX idx_messages_room_created ON messages(room_id, created_at);
+
+-- Ingest runs (one per IngestAgent execution; SPEC §10)
+CREATE TABLE ingest_runs (
+  id              TEXT PRIMARY KEY,
+  room_id         TEXT NOT NULL REFERENCES rooms(id),
+  triggered_by    TEXT NOT NULL,             -- user_id or 'cron'
+  started_at      INTEGER NOT NULL DEFAULT (unixepoch()),
+  finished_at     INTEGER,
+  last_message_id TEXT,                      -- bookmark
+  status          TEXT NOT NULL CHECK (status IN ('running', 'succeeded', 'failed')),
+  summary         TEXT,                      -- LLM-written one-liner
+  error           TEXT
+);
+
+-- Proposals (AI-generated wiki edits awaiting review; SPEC §10)
+CREATE TABLE proposals (
+  id              TEXT PRIMARY KEY,
+  run_id          TEXT NOT NULL REFERENCES ingest_runs(id),
+  page_path       TEXT NOT NULL,             -- e.g. /wiki/concepts/dmarc.md
+  action          TEXT NOT NULL CHECK (action IN ('create', 'update')),
+  before_sha      TEXT,                      -- null for 'create'
+  after_content   TEXT NOT NULL,             -- proposed markdown
+  rationale       TEXT NOT NULL,             -- LLM's reasoning
+  status          TEXT NOT NULL CHECK (status IN ('pending', 'merged', 'rejected', 'superseded')),
+  created_at      INTEGER NOT NULL DEFAULT (unixepoch()),
+  reviewed_at     INTEGER,
+  reviewed_by     TEXT REFERENCES users(id),
+  artifacts_commit TEXT                      -- set on merge
+);
+CREATE INDEX idx_proposals_status ON proposals(status, created_at);
+
+-- BYOK keys — envelope-encrypted with BYOK_ENCRYPTION_KEY. Routes that touch
+-- this table land in M8; M1 just provisions the schema.
+CREATE TABLE byok_keys (
+  workspace_id    TEXT NOT NULL REFERENCES workspaces(id),
+  provider        TEXT NOT NULL,             -- 'anthropic' | 'openai' | 'google'
+  ciphertext      BLOB NOT NULL,
+  iv              BLOB NOT NULL,
+  created_at      INTEGER NOT NULL DEFAULT (unixepoch()),
+  created_by      TEXT NOT NULL REFERENCES users(id),
+  PRIMARY KEY (workspace_id, provider)
+);

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@loomwiki/schema",
+  "version": "0.0.1",
+  "private": true,
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./parsers": "./src/parsers.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit false --emitDeclarationOnly",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@loomwiki/shared": "workspace:*",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Zod schemas + inferred types for the D1 row shapes declared in
+// d1-migrations/0001_init.sql. Routes parse rows through these schemas to
+// catch any DB drift loudly (DB_PARSE_ERROR → 500) rather than letting bad
+// data trickle into API responses.
+//
+// Times are stored as unix epoch seconds. Conversion to ISO-8601 happens at
+// the route layer (CLAUDE.md "Times: store as unix epoch seconds (integer)").
+
+import { z } from "zod";
+
+// UUIDv7 — sortable. Helper in @loomwiki/shared/id.
+export const Uuidv7Schema = z
+  .string()
+  .regex(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    "must be a UUIDv7",
+  );
+
+const EpochSeconds = z.number().int().nonnegative();
+
+// Email validation tracks the JWT `email` claim. Length cap matches RFC 5321.
+const EmailSchema = z.string().email().max(320);
+
+// Slug: kebab-case, lowercase, ASCII only, ≤ 60 chars (mirrors vault-template
+// AGENTS.md slug rules). M1 prompt resolves this default explicitly.
+export const SlugSchema = z
+  .string()
+  .regex(/^[a-z][a-z0-9-]{0,59}$/, "slug must be kebab-case lowercase ASCII");
+
+// ---------- D1 row schemas ----------
+
+export const UserRowSchema = z.object({
+  id: Uuidv7Schema,
+  email: EmailSchema,
+  display_name: z.string().min(1).max(120),
+  avatar_url: z.string().url().nullable(),
+  created_at: EpochSeconds,
+});
+export type User = z.infer<typeof UserRowSchema>;
+
+export const WorkspaceRowSchema = z.object({
+  id: Uuidv7Schema,
+  name: z.string().min(1).max(120),
+  owner_id: Uuidv7Schema,
+  vault_repo: z.string().min(1),
+  ai_search_id: z.string().nullable(),
+  created_at: EpochSeconds,
+});
+export type Workspace = z.infer<typeof WorkspaceRowSchema>;
+
+export const RoomRowSchema = z.object({
+  id: Uuidv7Schema,
+  workspace_id: Uuidv7Schema,
+  slug: SlugSchema,
+  name: z.string().min(1).max(120),
+  topic: z.string().nullable(),
+  created_by: Uuidv7Schema,
+  created_at: EpochSeconds,
+});
+export type Room = z.infer<typeof RoomRowSchema>;
+
+export const RoomMemberRoleSchema = z.enum(["admin", "member", "viewer"]);
+export type RoomMemberRole = z.infer<typeof RoomMemberRoleSchema>;
+
+export const RoomMemberRowSchema = z.object({
+  room_id: Uuidv7Schema,
+  user_id: Uuidv7Schema,
+  role: RoomMemberRoleSchema,
+  joined_at: EpochSeconds,
+});
+export type RoomMember = z.infer<typeof RoomMemberRowSchema>;
+
+export const MessageRowSchema = z.object({
+  id: Uuidv7Schema,
+  room_id: Uuidv7Schema,
+  user_id: Uuidv7Schema,
+  body: z.string().max(4096),
+  parent_id: Uuidv7Schema.nullable(),
+  created_at: EpochSeconds,
+  edited_at: EpochSeconds.nullable(),
+  deleted_at: EpochSeconds.nullable(),
+});
+export type Message = z.infer<typeof MessageRowSchema>;
+
+// ---------- Request body schemas ----------
+
+export const CreateRoomRequestSchema = z.object({
+  slug: SlugSchema,
+  name: z.string().min(1).max(120),
+  topic: z.string().max(2000).optional(),
+});
+export type CreateRoomRequest = z.infer<typeof CreateRoomRequestSchema>;

--- a/packages/schema/src/parsers.ts
+++ b/packages/schema/src/parsers.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Typed row parsers for D1 result rows. A failed parse means the DB returned
+// a shape we don't expect — that's a 500 with code `DB_PARSE_ERROR`, not a
+// 4xx, because the client did nothing wrong.
+//
+// Routes call these on every read so schema drift surfaces loudly instead of
+// causing silent bad data downstream.
+
+import { LoomwikiError } from "@loomwiki/shared";
+import type { infer as ZodInfer, ZodTypeAny } from "zod";
+import {
+  MessageRowSchema,
+  RoomMemberRowSchema,
+  RoomRowSchema,
+  UserRowSchema,
+  WorkspaceRowSchema,
+} from "./index.js";
+
+function parseRow<S extends ZodTypeAny>(schema: S, row: unknown, table: string): ZodInfer<S> {
+  const result = schema.safeParse(row);
+  if (!result.success) {
+    throw new LoomwikiError("DB_PARSE_ERROR", `Failed to parse ${table} row`, {
+      status: 500,
+      details: result.error.issues,
+    });
+  }
+  return result.data;
+}
+
+export const parseUserRow = (row: unknown) => parseRow(UserRowSchema, row, "users");
+export const parseWorkspaceRow = (row: unknown) => parseRow(WorkspaceRowSchema, row, "workspaces");
+export const parseRoomRow = (row: unknown) => parseRow(RoomRowSchema, row, "rooms");
+export const parseRoomMemberRow = (row: unknown) =>
+  parseRow(RoomMemberRowSchema, row, "room_members");
+export const parseMessageRow = (row: unknown) => parseRow(MessageRowSchema, row, "messages");
+
+export type {
+  Message,
+  Room,
+  RoomMember,
+  RoomMemberRole,
+  User,
+  Workspace,
+} from "./index.js";

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "lib": ["ES2023"],
+    "types": []
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -10,6 +10,7 @@
     ".": "./src/index.ts",
     "./id": "./src/id.ts",
     "./error": "./src/error.ts",
+    "./errors": "./src/errors.ts",
     "./result": "./src/result.ts"
   },
   "scripts": {

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Error code constants for ApiResult<err> responses. Routes throw a typed
+// LoomwikiError; the worker error middleware maps `code` → status and
+// `code` → JSON body.
+//
+// Status mapping lives in apps/worker/src/middleware/error.ts and is the
+// single source of truth for HTTP semantics; codes here are the wire format
+// shared between worker and web.
+
+export const ErrorCodes = {
+  AUTH_REQUIRED: "AUTH_REQUIRED",
+  AUTH_INVALID_JWT: "AUTH_INVALID_JWT",
+  AUTH_EXPIRED: "AUTH_EXPIRED",
+  NOT_FOUND: "NOT_FOUND",
+  FORBIDDEN: "FORBIDDEN",
+  CONFLICT: "CONFLICT",
+  VALIDATION_FAILED: "VALIDATION_FAILED",
+  RATE_LIMITED: "RATE_LIMITED",
+  DB_PARSE_ERROR: "DB_PARSE_ERROR",
+  INTERNAL_ERROR: "INTERNAL_ERROR",
+} as const;
+
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -2,4 +2,5 @@
 
 export { type ApiError, type ApiResult, apiOk, apiErr } from "./result.js";
 export { LoomwikiError, type LoomwikiErrorOptions, isLoomwikiError } from "./error.js";
+export { ErrorCodes, type ErrorCode } from "./errors.js";
 export { id } from "./id.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,12 +57,18 @@ importers:
 
   apps/worker:
     dependencies:
+      '@loomwiki/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
       '@loomwiki/shared':
         specifier: workspace:*
         version: link:../../packages/shared
       hono:
         specifier: ^4.6.14
         version: 4.12.16
+      jose:
+        specifier: ^5.9.6
+        version: 5.10.0
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.15.2
@@ -79,6 +85,22 @@ importers:
       wrangler:
         specifier: ^4.0.0
         version: 4.87.0(@cloudflare/workers-types@4.20260503.1)
+
+  packages/schema:
+    dependencies:
+      '@loomwiki/shared':
+        specifier: workspace:*
+        version: link:../shared
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.5(@types/node@25.6.0)(vite@6.4.2(@types/node@25.6.0)(yaml@2.8.4))
 
   packages/shared:
     dependencies:
@@ -1985,6 +2007,9 @@ packages:
   is-wsl@3.1.1:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4737,6 +4762,8 @@ snapshots:
   is-wsl@3.1.1:
     dependencies:
       is-inside-container: 1.0.0
+
+  jose@5.10.0: {}
 
   js-tokens@4.0.0: {}
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -42,7 +42,18 @@
     "DEFAULT_LLM_MODEL": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
     "EMBEDDING_MODEL": "@cf/baai/bge-base-en-v1.5",
     "ARTIFACTS_REPO": "loomwiki-vault",
-    "AI_SEARCH_INSTANCE": "loomwiki-search"
+    "AI_SEARCH_INSTANCE": "loomwiki-search",
+    // Cloudflare Access — operators MUST override these in production via the
+    // dashboard or a wrangler `env` block. The dev defaults below match the
+    // values vitest tests use (with mocked JWKS in KV); they are not valid
+    // for a real Access tenant.
+    "ACCESS_TEAM": "loomwiki-dev",
+    "ACCESS_AUD": "loomwiki-dev-aud",
+    // Local-dev auth bypass (X-Local-Dev-Email header). Triple-gated; see
+    // apps/worker/src/middleware/auth.ts. Default off; flip to "true" via
+    // .dev.vars for local development only.
+    "ALLOW_LOCAL_DEV_AUTH": "false",
+    "LOCAL_DEV_EMAIL": ""
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
## Summary

Wires authentication and the data layer per [SPEC.md](SPEC.md) §19 → M1. After this PR, a real user authenticated via Cloudflare Access reaches a typed API surface and is JIT-provisioned in D1. The base resource routes (`/me`, `/workspaces`, `/rooms`) exist and return real data. Closes #4.

11 commits, one logical chunk each — schema package → migration → shared error codes → JWT lib → middleware → JIT helpers → routes → wiring → tests → env/scripts → docs.

## What landed

**Schema package (`@loomwiki/schema`):**
- Zod schemas for User, Workspace, Room, RoomMember, Message + `parse*Row()` helpers that throw `LoomwikiError(code: "DB_PARSE_ERROR", status: 500)` on schema drift.
- `0001_init.sql` migration with all 8 SPEC §7.1 tables and the 3 indexes (idx_users_email, idx_messages_room_created, idx_proposals_status). Forward-only.
- `CreateRoomRequestSchema` and a kebab-case `SlugSchema` mirroring vault-template/AGENTS.md §7.

**Shared error taxonomy (`@loomwiki/shared`):**
- `ErrorCodes` constant: AUTH_REQUIRED, AUTH_INVALID_JWT, AUTH_EXPIRED, NOT_FOUND, FORBIDDEN, CONFLICT, VALIDATION_FAILED, RATE_LIMITED, DB_PARSE_ERROR, INTERNAL_ERROR.

**Worker auth + routes:**
- [`apps/worker/src/lib/auth.ts`](apps/worker/src/lib/auth.ts) — Access JWT verification via `jose` 5.x. JWKS cached in KV under `access-jwks:<team>` with **24h TTL**. Both `audience` and `issuer` checked against env. Distinct `AUTH_EXPIRED` vs `AUTH_INVALID_JWT` codes.
- [`apps/worker/src/middleware/auth.ts`](apps/worker/src/middleware/auth.ts) — Hono middleware. Triple-gated local-dev bypass (see below).
- [`apps/worker/src/middleware/error.ts`](apps/worker/src/middleware/error.ts) — centralized `LoomwikiError` → `ApiResult` mapping. `cause` is logged server-side but never reaches the client.
- [`apps/worker/src/lib/users.ts`](apps/worker/src/lib/users.ts) — JIT user provisioning. SELECT-first (hot path), then INSERT-ON-CONFLICT(email)-DO-NOTHING + re-SELECT on miss (cold path, race-safe).
- [`apps/worker/src/lib/workspace.ts`](apps/worker/src/lib/workspace.ts) — single-tenant workspace bootstrap keyed by a constant UUIDv7-formatted ID. First authenticated user is the owner.
- [`apps/worker/src/lib/serialize.ts`](apps/worker/src/lib/serialize.ts) — converts D1's epoch-seconds to ISO-8601 strings at the edge.
- Routes: `GET /api/me`, `GET /api/workspaces/:wid`, `GET /api/workspaces/:wid/rooms`, `POST /api/workspaces/:wid/rooms` (auto-adds creator as `room_members.role='admin'`), `GET /api/rooms/:rid` (404 unknown / cross-workspace, 403 non-member), `POST /api/_debug/invalidate-jwks` (404 unless triple-gate passes).

**Tests:** 29 vitest suites in `apps/worker` covering JWT validation matrix, JIT idempotency, slug validation + uniqueness conflicts, IP-gate rejection of `CF-Connecting-IP: 8.8.8.8` spoofs, and ISO-8601 timestamp shape. The fixtures generate an RSA keypair at fixture-load and seed it into KV so tests never touch the real Access endpoint. D1 migrations applied per-suite via `applyD1Migrations(env.DB, env.TEST_MIGRATIONS)` (vitest.config.ts reads `packages/schema/d1-migrations` at startup).

**Config + scripts:**
- `pnpm migrate:local` / `migrate:remote` / `migrate:new <name>` are now real Wrangler-native commands.
- `wrangler.jsonc` `vars`: ACCESS_TEAM, ACCESS_AUD (dev placeholders that operators **must** override in production), ALLOW_LOCAL_DEV_AUTH=`"false"`, LOCAL_DEV_EMAIL=`""`.
- `.env.example` extended; new `.dev.vars.example` template; `.gitignore` excepted via `!.dev.vars.example`.

**Docs:** [`docs/ADR/0002-no-orm.md`](docs/ADR/0002-no-orm.md) (no-ORM decision); [`DEPLOY.md`](DEPLOY.md) (Access setup walkthrough).

## Decisions worth surfacing

- **JWKS cache TTL = 24h.** Per the M1 prompt's resolved decision. KV roundtrip on cold; sub-millisecond on warm. Manual invalidation via `POST /api/_debug/invalidate-jwks` (gated).
- **Local-dev auth gating — every guard required, no single-flag bypass.**
  1. `process.env.NODE_ENV !== "production"` — symbolic in Workers production runtime (NODE_ENV is undefined there); a tripwire for accidental builds with NODE_ENV set.
  2. `env.ALLOW_LOCAL_DEV_AUTH === "true"` — operator must explicitly opt in. Default `"false"` in `wrangler.jsonc`.
  3. `CF-Connecting-IP ∈ {127.0.0.1, ::1, null}` — load-bearing gate. In production Cloudflare always sets this header.
  Failing any one falls through to JWT validation, which then 401s. Verified by tests at `apps/worker/src/__tests__/auth.test.ts:114-145` (the `8.8.8.8` spoof test).
- **Wrangler-native migrations only.** No third-party migration lib.
- **JIT idempotency** verified two ways: (a) unit test `me.test.ts:39-50` calls `/api/me` twice with the same email and asserts the user ID matches; (b) live curl smoke against `wrangler dev` produced identical user IDs across calls (see "Verification" below).
- **`/_debug` route hardening (post security review):** the gate now uses the full `isLocalDevAuthAllowed` triple-gate, not just the env flag, so an operator who flips `ALLOW_LOCAL_DEV_AUTH=true` on a public deployment by mistake is still protected by the IP gate.
- **ADR-0002** captures the no-ORM decision: [docs/ADR/0002-no-orm.md](docs/ADR/0002-no-orm.md).

## Wire-format change to flag

The 404 unknown-route response code changes from `code: "not_found"` (lowercase, M0) to `code: "NOT_FOUND"` (uppercase, the new `ErrorCodes` taxonomy). Existing M0 health test updated to match. Nothing external should be consuming this code yet, but worth calling out.

## Assumptions made (CLAUDE.md "When to ask vs proceed" gray zones)

- Default display name for JIT users: email local-part with first letter uppercased (`alice@example.com` → `Alice`). User can change later in M3.
- Slug rules: `^[a-z][a-z0-9-]{0,59}$` per vault-template/AGENTS.md §7.
- Room creator auto-added as `role='admin'`; other workspace members must explicitly join (M2 will surface "join" UX).
- `created_at` exposed in API responses as ISO-8601, converted from epoch-seconds at the edge.
- Local-dev IP-gate test (`CF-Connecting-IP: 8.8.8.8` rejection) — included; this is the highest-risk path in M1.
- `migrations_dir` lives at the top level in `wrangler.jsonc` (one D1 binding).
- Workspace keyed by a constant UUIDv7-formatted ID (`00000000-0000-7000-8000-000000000000`) for v0.0.1 single-tenant. Replaced with per-workspace UUIDv7s when multi-workspace lands in v0.1.

## Verification

```sh
pnpm install                                # already current
pnpm typecheck                              # all green (4 packages)
pnpm lint                                   # biome clean (48 files)
pnpm test                                   # 29 worker + 3 shared = 32 tests passing
pnpm migrate:local                          # No migrations to apply (idempotent re-run)
wrangler d1 execute loomwiki --local --config wrangler.jsonc \
  --command "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'd1_%' ORDER BY name"
# → byok_keys, ingest_runs, messages, proposals, room_members, rooms, users, workspaces (8 tables ✓)
```

Live worker probe (`pnpm --filter @loomwiki/worker dev` with `.dev.vars` setting `ALLOW_LOCAL_DEV_AUTH=true`):

```
$ curl -s http://127.0.0.1:8788/api/me
{"ok":false,"error":{"code":"AUTH_REQUIRED","message":"Missing Access JWT"}}    # 401 ✓

$ curl -s -H "X-Local-Dev-Email: cory@example.com" http://127.0.0.1:8788/api/me | jq '.data.user.id'
"019df054-3d67-7e2e-9111-21f92367d6a9"

$ curl -s -H "X-Local-Dev-Email: cory@example.com" http://127.0.0.1:8788/api/me | jq '.data.user.id'
"019df054-3d67-7e2e-9111-21f92367d6a9"                                          # IDENTICAL — JIT idempotent ✓

$ curl -s -H "X-Local-Dev-Email: alice@example.com" -H "CF-Connecting-IP: 8.8.8.8" http://127.0.0.1:8788/api/me
{"ok":false,"error":{"code":"AUTH_REQUIRED","message":"Missing Access JWT"}}    # 401 — IP gate works ✓
```

The "LOCAL DEV AUTH ENABLED — ABORT IF YOU SEE THIS IN PRODUCTION" warning fired exactly once on first use.

## Test plan

- [x] `pnpm typecheck` — green across `@loomwiki/{shared,schema,worker}` and `apps/web`
- [x] `pnpm lint` — biome clean, 48 files
- [x] `pnpm test` — 32 passing (29 worker + 3 shared)
- [x] `pnpm migrate:local` — applies on a fresh local D1; re-run is a no-op
- [x] `/api/me` 401 without auth, 200 with `X-Local-Dev-Email`, identical user ID across calls
- [x] CF-Connecting-IP spoof rejected (401)
- [ ] CI green on this PR (verify in checks tab)
- [ ] Real Cloudflare Access deploy — operator-side; per `DEPLOY.md` §2

## Out of scope (defer)

Everything explicitly listed in the M1 prompt as "Do NOT implement": WebSocket/chat (M2), wiki routes (M4), cron (M5), AI Search/`/ask` (M6), ingest agent (M7), BYOK (M8), pagination on rooms list, ORM, role-gating beyond owner==admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)