### PR TITLE
M2: ChatRoom DO + WebSocket Hibernation

### DIFF
--- a/apps/web/src/lib/ws.test.ts
+++ b/apps/web/src/lib/ws.test.ts
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { PROTOCOL_VERSION, type ServerMsg } from "@loomwiki/shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatClient, type ChatClientEvent, type ChatClientOptions } from "./ws.js";
+
+// ----- Fake WebSocket -----
+// Implements just enough of the DOM WebSocket interface to drive
+// ChatClient. Each instance lives until the test calls `.simulateClose()`.
+
+const READY = {
+  CONNECTING: 0,
+  OPEN: 1,
+  CLOSING: 2,
+  CLOSED: 3,
+} as const;
+
+interface FakeListener {
+  type: string;
+  fn: (event: unknown) => void;
+}
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static CONNECTING = READY.CONNECTING;
+  static OPEN = READY.OPEN;
+  static CLOSING = READY.CLOSING;
+  static CLOSED = READY.CLOSED;
+
+  url: string;
+  readyState: number = READY.CONNECTING;
+  sent: string[] = [];
+  private listeners: FakeListener[] = [];
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, fn: (event: unknown) => void): void {
+    this.listeners.push({ type, fn });
+  }
+
+  send(data: string): void {
+    if (this.readyState !== READY.OPEN) throw new Error("not open");
+    this.sent.push(data);
+  }
+
+  close(code = 1000, reason = ""): void {
+    if (this.readyState === READY.CLOSED) return;
+    this.readyState = READY.CLOSED;
+    this.dispatch("close", { code, reason });
+  }
+
+  // ----- test driver -----
+  simulateOpen(): void {
+    this.readyState = READY.OPEN;
+    this.dispatch("open", {});
+  }
+
+  simulateMessage(envelope: ServerMsg): void {
+    this.dispatch("message", { data: JSON.stringify(envelope) });
+  }
+
+  simulateRawMessage(data: string): void {
+    this.dispatch("message", { data });
+  }
+
+  simulateClose(reason = "remote close", code = 1006): void {
+    if (this.readyState === READY.CLOSED) return;
+    this.readyState = READY.CLOSED;
+    this.dispatch("close", { code, reason });
+  }
+
+  private dispatch(type: string, event: unknown): void {
+    for (const l of this.listeners) {
+      if (l.type === type) l.fn(event);
+    }
+  }
+}
+
+// Cast the fake to satisfy `typeof WebSocket` — runtime shape is what
+// matters; ChatClient only touches `new`, `send`, `close`, `readyState`,
+// `addEventListener` and the static `OPEN`.
+function ctor(): typeof WebSocket {
+  return FakeWebSocket as unknown as typeof WebSocket;
+}
+
+beforeEach(() => {
+  FakeWebSocket.instances = [];
+  vi.useFakeTimers();
+  // Math.random is used for jitter; pin it so backoff is deterministic.
+  vi.spyOn(Math, "random").mockReturnValue(0.5);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function lastInstance(): FakeWebSocket {
+  const last = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+  if (!last) throw new Error("no fake WebSocket instances yet");
+  return last;
+}
+
+function newClient(extras: Partial<ChatClientOptions> = {}) {
+  return new ChatClient({
+    url: "wss://api.local/api/rooms/r1/ws",
+    WebSocketCtor: ctor(),
+    setTimer: globalThis.setTimeout,
+    clearTimer: globalThis.clearTimeout,
+    ...extras,
+  });
+}
+
+describe("ChatClient — happy path", () => {
+  it("sends `hello` (with PROTOCOL_VERSION) as the first frame on open", () => {
+    const client = newClient();
+    client.connect();
+    const ws = lastInstance();
+    ws.simulateOpen();
+
+    expect(ws.sent).toHaveLength(1);
+    const sent = JSON.parse(ws.sent[0] ?? "{}");
+    expect(sent).toMatchObject({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    expect(sent.sinceMessageId).toBeUndefined();
+  });
+
+  it("includes sinceMessageId on hello when initialSinceMessageId is set", () => {
+    const client = newClient({ initialSinceMessageId: "0190b0a4-7b2e-7eee-8aaa-aaaaaaaaaaaa" });
+    client.connect();
+    const ws = lastInstance();
+    ws.simulateOpen();
+    const sent = JSON.parse(ws.sent[0] ?? "{}");
+    expect(sent.sinceMessageId).toBe("0190b0a4-7b2e-7eee-8aaa-aaaaaaaaaaaa");
+  });
+
+  it("emits server events for typed envelopes and tracks lastReceivedServerId", () => {
+    const client = newClient();
+    const seen: ChatClientEvent[] = [];
+    client.on((e) => seen.push(e));
+    client.connect();
+    const ws = lastInstance();
+    ws.simulateOpen();
+
+    const messageId = "0190b0a4-7b2e-7eee-8aaa-bbbbbbbbbbbb";
+    ws.simulateMessage({
+      kind: "welcome",
+      protocolVersion: PROTOCOL_VERSION,
+      roomId: "0190b0a4-7b2e-7eee-8aaa-cccccccccccc",
+      recentMessages: [],
+    });
+    ws.simulateMessage({
+      kind: "message",
+      message: {
+        id: messageId,
+        room_id: "0190b0a4-7b2e-7eee-8aaa-cccccccccccc",
+        user_id: "0190b0a4-7b2e-7eee-8aaa-dddddddddddd",
+        body: "hi",
+        parent_id: null,
+        created_at: 1,
+        edited_at: null,
+        deleted_at: null,
+      },
+    });
+
+    const serverEvents = seen.filter((e) => e.kind === "server");
+    expect(serverEvents.map((e) => (e.kind === "server" ? e.msg.kind : null))).toEqual([
+      "welcome",
+      "message",
+    ]);
+
+    // Reconnect: lastReceivedServerId should be carried into hello.
+    ws.simulateClose();
+    vi.advanceTimersByTime(2000);
+    const ws2 = lastInstance();
+    expect(ws2).not.toBe(ws);
+    ws2.simulateOpen();
+    const helloSent = JSON.parse(ws2.sent[0] ?? "{}");
+    expect(helloSent.sinceMessageId).toBe(messageId);
+  });
+});
+
+describe("ChatClient — send queue", () => {
+  it("buffers sends issued before the socket opens, then flushes on open", () => {
+    const client = newClient();
+    client.sendMessage("t1", "hi");
+    client.sendMessage("t2", "again");
+    expect(client.pendingSendCount()).toBe(2);
+
+    client.connect();
+    const ws = lastInstance();
+    expect(ws.sent).toHaveLength(0);
+    ws.simulateOpen();
+
+    // First sent frame is `hello`, then the two queued sends.
+    expect(ws.sent.length).toBe(3);
+    expect(JSON.parse(ws.sent[0] ?? "{}").kind).toBe("hello");
+    expect(JSON.parse(ws.sent[1] ?? "{}")).toMatchObject({ kind: "send", tempId: "t1" });
+    expect(JSON.parse(ws.sent[2] ?? "{}")).toMatchObject({ kind: "send", tempId: "t2" });
+    expect(client.pendingSendCount()).toBe(0);
+  });
+
+  it("re-buffers + replays sends across a reconnect", () => {
+    const client = newClient();
+    client.connect();
+    const ws = lastInstance();
+    ws.simulateOpen();
+
+    ws.simulateClose();
+    expect(client.pendingSendCount()).toBe(0);
+
+    // Queue a send while disconnected.
+    client.sendMessage("t-mid", "while-disconnected");
+    expect(client.pendingSendCount()).toBe(1);
+
+    vi.advanceTimersByTime(2000);
+    const ws2 = lastInstance();
+    expect(ws2).not.toBe(ws);
+    ws2.simulateOpen();
+
+    expect(client.pendingSendCount()).toBe(0);
+    const allSent = ws2.sent.map((s) => JSON.parse(s));
+    expect(allSent[0]).toMatchObject({ kind: "hello" });
+    expect(allSent[1]).toMatchObject({ kind: "send", tempId: "t-mid" });
+  });
+});
+
+describe("ChatClient — heartbeat & reconnect", () => {
+  it("sends a `ping` after pingIntervalMs and tolerates a `pong` reply", () => {
+    const client = newClient({ pingIntervalMs: 1000, pongTimeoutMs: 500 });
+    client.connect();
+    const ws = lastInstance();
+    ws.simulateOpen();
+
+    vi.advanceTimersByTime(1000);
+    const pingFrame = ws.sent[ws.sent.length - 1];
+    expect(JSON.parse(pingFrame ?? "{}")).toEqual({ kind: "ping" });
+
+    ws.simulateMessage({ kind: "pong" });
+    // pong drained; next ping schedules in another 1000ms.
+    vi.advanceTimersByTime(1000);
+    const next = ws.sent[ws.sent.length - 1];
+    expect(JSON.parse(next ?? "{}")).toEqual({ kind: "ping" });
+  });
+
+  it("force-closes when `pong` does not arrive within pongTimeoutMs", () => {
+    const client = newClient({ pingIntervalMs: 1000, pongTimeoutMs: 500 });
+    client.connect();
+    const ws = lastInstance();
+    ws.simulateOpen();
+
+    vi.advanceTimersByTime(1000);
+    expect(ws.readyState).toBe(READY.OPEN);
+    vi.advanceTimersByTime(600);
+    expect(ws.readyState).toBe(READY.CLOSED);
+  });
+
+  it("does NOT reconnect after `client.close()`", () => {
+    const client = newClient();
+    client.connect();
+    const ws = lastInstance();
+    ws.simulateOpen();
+
+    client.close();
+    vi.advanceTimersByTime(60_000);
+    expect(FakeWebSocket.instances.length).toBe(1);
+  });
+});
+
+describe("ChatClient — malformed server frames", () => {
+  it("emits error events for non-JSON and shape-invalid frames but stays connected", () => {
+    const client = newClient();
+    const seen: ChatClientEvent[] = [];
+    client.on((e) => seen.push(e));
+    client.connect();
+    const ws = lastInstance();
+    ws.simulateOpen();
+
+    ws.simulateRawMessage("not-json{");
+    ws.simulateRawMessage(JSON.stringify({ kind: "made-up-envelope" }));
+
+    const errs = seen.filter((e) => e.kind === "error");
+    expect(errs.length).toBe(2);
+    expect(ws.readyState).toBe(READY.OPEN);
+  });
+});

--- a/apps/web/src/lib/ws.ts
+++ b/apps/web/src/lib/ws.ts
@@ -1,0 +1,354 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Typed ChatRoom WebSocket client for the browser. Job: don't lose
+// messages.
+//
+//   - Exponential reconnect with jitter (250ms → 30s).
+//   - Heartbeat ping every 30s; force-close after 10s of no pong.
+//   - Send queue buffers while disconnected; flushed on (re)open.
+//   - On reconnect, sends `hello { sinceMessageId: lastReceivedServerId }`
+//     so the server replays only what we missed (UUIDv7 cursor — SPEC §9).
+//   - Each enqueued send carries a stable client `tempId` so the eventual
+//     `ack` can deduplicate against the optimistic-UI entry.
+//
+// Auth is the Cloudflare Access cookie set by the browser on the upgrade
+// request — there is no header to attach, the WebSocket constructor sends
+// cookies for same-origin URLs automatically.
+//
+// The `WebSocketCtor` constructor parameter is a test seam: pass a fake to
+// avoid relying on `globalThis.WebSocket` in unit tests.
+
+import {
+  type ClientMsg,
+  PROTOCOL_VERSION,
+  type ServerMsg,
+  ServerMsgSchema,
+} from "@loomwiki/shared";
+
+export interface ChatClientOptions {
+  url: string;
+  /** Resume cursor on first connect — pass undefined for a fresh client. */
+  initialSinceMessageId?: string;
+  /** Override for tests. Defaults to `globalThis.WebSocket`. */
+  WebSocketCtor?: typeof WebSocket;
+  /** Test seam: schedule a callback. Defaults to `setTimeout`. */
+  setTimer?: typeof setTimeout;
+  clearTimer?: typeof clearTimeout;
+  /** Backoff knobs (defaults match SPEC + M2 prompt). */
+  initialBackoffMs?: number;
+  maxBackoffMs?: number;
+  jitterFraction?: number;
+  pingIntervalMs?: number;
+  pongTimeoutMs?: number;
+}
+
+export type ChatClientEvent =
+  | { kind: "open" }
+  | { kind: "close"; reason: string }
+  | { kind: "server"; msg: ServerMsg }
+  | { kind: "error"; error: Error };
+
+export type ChatClientListener = (e: ChatClientEvent) => void;
+
+interface QueuedSend {
+  envelope: ClientMsg;
+}
+
+const DEFAULTS = {
+  initialBackoffMs: 250,
+  maxBackoffMs: 30_000,
+  jitterFraction: 0.2,
+  pingIntervalMs: 30_000,
+  pongTimeoutMs: 10_000,
+} as const;
+
+export class ChatClient {
+  private readonly opts: Required<
+    Omit<ChatClientOptions, "initialSinceMessageId" | "WebSocketCtor" | "setTimer" | "clearTimer">
+  > & {
+    initialSinceMessageId?: string | undefined;
+    WebSocketCtor: typeof WebSocket;
+    setTimer: typeof setTimeout;
+    clearTimer: typeof clearTimeout;
+  };
+
+  private socket: WebSocket | null = null;
+  private listeners: Set<ChatClientListener> = new Set();
+  private sendQueue: QueuedSend[] = [];
+  private lastReceivedServerId: string | undefined;
+  private reconnectAttempts = 0;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private pingTimer: ReturnType<typeof setTimeout> | null = null;
+  private pongDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
+  private closedByUser = false;
+
+  constructor(options: ChatClientOptions) {
+    this.opts = {
+      url: options.url,
+      initialSinceMessageId: options.initialSinceMessageId,
+      WebSocketCtor: options.WebSocketCtor ?? globalThis.WebSocket,
+      setTimer: options.setTimer ?? setTimeout,
+      clearTimer: options.clearTimer ?? clearTimeout,
+      initialBackoffMs: options.initialBackoffMs ?? DEFAULTS.initialBackoffMs,
+      maxBackoffMs: options.maxBackoffMs ?? DEFAULTS.maxBackoffMs,
+      jitterFraction: options.jitterFraction ?? DEFAULTS.jitterFraction,
+      pingIntervalMs: options.pingIntervalMs ?? DEFAULTS.pingIntervalMs,
+      pongTimeoutMs: options.pongTimeoutMs ?? DEFAULTS.pongTimeoutMs,
+    };
+    if (options.initialSinceMessageId !== undefined) {
+      this.lastReceivedServerId = options.initialSinceMessageId;
+    }
+  }
+
+  on(listener: ChatClientListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Idempotent. Opens a socket if one is not already open or opening. */
+  connect(): void {
+    if (this.socket && this.socket.readyState <= WebSocket.OPEN) return;
+    this.closedByUser = false;
+    this.openSocket();
+  }
+
+  /** Closes permanently — no reconnect. */
+  close(): void {
+    this.closedByUser = true;
+    this.cancelReconnect();
+    this.cancelPingTimers();
+    if (this.socket) {
+      try {
+        this.socket.close();
+      } catch {
+        // already closed
+      }
+    }
+  }
+
+  /**
+   * Send a `send` envelope. Buffered if not currently connected; flushed
+   * on (re)connect. Caller supplies a `tempId` so optimistic UI can
+   * reconcile against the eventual `ack`.
+   */
+  sendMessage(tempId: string, body: string, parentId?: string): void {
+    const envelope: ClientMsg =
+      parentId !== undefined
+        ? { kind: "send", tempId, body, parentId }
+        : { kind: "send", tempId, body };
+    this.enqueue(envelope);
+  }
+
+  edit(messageId: string, body: string): void {
+    this.enqueue({ kind: "edit", messageId, body });
+  }
+
+  delete(messageId: string): void {
+    this.enqueue({ kind: "delete", messageId });
+  }
+
+  /** Inspect-only — used by tests to assert on flush behavior. */
+  pendingSendCount(): number {
+    return this.sendQueue.length;
+  }
+
+  // ---------- internals ----------
+
+  private enqueue(envelope: ClientMsg): void {
+    this.sendQueue.push({ envelope });
+    this.flushQueue();
+  }
+
+  private flushQueue(): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    while (this.sendQueue.length > 0) {
+      const head = this.sendQueue[0];
+      if (!head) break;
+      try {
+        this.socket.send(JSON.stringify(head.envelope));
+        this.sendQueue.shift();
+      } catch {
+        // Send raised — leave in queue, the close handler will trigger
+        // reconnect, and the next open will flush again.
+        return;
+      }
+    }
+  }
+
+  private openSocket(): void {
+    let socket: WebSocket;
+    try {
+      socket = new this.opts.WebSocketCtor(this.opts.url);
+    } catch (err) {
+      this.emitError(err);
+      this.scheduleReconnect();
+      return;
+    }
+    this.socket = socket;
+
+    socket.addEventListener("open", () => this.handleOpen());
+    socket.addEventListener("message", (event) => this.handleMessage(event));
+    socket.addEventListener("close", (event) => this.handleClose(event));
+    socket.addEventListener("error", () => {
+      // The WebSocket spec emits a generic Event on error; close follows.
+      // We only emit a typed error if we actually have one (handled in
+      // openSocket's try/catch and in handleClose's reason).
+    });
+  }
+
+  private handleOpen(): void {
+    this.reconnectAttempts = 0;
+    this.cancelReconnect();
+
+    // First frame is always `hello` so the server can resume from our
+    // cursor. We send it directly (not via the queue) so a stuffed queue
+    // can't push a `send` in front of `hello`.
+    const hello: ClientMsg =
+      this.lastReceivedServerId !== undefined
+        ? {
+            kind: "hello",
+            protocolVersion: PROTOCOL_VERSION,
+            sinceMessageId: this.lastReceivedServerId,
+          }
+        : { kind: "hello", protocolVersion: PROTOCOL_VERSION };
+    try {
+      this.socket?.send(JSON.stringify(hello));
+    } catch (err) {
+      this.emitError(err);
+      return;
+    }
+
+    this.flushQueue();
+    this.startPing();
+    this.emit({ kind: "open" });
+  }
+
+  private handleMessage(event: MessageEvent): void {
+    const raw = typeof event.data === "string" ? event.data : "";
+    let parsed: ServerMsg;
+    try {
+      const json: unknown = JSON.parse(raw);
+      const result = ServerMsgSchema.safeParse(json);
+      if (!result.success) {
+        this.emitError(new Error("malformed server envelope"));
+        return;
+      }
+      parsed = result.data;
+    } catch {
+      this.emitError(new Error("non-JSON server frame"));
+      return;
+    }
+
+    if (parsed.kind === "pong") {
+      this.cancelPongDeadline();
+      // Don't surface pong to listeners — it's heartbeat plumbing.
+      return;
+    }
+
+    if (parsed.kind === "welcome") {
+      const last = parsed.recentMessages[parsed.recentMessages.length - 1];
+      if (last) this.lastReceivedServerId = last.id;
+    } else if (parsed.kind === "message") {
+      this.lastReceivedServerId = parsed.message.id;
+    } else if (parsed.kind === "ack") {
+      this.lastReceivedServerId = parsed.messageId;
+    }
+
+    this.emit({ kind: "server", msg: parsed });
+  }
+
+  private handleClose(event: CloseEvent): void {
+    this.cancelPingTimers();
+    this.socket = null;
+    this.emit({ kind: "close", reason: event.reason || `code=${event.code}` });
+    if (!this.closedByUser) this.scheduleReconnect();
+  }
+
+  // Heartbeat: ping every interval; force-close if no pong inside deadline.
+  private startPing(): void {
+    this.cancelPingTimers();
+    this.pingTimer = this.opts.setTimer(() => this.sendPing(), this.opts.pingIntervalMs);
+  }
+
+  private sendPing(): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    try {
+      this.socket.send(JSON.stringify({ kind: "ping" } satisfies ClientMsg));
+    } catch (err) {
+      this.emitError(err);
+      return;
+    }
+    this.pongDeadlineTimer = this.opts.setTimer(
+      () => this.handlePongTimeout(),
+      this.opts.pongTimeoutMs,
+    );
+  }
+
+  private handlePongTimeout(): void {
+    if (this.socket) {
+      try {
+        this.socket.close(4000, "pong timeout");
+      } catch {
+        // ignore
+      }
+    }
+    // close handler runs scheduleReconnect for us.
+  }
+
+  private cancelPingTimers(): void {
+    if (this.pingTimer) {
+      this.opts.clearTimer(this.pingTimer);
+      this.pingTimer = null;
+    }
+    this.cancelPongDeadline();
+  }
+
+  private cancelPongDeadline(): void {
+    if (this.pongDeadlineTimer) {
+      this.opts.clearTimer(this.pongDeadlineTimer);
+      this.pongDeadlineTimer = null;
+    }
+    // After receiving a pong, queue the next ping.
+    this.pingTimer = this.opts.setTimer(() => this.sendPing(), this.opts.pingIntervalMs);
+  }
+
+  private scheduleReconnect(): void {
+    if (this.closedByUser) return;
+    this.cancelReconnect();
+    const delay = this.computeBackoff(this.reconnectAttempts);
+    this.reconnectAttempts++;
+    this.reconnectTimer = this.opts.setTimer(() => {
+      this.reconnectTimer = null;
+      this.openSocket();
+    }, delay);
+  }
+
+  private cancelReconnect(): void {
+    if (this.reconnectTimer) {
+      this.opts.clearTimer(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private computeBackoff(attempt: number): number {
+    const base = Math.min(this.opts.initialBackoffMs * 2 ** attempt, this.opts.maxBackoffMs);
+    const jitterAmp = base * this.opts.jitterFraction;
+    const jitter = (Math.random() * 2 - 1) * jitterAmp;
+    return Math.max(0, base + jitter);
+  }
+
+  private emit(event: ChatClientEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch (err) {
+        console.error("[ChatClient] listener threw", err);
+      }
+    }
+  }
+
+  private emitError(err: unknown): void {
+    const error = err instanceof Error ? err : new Error(String(err));
+    this.emit({ kind: "error", error });
+  }
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Web app vitest config. Uses node environment because the client lib
+// avoids browser globals beyond the constructor it accepts as a parameter
+// (see src/lib/ws.ts) — tests inject a fake WebSocket constructor.
+
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/apps/worker/src/__tests__/__fixtures__/ws.ts
+++ b/apps/worker/src/__tests__/__fixtures__/ws.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// WebSocket test helper. Opens a session through `SELF.fetch` (so auth +
+// route + DO upgrade all run as one unit) and exposes a Promise-based
+// queue of inbound `ServerMsg` envelopes.
+
+import { SELF } from "cloudflare:test";
+import { type ServerMsg, ServerMsgSchema } from "@loomwiki/shared";
+
+export interface WsSession {
+  ws: WebSocket;
+  /** Resolves with the next inbound ServerMsg, or rejects on timeout. */
+  next(timeoutMs?: number): Promise<ServerMsg>;
+  /** Drain inbound queue for ~`waitMs` and return everything seen. */
+  collect(waitMs?: number): Promise<ServerMsg[]>;
+  send(envelope: unknown): void;
+  close(): void;
+}
+
+interface PendingResolver {
+  resolve(msg: ServerMsg): void;
+  reject(err: Error): void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+export async function openWs(roomId: string, jwt: string): Promise<WsSession> {
+  const res = await SELF.fetch(`https://api.local/api/rooms/${roomId}/ws`, {
+    headers: {
+      Upgrade: "websocket",
+      "CF-Access-Jwt-Assertion": jwt,
+    },
+  });
+  if (res.status !== 101 || !res.webSocket) {
+    const body = await res.text().catch(() => "<unreadable>");
+    throw new Error(`ws upgrade failed: status=${res.status} body=${body}`);
+  }
+  const ws = res.webSocket;
+
+  const queue: ServerMsg[] = [];
+  const waiters: PendingResolver[] = [];
+
+  ws.addEventListener("message", (event) => {
+    const data = typeof event.data === "string" ? event.data : new TextDecoder().decode(event.data);
+    let parsed: ServerMsg;
+    try {
+      const json: unknown = JSON.parse(data);
+      const result = ServerMsgSchema.safeParse(json);
+      if (!result.success) {
+        console.warn("[ws-test] unexpected envelope shape", result.error.issues);
+        return;
+      }
+      parsed = result.data;
+    } catch (err) {
+      console.warn("[ws-test] non-JSON frame", err);
+      return;
+    }
+    const waiter = waiters.shift();
+    if (waiter) {
+      clearTimeout(waiter.timer);
+      waiter.resolve(parsed);
+    } else {
+      queue.push(parsed);
+    }
+  });
+
+  ws.accept();
+
+  return {
+    ws,
+    async next(timeoutMs = 1500): Promise<ServerMsg> {
+      const buffered = queue.shift();
+      if (buffered !== undefined) return buffered;
+      return new Promise<ServerMsg>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          const idx = waiters.findIndex((w) => w.timer === timer);
+          if (idx >= 0) waiters.splice(idx, 1);
+          reject(new Error(`ws.next() timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+        waiters.push({ resolve, reject, timer });
+      });
+    },
+    async collect(waitMs = 200): Promise<ServerMsg[]> {
+      await new Promise((r) => setTimeout(r, waitMs));
+      const drained = queue.splice(0, queue.length);
+      return drained;
+    },
+    send(envelope: unknown): void {
+      ws.send(JSON.stringify(envelope));
+    },
+    close(): void {
+      try {
+        ws.close();
+      } catch {
+        // ignore
+      }
+    },
+  };
+}

--- a/apps/worker/src/__tests__/chat-room.test.ts
+++ b/apps/worker/src/__tests__/chat-room.test.ts
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// ChatRoom DO end-to-end tests, exercised through SELF.fetch so auth +
+// route + DO upgrade all run as one unit. Reserves runInDurableObject for
+// cases the route layer cannot reach (alarm fire, mirror failure paths).
+
+import { SELF, env } from "cloudflare:test";
+import { PROTOCOL_VERSION } from "@loomwiki/shared";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+import { type WsSession, openWs } from "./__fixtures__/ws.js";
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+const openSessions: WsSession[] = [];
+afterEach(() => {
+  while (openSessions.length > 0) {
+    const s = openSessions.pop();
+    s?.close();
+  }
+});
+
+interface RoomBootstrap {
+  jwt: string;
+  userId: string;
+  roomId: string;
+}
+
+async function bootstrapMember(email: string, slug: string): Promise<RoomBootstrap> {
+  const jwt = await fixture.mint({ email });
+  const me = await SELF.fetch("https://api.local/api/me", {
+    headers: { "CF-Access-Jwt-Assertion": jwt },
+  });
+  const meBody = (await me.json()) as {
+    data: { user: { id: string }; workspace: { id: string } };
+  };
+
+  const create = await SELF.fetch(
+    `https://api.local/api/workspaces/${meBody.data.workspace.id}/rooms`,
+    {
+      method: "POST",
+      headers: {
+        "CF-Access-Jwt-Assertion": jwt,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ slug, name: slug }),
+    },
+  );
+  const room = (await create.json()) as { data: { room: { id: string } } };
+  return { jwt, userId: meBody.data.user.id, roomId: room.data.room.id };
+}
+
+async function joinAsMember(jwt: string, roomId: string): Promise<string> {
+  // Bootstrap user via /me so the row exists, then add to room_members
+  // directly via D1 (the public room-join API lands later — for now this
+  // is the test seam).
+  const me = await SELF.fetch("https://api.local/api/me", {
+    headers: { "CF-Access-Jwt-Assertion": jwt },
+  });
+  const meBody = (await me.json()) as { data: { user: { id: string } } };
+  await env.DB.prepare(
+    "INSERT OR IGNORE INTO room_members (room_id, user_id, role) VALUES (?, ?, 'member')",
+  )
+    .bind(roomId, meBody.data.user.id)
+    .run();
+  return meBody.data.user.id;
+}
+
+async function track<T extends WsSession>(s: T): Promise<T> {
+  openSessions.push(s);
+  return s;
+}
+
+describe("ChatRoom DO — WebSocket flow", () => {
+  it("rejects upgrade for non-members with 403", async () => {
+    const alice = await bootstrapMember("alice@example.com", "alice-room");
+    const bobJwt = await fixture.mint({ email: "bob@example.com" });
+    await SELF.fetch("https://api.local/api/me", {
+      headers: { "CF-Access-Jwt-Assertion": bobJwt },
+    });
+
+    const res = await SELF.fetch(`https://api.local/api/rooms/${alice.roomId}/ws`, {
+      headers: { Upgrade: "websocket", "CF-Access-Jwt-Assertion": bobJwt },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects upgrade for unknown room with 404", async () => {
+    const alice = await bootstrapMember("alice@example.com", "alice-room");
+    const bogus = "0190b0a4-7b2e-7eee-8aaa-aaaaaaaaaaaa";
+    const res = await SELF.fetch(`https://api.local/api/rooms/${bogus}/ws`, {
+      headers: { Upgrade: "websocket", "CF-Access-Jwt-Assertion": alice.jwt },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("hello → welcome with empty backlog returns protocolVersion", async () => {
+    const alice = await bootstrapMember("alice@example.com", "general");
+    const ws = await track(await openWs(alice.roomId, alice.jwt));
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+
+    const welcome = await ws.next();
+    expect(welcome.kind).toBe("welcome");
+    if (welcome.kind !== "welcome") throw new Error("unreachable");
+    expect(welcome.protocolVersion).toBe(PROTOCOL_VERSION);
+    expect(welcome.roomId).toBe(alice.roomId);
+    expect(welcome.recentMessages).toEqual([]);
+  });
+
+  it("two members exchange a message; sender gets ack, receiver gets message", async () => {
+    const alice = await bootstrapMember("alice@example.com", "general");
+    const bobJwt = await fixture.mint({ email: "bob@example.com" });
+    await joinAsMember(bobJwt, alice.roomId);
+
+    const aliceWs = await track(await openWs(alice.roomId, alice.jwt));
+    const bobWs = await track(await openWs(alice.roomId, bobJwt));
+
+    aliceWs.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    bobWs.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await aliceWs.next();
+    await bobWs.next();
+
+    aliceWs.send({ kind: "send", tempId: "t-1", body: "hello bob" });
+
+    const ack = await aliceWs.next();
+    expect(ack.kind).toBe("ack");
+    if (ack.kind !== "ack") throw new Error("unreachable");
+    expect(ack.tempId).toBe("t-1");
+
+    const recv = await bobWs.next();
+    expect(recv.kind).toBe("message");
+    if (recv.kind !== "message") throw new Error("unreachable");
+    expect(recv.message.body).toBe("hello bob");
+    expect(recv.message.id).toBe(ack.messageId);
+    expect(recv.message.user_id).toBe(alice.userId);
+  });
+
+  it("rejects body > 4096 chars with VALIDATION_FAILED, echoing tempId", async () => {
+    const alice = await bootstrapMember("alice@example.com", "general");
+    const ws = await track(await openWs(alice.roomId, alice.jwt));
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws.next();
+
+    ws.send({ kind: "send", tempId: "too-long", body: "x".repeat(4097) });
+    const err = await ws.next();
+    expect(err.kind).toBe("error");
+    if (err.kind !== "error") throw new Error("unreachable");
+    expect(err.code).toBe("VALIDATION_FAILED");
+    expect(err.tempId).toBe("too-long");
+  });
+
+  it("rate-limits beyond 100 msg/sec/room with RATE_LIMITED", async () => {
+    const alice = await bootstrapMember("alice@example.com", "general");
+    const ws = await track(await openWs(alice.roomId, alice.jwt));
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws.next();
+
+    // Drain the budget by firing 100 sends.
+    for (let i = 0; i < 100; i++) {
+      ws.send({ kind: "send", tempId: `t-${i}`, body: `m${i}` });
+    }
+    // Drain acks (and any echoed messages — there's only one socket so we
+    // expect 100 acks total).
+    let acks = 0;
+    while (acks < 100) {
+      const m = await ws.next(2000);
+      if (m.kind === "ack") acks++;
+    }
+
+    // The 101st must be rejected.
+    ws.send({ kind: "send", tempId: "rate", body: "rate-me" });
+    const next = await ws.next();
+    expect(next.kind).toBe("error");
+    if (next.kind !== "error") throw new Error("unreachable");
+    expect(next.code).toBe("RATE_LIMITED");
+    expect(next.tempId).toBe("rate");
+  });
+
+  it("reconnect with sinceMessageId returns missed messages in welcome", async () => {
+    const alice = await bootstrapMember("alice@example.com", "general");
+    // Round 1: send a few messages, capture IDs.
+    const ws1 = await track(await openWs(alice.roomId, alice.jwt));
+    ws1.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws1.next();
+
+    const sentIds: string[] = [];
+    for (const body of ["one", "two", "three"]) {
+      ws1.send({ kind: "send", tempId: body, body });
+      const ack = await ws1.next();
+      if (ack.kind !== "ack") throw new Error("expected ack");
+      sentIds.push(ack.messageId);
+    }
+    ws1.close();
+    openSessions.pop();
+
+    // Round 2: reconnect with sinceMessageId set to the first message;
+    // welcome should include "two" and "three", not "one".
+    const ws2 = await track(await openWs(alice.roomId, alice.jwt));
+    ws2.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION, sinceMessageId: sentIds[0] });
+    const welcome = await ws2.next();
+    if (welcome.kind !== "welcome") throw new Error("expected welcome");
+    expect(welcome.recentMessages.map((m) => m.body)).toEqual(["two", "three"]);
+  });
+
+  it("edit by author succeeds; non-author gets FORBIDDEN", async () => {
+    const alice = await bootstrapMember("alice@example.com", "general");
+    const bobJwt = await fixture.mint({ email: "bob@example.com" });
+    await joinAsMember(bobJwt, alice.roomId);
+
+    const aliceWs = await track(await openWs(alice.roomId, alice.jwt));
+    const bobWs = await track(await openWs(alice.roomId, bobJwt));
+    aliceWs.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    bobWs.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await aliceWs.next();
+    await bobWs.next();
+
+    aliceWs.send({ kind: "send", tempId: "e1", body: "original" });
+    const ack = await aliceWs.next();
+    if (ack.kind !== "ack") throw new Error("expected ack");
+    await bobWs.next(); // bob receives the message broadcast
+
+    // Author edits — should broadcast to both, including sender.
+    aliceWs.send({ kind: "edit", messageId: ack.messageId, body: "edited!" });
+    const aliceEdited = await aliceWs.next();
+    expect(aliceEdited.kind).toBe("edited");
+    const bobEdited = await bobWs.next();
+    expect(bobEdited.kind).toBe("edited");
+
+    // Bob attempts to edit Alice's message — FORBIDDEN.
+    bobWs.send({ kind: "edit", messageId: ack.messageId, body: "naughty" });
+    const denied = await bobWs.next();
+    expect(denied.kind).toBe("error");
+    if (denied.kind !== "error") throw new Error("unreachable");
+    expect(denied.code).toBe("FORBIDDEN");
+  });
+
+  it("delete by author tombstones; scrollback returns blanked body", async () => {
+    const alice = await bootstrapMember("alice@example.com", "general");
+    const ws = await track(await openWs(alice.roomId, alice.jwt));
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws.next();
+
+    ws.send({ kind: "send", tempId: "d1", body: "doomed" });
+    const ack = await ws.next();
+    if (ack.kind !== "ack") throw new Error("expected ack");
+
+    ws.send({ kind: "delete", messageId: ack.messageId });
+    const deleted = await ws.next();
+    expect(deleted.kind).toBe("deleted");
+    if (deleted.kind !== "deleted") throw new Error("unreachable");
+    expect(deleted.messageId).toBe(ack.messageId);
+
+    // Reconnect — backlog includes the tombstoned message with body=""
+    ws.close();
+    openSessions.pop();
+    const ws2 = await track(await openWs(alice.roomId, alice.jwt));
+    ws2.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    const welcome = await ws2.next();
+    if (welcome.kind !== "welcome") throw new Error("expected welcome");
+    const tombstone = welcome.recentMessages.find((m) => m.id === ack.messageId);
+    expect(tombstone?.body).toBe("");
+    expect(tombstone?.deleted_at).not.toBeNull();
+  });
+
+  it("malformed JSON yields VALIDATION_FAILED but keeps the socket open", async () => {
+    const alice = await bootstrapMember("alice@example.com", "general");
+    const ws = await track(await openWs(alice.roomId, alice.jwt));
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws.next();
+
+    ws.ws.send("{not-json");
+    const err = await ws.next();
+    expect(err.kind).toBe("error");
+    if (err.kind !== "error") throw new Error("unreachable");
+    expect(err.code).toBe("VALIDATION_FAILED");
+
+    // Socket still works.
+    ws.send({ kind: "ping" });
+    const pong = await ws.next();
+    expect(pong.kind).toBe("pong");
+  });
+});

--- a/apps/worker/src/__tests__/messages.test.ts
+++ b/apps/worker/src/__tests__/messages.test.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Historical scrollback (`GET /api/rooms/:rid/messages`) tests. Reads from
+// D1, so we drive it by inserting rows directly rather than going through
+// the WS path (which would also work but is slower and exercises code that
+// has its own test file).
+
+import { SELF, env } from "cloudflare:test";
+import { id } from "@loomwiki/shared";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+interface Bootstrap {
+  jwt: string;
+  userId: string;
+  roomId: string;
+}
+
+async function bootstrapAliceRoom(): Promise<Bootstrap> {
+  const jwt = await fixture.mint({ email: "alice@example.com" });
+  const me = await SELF.fetch("https://api.local/api/me", {
+    headers: { "CF-Access-Jwt-Assertion": jwt },
+  });
+  const meBody = (await me.json()) as {
+    data: { user: { id: string }; workspace: { id: string } };
+  };
+  const create = await SELF.fetch(
+    `https://api.local/api/workspaces/${meBody.data.workspace.id}/rooms`,
+    {
+      method: "POST",
+      headers: {
+        "CF-Access-Jwt-Assertion": jwt,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ slug: "general", name: "General" }),
+    },
+  );
+  const room = (await create.json()) as { data: { room: { id: string } } };
+  return { jwt, userId: meBody.data.user.id, roomId: room.data.room.id };
+}
+
+async function seedMessage(roomId: string, userId: string, body: string): Promise<string> {
+  const mid = id();
+  // UUIDv7 is monotonic enough for our ordering checks; tiny await to ensure
+  // separate millisecond ticks across calls.
+  await new Promise((r) => setTimeout(r, 2));
+  await env.DB.prepare("INSERT INTO messages (id, room_id, user_id, body) VALUES (?, ?, ?, ?)")
+    .bind(mid, roomId, userId, body)
+    .run();
+  return mid;
+}
+
+describe("GET /api/rooms/:rid/messages", () => {
+  it("returns 200 with messages oldest-first for a member", async () => {
+    const { jwt, userId, roomId } = await bootstrapAliceRoom();
+    await seedMessage(roomId, userId, "first");
+    await seedMessage(roomId, userId, "second");
+    await seedMessage(roomId, userId, "third");
+
+    const res = await SELF.fetch(`https://api.local/api/rooms/${roomId}/messages?limit=10`, {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      data: { messages: { body: string }[]; hasMore: boolean };
+    };
+    expect(body.data.messages.map((m) => m.body)).toEqual(["first", "second", "third"]);
+    expect(body.data.hasMore).toBe(false);
+  });
+
+  it("403 for non-member; 404 for unknown room", async () => {
+    const alice = await bootstrapAliceRoom();
+    const bobJwt = await fixture.mint({ email: "bob@example.com" });
+    await SELF.fetch("https://api.local/api/me", {
+      headers: { "CF-Access-Jwt-Assertion": bobJwt },
+    });
+    const nonMember = await SELF.fetch(`https://api.local/api/rooms/${alice.roomId}/messages`, {
+      headers: { "CF-Access-Jwt-Assertion": bobJwt },
+    });
+    expect(nonMember.status).toBe(403);
+
+    const bogus = "0190b0a4-7b2e-7eee-8aaa-aaaaaaaaaaaa";
+    const unknown = await SELF.fetch(`https://api.local/api/rooms/${bogus}/messages`, {
+      headers: { "CF-Access-Jwt-Assertion": alice.jwt },
+    });
+    expect(unknown.status).toBe(404);
+  });
+
+  it("paginates via `before` cursor and reports hasMore", async () => {
+    const { jwt, userId, roomId } = await bootstrapAliceRoom();
+    const ids: string[] = [];
+    for (let i = 0; i < 5; i++) {
+      ids.push(await seedMessage(roomId, userId, `m${i}`));
+    }
+
+    // First page: limit=2 → newest 2 messages, hasMore=true.
+    const page1 = await SELF.fetch(`https://api.local/api/rooms/${roomId}/messages?limit=2`, {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    const body1 = (await page1.json()) as {
+      data: { messages: { id: string; body: string }[]; hasMore: boolean };
+    };
+    expect(body1.data.messages.map((m) => m.body)).toEqual(["m3", "m4"]);
+    expect(body1.data.hasMore).toBe(true);
+
+    // Second page: before=oldest-from-page1, limit=2 → next 2 older.
+    const oldestFromPage1 = body1.data.messages[0]?.id;
+    const page2 = await SELF.fetch(
+      `https://api.local/api/rooms/${roomId}/messages?limit=2&before=${oldestFromPage1}`,
+      { headers: { "CF-Access-Jwt-Assertion": jwt } },
+    );
+    const body2 = (await page2.json()) as {
+      data: { messages: { body: string }[]; hasMore: boolean };
+    };
+    expect(body2.data.messages.map((m) => m.body)).toEqual(["m1", "m2"]);
+    expect(body2.data.hasMore).toBe(true);
+  });
+
+  it("clamps limit to MAX_LIMIT (200) and rejects bad limit", async () => {
+    const { jwt, roomId } = await bootstrapAliceRoom();
+
+    const huge = await SELF.fetch(`https://api.local/api/rooms/${roomId}/messages?limit=99999`, {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(huge.status).toBe(200);
+
+    const bad = await SELF.fetch(`https://api.local/api/rooms/${roomId}/messages?limit=oops`, {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    expect(bad.status).toBe(400);
+    const badBody = (await bad.json()) as { error: { code: string } };
+    expect(badBody.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("blanks body for tombstoned (soft-deleted) messages", async () => {
+    const { jwt, userId, roomId } = await bootstrapAliceRoom();
+    const mid = await seedMessage(roomId, userId, "secrets");
+    await env.DB.prepare("UPDATE messages SET deleted_at = unixepoch() WHERE id = ?")
+      .bind(mid)
+      .run();
+
+    const res = await SELF.fetch(`https://api.local/api/rooms/${roomId}/messages`, {
+      headers: { "CF-Access-Jwt-Assertion": jwt },
+    });
+    const body = (await res.json()) as {
+      data: { messages: { body: string; deleted_at: number | null }[] };
+    };
+    expect(body.data.messages[0]?.body).toBe("");
+    expect(body.data.messages[0]?.deleted_at).not.toBeNull();
+  });
+});

--- a/apps/worker/src/__tests__/rate-limit.test.ts
+++ b/apps/worker/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { RollingWindowLimiter } from "../lib/rate-limit.js";
+
+describe("RollingWindowLimiter", () => {
+  it("permits up to `limit` hits in a window then rejects", () => {
+    const lim = new RollingWindowLimiter(3, 1000);
+    expect(lim.tryAcquire(0)).toBe(true);
+    expect(lim.tryAcquire(100)).toBe(true);
+    expect(lim.tryAcquire(200)).toBe(true);
+    expect(lim.tryAcquire(300)).toBe(false);
+  });
+
+  it("recovers capacity once old hits fall outside the window", () => {
+    const lim = new RollingWindowLimiter(2, 1000);
+    expect(lim.tryAcquire(0)).toBe(true);
+    expect(lim.tryAcquire(500)).toBe(true);
+    expect(lim.tryAcquire(900)).toBe(false);
+    // First hit (t=0) is now outside the window from t=1100.
+    expect(lim.tryAcquire(1100)).toBe(true);
+  });
+
+  it("does not consume capacity on a rejected call", () => {
+    const lim = new RollingWindowLimiter(1, 1000);
+    expect(lim.tryAcquire(0)).toBe(true);
+    expect(lim.tryAcquire(100)).toBe(false);
+    expect(lim.tryAcquire(200)).toBe(false);
+    expect(lim.size()).toBe(1);
+  });
+});

--- a/apps/worker/src/__tests__/ws-mirror.test.ts
+++ b/apps/worker/src/__tests__/ws-mirror.test.ts
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// D1 mirror tests for the ChatRoom DO write-through path. The DO is the
+// source of truth for the live state; `messages` in D1 is the queryable
+// mirror that ingest, scrollback, and the daily-log cron rely on.
+
+import { SELF, env } from "cloudflare:test";
+import { PROTOCOL_VERSION } from "@loomwiki/shared";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+import { type WsSession, openWs } from "./__fixtures__/ws.js";
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+const sessions: WsSession[] = [];
+afterEach(() => {
+  while (sessions.length > 0) {
+    sessions.pop()?.close();
+  }
+});
+
+async function bootstrap(slug: string): Promise<{ jwt: string; roomId: string; userId: string }> {
+  const jwt = await fixture.mint({ email: "alice@example.com" });
+  const me = await SELF.fetch("https://api.local/api/me", {
+    headers: { "CF-Access-Jwt-Assertion": jwt },
+  });
+  const meBody = (await me.json()) as {
+    data: { user: { id: string }; workspace: { id: string } };
+  };
+  const create = await SELF.fetch(
+    `https://api.local/api/workspaces/${meBody.data.workspace.id}/rooms`,
+    {
+      method: "POST",
+      headers: {
+        "CF-Access-Jwt-Assertion": jwt,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ slug, name: slug }),
+    },
+  );
+  const room = (await create.json()) as { data: { room: { id: string } } };
+  return { jwt, roomId: room.data.room.id, userId: meBody.data.user.id };
+}
+
+async function readMessageFromD1(messageId: string): Promise<{ body: string } | null> {
+  const row = await env.DB.prepare("SELECT body FROM messages WHERE id = ?")
+    .bind(messageId)
+    .first<{ body: string }>();
+  return row;
+}
+
+async function waitFor<T>(fn: () => Promise<T | null>, timeoutMs = 1500): Promise<T> {
+  const deadline = Date.now() + timeoutMs;
+  // Tight poll — vitest-pool-workers' D1 is in-process, so 25ms is plenty.
+  while (Date.now() < deadline) {
+    const v = await fn();
+    if (v !== null) return v;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}
+
+describe("ChatRoom → D1 mirror", () => {
+  it("a sent message is visible in D1 `messages` within 1 second", async () => {
+    const { jwt, roomId } = await bootstrap("general");
+    const ws = sessions[sessions.push(await openWs(roomId, jwt)) - 1];
+    if (!ws) throw new Error("session push failed");
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws.next();
+
+    ws.send({ kind: "send", tempId: "m1", body: "mirrored?" });
+    const ack = await ws.next();
+    if (ack.kind !== "ack") throw new Error("expected ack");
+
+    const row = await waitFor(() => readMessageFromD1(ack.messageId), 1500);
+    expect(row.body).toBe("mirrored?");
+  });
+
+  it("an edited message updates the D1 row body", async () => {
+    const { jwt, roomId } = await bootstrap("general");
+    const ws = sessions[sessions.push(await openWs(roomId, jwt)) - 1];
+    if (!ws) throw new Error("session push failed");
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws.next();
+
+    ws.send({ kind: "send", tempId: "m1", body: "v1" });
+    const ack = await ws.next();
+    if (ack.kind !== "ack") throw new Error("expected ack");
+    await waitFor(() => readMessageFromD1(ack.messageId));
+
+    ws.send({ kind: "edit", messageId: ack.messageId, body: "v2" });
+    await ws.next(); // consume the edited broadcast
+
+    const row = await waitFor(async () => {
+      const r = await readMessageFromD1(ack.messageId);
+      return r && r.body === "v2" ? r : null;
+    }, 1500);
+    expect(row.body).toBe("v2");
+  });
+
+  it("a deleted message updates D1 deleted_at", async () => {
+    const { jwt, roomId } = await bootstrap("general");
+    const ws = sessions[sessions.push(await openWs(roomId, jwt)) - 1];
+    if (!ws) throw new Error("session push failed");
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws.next();
+
+    ws.send({ kind: "send", tempId: "m1", body: "doomed" });
+    const ack = await ws.next();
+    if (ack.kind !== "ack") throw new Error("expected ack");
+    await waitFor(() => readMessageFromD1(ack.messageId));
+
+    ws.send({ kind: "delete", messageId: ack.messageId });
+    await ws.next();
+
+    await waitFor(async () => {
+      const r = await env.DB.prepare("SELECT deleted_at FROM messages WHERE id = ?")
+        .bind(ack.messageId)
+        .first<{ deleted_at: number | null }>();
+      return r && r.deleted_at !== null ? r : null;
+    }, 1500);
+  });
+});

--- a/apps/worker/src/do/ChatRoom.ts
+++ b/apps/worker/src/do/ChatRoom.ts
@@ -1,20 +1,461 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// Stub ChatRoom Durable Object. Real implementation lands in M2 (SPEC §9).
-// Declared here so the binding in wrangler.jsonc is satisfied in M0 — the spec
-// (CLAUDE.md) requires all bindings be declared up front to prevent schema drift.
+// ChatRoom Durable Object — one instance per room. SPEC §9.
+//
+// Uses the **WebSocket Hibernation API**: between message bursts the JS
+// isolate is unloaded and idle rooms cost zero GB-s. Identity for an open
+// socket survives via `ws.serializeAttachment(...)`; per-room SQLite state
+// survives via `ctx.storage.sql`.
+//
+// References:
+//   - https://developers.cloudflare.com/durable-objects/best-practices/websockets/
+//   - cloudflare/workers-chat-demo (canonical hibernation pattern)
+//
+// Critical invariants:
+//   1. Never the legacy `ws.addEventListener` API. The four overrides
+//      (`fetch`, `webSocketMessage`, `webSocketClose`, `webSocketError`)
+//      are class methods, called by the runtime on traffic.
+//   2. Never iterate a `Map<userId, ws>` instance field — it dies at
+//      hibernation. Use `ctx.getWebSockets()`.
+//   3. The `send` path wraps insert + ack-send in
+//      `ctx.blockConcurrencyWhile(...)` so a checkpoint between durable
+//      write and acknowledgement is impossible (SPEC §9 acceptance
+//      criterion: "killing the DO mid-write does not lose acknowledged
+//      messages").
 
 import { DurableObject } from "cloudflare:workers";
+import {
+  type ClientMsg,
+  ClientMsgSchema,
+  ErrorCodes,
+  MAX_BODY_CHARS,
+  PROTOCOL_VERSION,
+  type ServerMsg,
+  type WireMessage,
+  id,
+} from "@loomwiki/shared";
 import type { Env } from "../env.js";
+import { type MirrorMessage, mirrorMessageToD1 } from "../lib/d1-mirror.js";
+import { RollingWindowLimiter } from "../lib/rate-limit.js";
+import {
+  appendMessage,
+  applyDelete,
+  applyEdit,
+  clearPendingMirror,
+  getMessageById,
+  getPendingMirrorRows,
+  getRecent,
+  getRecentSince,
+  getRoomId,
+  hasPendingMirror,
+  initStorage,
+  markPendingMirror,
+  setRoomId,
+} from "./storage.js";
+
+// SPEC §9 caps.
+const RATE_LIMIT_WINDOW_MS = 1000;
+const RATE_LIMIT_PER_WINDOW = 100;
+// Reconnect-resume payload cap (SPEC §9 prompt: "capped at 200 to bound
+// payload"). Fresh connects (no `sinceMessageId`) get the most recent 50.
+const WELCOME_MAX_RESUME = 200;
+const WELCOME_DEFAULT_RECENT = 50;
+// Mirror reconciliation: if any rows are pending, schedule an alarm 60s out
+// to retry. Cleared once the queue drains.
+const MIRROR_RETRY_ALARM_MS = 60_000;
+// Per-alarm batch cap — a long mirror outage can't queue an unbounded retry.
+const MIRROR_RETRY_BATCH = 100;
+
+/** Per-WS attachment shape. Survives hibernation. */
+interface WsAttachment {
+  userId: string;
+  roomId: string;
+  /**
+   * Last server messageId delivered to this socket. We don't need it for
+   * correctness (reconnect via `sinceMessageId` is the resume mechanism),
+   * but having it persists "this client has seen up to here" across
+   * hibernation in case future surfaces (presence, read receipts) need it.
+   */
+  lastSeenId?: string;
+}
+
+function readAttachment(ws: WebSocket): WsAttachment | null {
+  const raw = ws.deserializeAttachment();
+  if (raw && typeof raw === "object" && "userId" in raw && "roomId" in raw) {
+    return raw as WsAttachment;
+  }
+  return null;
+}
+
+function sendServer(ws: WebSocket, msg: ServerMsg): void {
+  try {
+    ws.send(JSON.stringify(msg));
+  } catch {
+    // Socket closed mid-send; the runtime fires webSocketClose shortly.
+  }
+}
+
+function sendError(ws: WebSocket, code: string, message: string, tempId?: string): void {
+  const env: ServerMsg =
+    tempId !== undefined
+      ? { kind: "error", code, message, tempId }
+      : { kind: "error", code, message };
+  sendServer(ws, env);
+}
 
 export class ChatRoom extends DurableObject<Env> {
-  override fetch(_request: Request): Response {
-    return new Response(
-      JSON.stringify({
-        ok: false,
-        error: { code: "not_implemented", message: "ChatRoom DO arrives in M2" },
-      }),
-      { status: 501, headers: { "content-type": "application/json" } },
-    );
+  private readonly sql: SqlStorage;
+  private readonly limiter: RollingWindowLimiter;
+
+  constructor(ctx: DurableObjectState, env: Env) {
+    super(ctx, env);
+    this.sql = ctx.storage.sql;
+    initStorage(this.sql);
+    this.limiter = new RollingWindowLimiter(RATE_LIMIT_PER_WINDOW, RATE_LIMIT_WINDOW_MS);
+  }
+
+  override async fetch(request: Request): Promise<Response> {
+    if (request.headers.get("Upgrade") !== "websocket") {
+      return new Response("expected upgrade", { status: 426 });
+    }
+
+    const userId = request.headers.get("x-loomwiki-user-id");
+    const roomId = request.headers.get("x-loomwiki-room-id");
+    if (!userId || !roomId) {
+      // The route layer in apps/worker/src/routes/rooms.ts is responsible
+      // for setting these. If they're missing, the upgrade was forged or
+      // the route layer regressed — fail closed.
+      return new Response("missing identity headers", { status: 400 });
+    }
+
+    // Persist roomId so the alarm path (mirror retry) can recover it even
+    // when zero sockets are open.
+    setRoomId(this.sql, roomId);
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+
+    // Hibernation API: the runtime owns the lifecycle from here. Class
+    // methods (`webSocketMessage`/`webSocketClose`/`webSocketError`) handle
+    // incoming traffic without keeping the isolate warm.
+    this.ctx.acceptWebSocket(server);
+
+    const attachment: WsAttachment = { userId, roomId };
+    server.serializeAttachment(attachment);
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  override async webSocketMessage(ws: WebSocket, raw: ArrayBuffer | string): Promise<void> {
+    const attachment = readAttachment(ws);
+    if (!attachment) {
+      sendError(ws, ErrorCodes.AUTH_REQUIRED, "session lost; reconnect");
+      ws.close(1011, "session lost");
+      return;
+    }
+
+    let parsed: ClientMsg;
+    try {
+      const text = typeof raw === "string" ? raw : new TextDecoder().decode(raw);
+      const json: unknown = JSON.parse(text);
+      const result = ClientMsgSchema.safeParse(json);
+      if (!result.success) {
+        sendError(ws, ErrorCodes.VALIDATION_FAILED, "invalid envelope");
+        return;
+      }
+      parsed = result.data;
+    } catch {
+      sendError(ws, ErrorCodes.VALIDATION_FAILED, "malformed JSON");
+      return;
+    }
+
+    switch (parsed.kind) {
+      case "hello":
+        await this.handleHello(ws, attachment, parsed.sinceMessageId);
+        return;
+      case "ping":
+        sendServer(ws, { kind: "pong" });
+        return;
+      case "send":
+        await this.handleSend(ws, attachment, parsed);
+        return;
+      case "edit":
+        await this.handleEdit(ws, attachment, parsed.messageId, parsed.body);
+        return;
+      case "delete":
+        await this.handleDelete(ws, attachment, parsed.messageId);
+        return;
+    }
+  }
+
+  override webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): void {
+    // Hibernation does not require explicit cleanup — the runtime drops the
+    // socket. We still call close() to finalize the close handshake when
+    // the peer initiated.
+    try {
+      ws.close();
+    } catch {
+      // Already closed.
+    }
+  }
+
+  override webSocketError(ws: WebSocket, error: unknown): void {
+    console.warn("[chatroom] websocket error", { error: String(error) });
+    try {
+      ws.close(1011, "internal error");
+    } catch {
+      // Already closed.
+    }
+  }
+
+  override async alarm(): Promise<void> {
+    await this.flushPendingMirror();
+    if (hasPendingMirror(this.sql)) {
+      await this.ctx.storage.setAlarm(Date.now() + MIRROR_RETRY_ALARM_MS);
+    }
+  }
+
+  // ---------- handlers ----------
+
+  private async handleHello(
+    ws: WebSocket,
+    attachment: WsAttachment,
+    sinceMessageId: string | undefined,
+  ): Promise<void> {
+    const recentMessages =
+      sinceMessageId !== undefined
+        ? getRecentSince(this.sql, attachment.roomId, sinceMessageId, WELCOME_MAX_RESUME)
+        : getRecent(this.sql, attachment.roomId, WELCOME_DEFAULT_RECENT);
+
+    sendServer(ws, {
+      kind: "welcome",
+      protocolVersion: PROTOCOL_VERSION,
+      roomId: attachment.roomId,
+      recentMessages,
+    });
+
+    if (recentMessages.length > 0) {
+      const last = recentMessages[recentMessages.length - 1];
+      if (last) {
+        const next: WsAttachment = { ...attachment, lastSeenId: last.id };
+        ws.serializeAttachment(next);
+      }
+    }
+  }
+
+  private async handleSend(
+    ws: WebSocket,
+    attachment: WsAttachment,
+    env: { tempId: string; body: string; parentId?: string },
+  ): Promise<void> {
+    if (env.body.length > MAX_BODY_CHARS) {
+      sendError(ws, ErrorCodes.VALIDATION_FAILED, "body exceeds 4096 chars", env.tempId);
+      return;
+    }
+    if (!this.limiter.tryAcquire(Date.now())) {
+      sendError(ws, ErrorCodes.RATE_LIMITED, "100 msg/sec/room cap reached", env.tempId);
+      return;
+    }
+
+    const messageId = id();
+    const createdAt = Math.floor(Date.now() / 1000);
+    const parentId = env.parentId ?? null;
+
+    let wireMessage: WireMessage | null = null;
+
+    // Insert + ack must be atomic. blockConcurrencyWhile prevents a
+    // checkpoint from landing between durable write and ack — SPEC §9
+    // acceptance criterion ("crashing the DO mid-write does not lose
+    // acknowledged messages").
+    await this.ctx.blockConcurrencyWhile(async () => {
+      appendMessage(this.sql, {
+        id: messageId,
+        userId: attachment.userId,
+        body: env.body,
+        parentId,
+        createdAt,
+        pendingMirror: true,
+      });
+      sendServer(ws, { kind: "ack", tempId: env.tempId, messageId });
+      wireMessage = {
+        id: messageId,
+        room_id: attachment.roomId,
+        user_id: attachment.userId,
+        body: env.body,
+        parent_id: parentId,
+        created_at: createdAt,
+        edited_at: null,
+        deleted_at: null,
+      };
+    });
+
+    if (!wireMessage) return;
+
+    this.broadcastExcept(ws, { kind: "message", message: wireMessage });
+
+    // D1 mirror: best-effort, off the ack critical path.
+    this.scheduleMirror({
+      id: messageId,
+      roomId: attachment.roomId,
+      userId: attachment.userId,
+      body: env.body,
+      parentId,
+      createdAt,
+      editedAt: null,
+      deletedAt: null,
+    });
+  }
+
+  private async handleEdit(
+    ws: WebSocket,
+    attachment: WsAttachment,
+    messageId: string,
+    newBody: string,
+  ): Promise<void> {
+    if (newBody.length > MAX_BODY_CHARS) {
+      sendError(ws, ErrorCodes.VALIDATION_FAILED, "body exceeds 4096 chars");
+      return;
+    }
+    const existing = getMessageById(this.sql, attachment.roomId, messageId);
+    if (!existing) {
+      sendError(ws, ErrorCodes.NOT_FOUND, "message not found");
+      return;
+    }
+    if (existing.user_id !== attachment.userId) {
+      sendError(ws, ErrorCodes.FORBIDDEN, "not message author");
+      return;
+    }
+    if (existing.deleted_at !== null) {
+      // Editing a tombstone is meaningless and would cause body to leak past
+      // the rowToWire blanking.
+      sendError(ws, ErrorCodes.CONFLICT, "message is deleted");
+      return;
+    }
+
+    const editedAt = Math.floor(Date.now() / 1000);
+    applyEdit(this.sql, messageId, newBody, editedAt);
+
+    const broadcast: ServerMsg = {
+      kind: "edited",
+      messageId,
+      body: newBody,
+      editedAt,
+    };
+    sendServer(ws, broadcast);
+    this.broadcastExcept(ws, broadcast);
+
+    this.scheduleMirror({
+      id: messageId,
+      roomId: attachment.roomId,
+      userId: existing.user_id,
+      body: newBody,
+      parentId: existing.parent_id,
+      createdAt: existing.created_at,
+      editedAt,
+      deletedAt: null,
+    });
+  }
+
+  private async handleDelete(
+    ws: WebSocket,
+    attachment: WsAttachment,
+    messageId: string,
+  ): Promise<void> {
+    const existing = getMessageById(this.sql, attachment.roomId, messageId);
+    if (!existing) {
+      sendError(ws, ErrorCodes.NOT_FOUND, "message not found");
+      return;
+    }
+    if (existing.user_id !== attachment.userId) {
+      sendError(ws, ErrorCodes.FORBIDDEN, "not message author");
+      return;
+    }
+    if (existing.deleted_at !== null) return; // idempotent
+
+    const deletedAt = Math.floor(Date.now() / 1000);
+    applyDelete(this.sql, messageId, deletedAt);
+
+    const broadcast: ServerMsg = { kind: "deleted", messageId, deletedAt };
+    sendServer(ws, broadcast);
+    this.broadcastExcept(ws, broadcast);
+
+    this.scheduleMirror({
+      id: messageId,
+      roomId: attachment.roomId,
+      userId: existing.user_id,
+      // Body intentionally retained in D1 alongside deleted_at so a future
+      // GDPR-style "hard erase" path can scrub deliberately. The on-wire
+      // shape blanks it via rowToWire.
+      body: existing.body,
+      parentId: existing.parent_id,
+      createdAt: existing.created_at,
+      editedAt: existing.edited_at,
+      deletedAt,
+    });
+  }
+
+  // ---------- broadcast / mirror plumbing ----------
+
+  private broadcastExcept(except: WebSocket, msg: ServerMsg): void {
+    const payload = JSON.stringify(msg);
+    for (const ws of this.ctx.getWebSockets()) {
+      if (ws === except) continue;
+      try {
+        ws.send(payload);
+      } catch {
+        // Drop and let webSocketClose run.
+      }
+    }
+  }
+
+  private scheduleMirror(msg: MirrorMessage): void {
+    this.ctx.waitUntil(this.tryMirror(msg));
+  }
+
+  private async tryMirror(msg: MirrorMessage): Promise<void> {
+    try {
+      await mirrorMessageToD1(this.env, msg);
+      clearPendingMirror(this.sql, msg.id);
+    } catch (err) {
+      console.warn("[chatroom] mirror failed", { id: msg.id, err: String(err) });
+      markPendingMirror(this.sql, msg.id);
+      await this.ensureRetryAlarm();
+    }
+  }
+
+  private async ensureRetryAlarm(): Promise<void> {
+    const current = await this.ctx.storage.getAlarm();
+    if (current === null) {
+      await this.ctx.storage.setAlarm(Date.now() + MIRROR_RETRY_ALARM_MS);
+    }
+  }
+
+  private async flushPendingMirror(): Promise<void> {
+    const roomId = getRoomId(this.sql);
+    if (!roomId) {
+      // Nothing has ever been written to this DO yet — nothing to mirror.
+      return;
+    }
+    const pending = getPendingMirrorRows(this.sql, MIRROR_RETRY_BATCH);
+    for (const row of pending) {
+      try {
+        await mirrorMessageToD1(this.env, {
+          id: row.id,
+          roomId,
+          userId: row.user_id,
+          body: row.body,
+          parentId: row.parent_id,
+          createdAt: row.created_at,
+          editedAt: row.edited_at,
+          deletedAt: row.deleted_at,
+        });
+        clearPendingMirror(this.sql, row.id);
+      } catch (err) {
+        console.warn("[chatroom] alarm mirror retry failed", { id: row.id, err: String(err) });
+        // Leave pending_mirror=1; next alarm will retry.
+        return;
+      }
+    }
   }
 }

--- a/apps/worker/src/do/storage.ts
+++ b/apps/worker/src/do/storage.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// DO SQLite schema and helpers for ChatRoom (SPEC §9).
+//
+// `messages_local` is the room's hot path; D1 `messages` is the queryable
+// mirror written through-but-asynchronously. The two diverge only briefly
+// when D1 is having a bad minute — `pending_mirror=1` rows reconcile on the
+// next message or via the alarm in ChatRoom.ts.
+//
+// `parent_id` is declared for schema parity with D1 / SPEC §7.1, but
+// threading is not exposed on the WS surface in M2 (SPEC §17 — out of scope).
+//
+// All `sql.exec(...)` calls below use the Cloudflare DO SqlStorage API
+// (parameterized statements, NOT a shell). The string-template lookalike
+// is unrelated to OS-level command execution.
+
+import type { WireMessage } from "@loomwiki/shared";
+
+const SCHEMA = `
+  CREATE TABLE IF NOT EXISTS messages_local (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL,
+    body            TEXT NOT NULL,
+    parent_id       TEXT,
+    created_at      INTEGER NOT NULL,
+    edited_at       INTEGER,
+    deleted_at      INTEGER,
+    pending_mirror  INTEGER NOT NULL DEFAULT 0
+  );
+  CREATE INDEX IF NOT EXISTS idx_messages_local_created
+    ON messages_local(created_at);
+  CREATE INDEX IF NOT EXISTS idx_messages_local_pending
+    ON messages_local(pending_mirror) WHERE pending_mirror = 1;
+  CREATE TABLE IF NOT EXISTS room_meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
+`;
+
+// Must satisfy `Record<string, SqlStorageValue>` so it can flow through
+// `sql.exec<LocalRow>(...)`. SqlStorageValue covers `string | number |
+// ArrayBuffer | Uint8Array | null`, which subsumes every column we project.
+type LocalRow = {
+  id: string;
+  user_id: string;
+  body: string;
+  parent_id: string | null;
+  created_at: number;
+  edited_at: number | null;
+  deleted_at: number | null;
+  pending_mirror: number;
+} & Record<string, SqlStorageValue>;
+
+/** Idempotent — call from the DO constructor on every wake. */
+export function initStorage(sql: SqlStorage): void {
+  sql.exec(SCHEMA);
+}
+
+/** Persist roomId so the alarm path can recover it without an open socket. */
+export function setRoomId(sql: SqlStorage, roomId: string): void {
+  sql.exec(
+    "INSERT INTO room_meta (key, value) VALUES ('room_id', ?) ON CONFLICT(key) DO NOTHING",
+    roomId,
+  );
+}
+
+export function getRoomId(sql: SqlStorage): string | null {
+  const cursor = sql.exec<{ value: string }>("SELECT value FROM room_meta WHERE key = 'room_id'");
+  for (const row of cursor) return row.value;
+  return null;
+}
+
+function rowToWire(row: LocalRow, roomId: string): WireMessage {
+  return {
+    id: row.id,
+    room_id: roomId,
+    user_id: row.user_id,
+    body: row.deleted_at !== null ? "" : row.body,
+    parent_id: row.parent_id,
+    created_at: row.created_at,
+    edited_at: row.edited_at,
+    deleted_at: row.deleted_at,
+  };
+}
+
+export interface AppendArgs {
+  id: string;
+  userId: string;
+  body: string;
+  parentId: string | null;
+  createdAt: number;
+  pendingMirror: boolean;
+}
+
+export function appendMessage(sql: SqlStorage, args: AppendArgs): void {
+  sql.exec(
+    `INSERT INTO messages_local
+       (id, user_id, body, parent_id, created_at, pending_mirror)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+    args.id,
+    args.userId,
+    args.body,
+    args.parentId,
+    args.createdAt,
+    args.pendingMirror ? 1 : 0,
+  );
+}
+
+export function getMessageById(
+  sql: SqlStorage,
+  roomId: string,
+  messageId: string,
+): WireMessage | null {
+  const cursor = sql.exec<LocalRow>("SELECT * FROM messages_local WHERE id = ?", messageId);
+  for (const row of cursor) return rowToWire(row, roomId);
+  return null;
+}
+
+/**
+ * Most-recent N messages, oldest first. Used when a fresh client (no
+ * `sinceMessageId`) connects — the welcome shows the recent backlog.
+ */
+export function getRecent(sql: SqlStorage, roomId: string, limit: number): WireMessage[] {
+  const cursor = sql.exec<LocalRow>("SELECT * FROM messages_local ORDER BY id DESC LIMIT ?", limit);
+  const rows: WireMessage[] = [];
+  for (const row of cursor) rows.push(rowToWire(row, roomId));
+  rows.reverse();
+  return rows;
+}
+
+/**
+ * Messages strictly after `sinceMessageId`. UUIDv7's lexicographic-time-order
+ * makes the cursor work without consulting `created_at`.
+ */
+export function getRecentSince(
+  sql: SqlStorage,
+  roomId: string,
+  sinceMessageId: string,
+  limit: number,
+): WireMessage[] {
+  const cursor = sql.exec<LocalRow>(
+    "SELECT * FROM messages_local WHERE id > ? ORDER BY id ASC LIMIT ?",
+    sinceMessageId,
+    limit,
+  );
+  const rows: WireMessage[] = [];
+  for (const row of cursor) rows.push(rowToWire(row, roomId));
+  return rows;
+}
+
+export function applyEdit(
+  sql: SqlStorage,
+  messageId: string,
+  newBody: string,
+  editedAt: number,
+): void {
+  sql.exec(
+    "UPDATE messages_local SET body = ?, edited_at = ?, pending_mirror = 1 WHERE id = ?",
+    newBody,
+    editedAt,
+    messageId,
+  );
+}
+
+export function applyDelete(sql: SqlStorage, messageId: string, deletedAt: number): void {
+  sql.exec(
+    "UPDATE messages_local SET deleted_at = ?, pending_mirror = 1 WHERE id = ?",
+    deletedAt,
+    messageId,
+  );
+}
+
+export function markPendingMirror(sql: SqlStorage, messageId: string): void {
+  sql.exec("UPDATE messages_local SET pending_mirror = 1 WHERE id = ?", messageId);
+}
+
+export function clearPendingMirror(sql: SqlStorage, messageId: string): void {
+  sql.exec("UPDATE messages_local SET pending_mirror = 0 WHERE id = ?", messageId);
+}
+
+export interface PendingRow {
+  id: string;
+  user_id: string;
+  body: string;
+  parent_id: string | null;
+  created_at: number;
+  edited_at: number | null;
+  deleted_at: number | null;
+}
+
+export function getPendingMirrorRows(sql: SqlStorage, limit: number): PendingRow[] {
+  const cursor = sql.exec<LocalRow>(
+    "SELECT * FROM messages_local WHERE pending_mirror = 1 ORDER BY id ASC LIMIT ?",
+    limit,
+  );
+  const rows: PendingRow[] = [];
+  for (const row of cursor) {
+    rows.push({
+      id: row.id,
+      user_id: row.user_id,
+      body: row.body,
+      parent_id: row.parent_id,
+      created_at: row.created_at,
+      edited_at: row.edited_at,
+      deleted_at: row.deleted_at,
+    });
+  }
+  return rows;
+}
+
+export function hasPendingMirror(sql: SqlStorage): boolean {
+  const cursor = sql.exec<{ c: number }>(
+    "SELECT COUNT(*) AS c FROM messages_local WHERE pending_mirror = 1",
+  );
+  for (const row of cursor) return row.c > 0;
+  return false;
+}

--- a/apps/worker/src/lib/d1-mirror.ts
+++ b/apps/worker/src/lib/d1-mirror.ts
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Write-through mirror from ChatRoom DO SQLite → D1 `messages` table.
+//
+// Idempotent on `id` so the same row can be re-mirrored after a transient
+// failure without producing a duplicate or overwriting an authoritative
+// edit. The DO is the source of truth for the live state; D1 is the
+// queryable store consulted by the historical-scrollback route, ingest
+// agent, and (in M5) the daily-log cron.
+
+import type { Env } from "../env.js";
+
+export interface MirrorMessage {
+  id: string;
+  roomId: string;
+  userId: string;
+  body: string;
+  parentId: string | null;
+  createdAt: number;
+  editedAt: number | null;
+  deletedAt: number | null;
+}
+
+/**
+ * Insert-or-update. We `INSERT … ON CONFLICT(id) DO UPDATE` because edits
+ * and deletes also flow through here — the write-through path is symmetric
+ * for create / edit / delete.
+ *
+ * Throws on D1 error so the caller can flip `pending_mirror=1` and retry.
+ */
+export async function mirrorMessageToD1(env: Env, msg: MirrorMessage): Promise<void> {
+  await env.DB.prepare(
+    `INSERT INTO messages
+       (id, room_id, user_id, body, parent_id, created_at, edited_at, deleted_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       body       = excluded.body,
+       edited_at  = excluded.edited_at,
+       deleted_at = excluded.deleted_at`,
+  )
+    .bind(
+      msg.id,
+      msg.roomId,
+      msg.userId,
+      msg.body,
+      msg.parentId,
+      msg.createdAt,
+      msg.editedAt,
+      msg.deletedAt,
+    )
+    .run();
+}

--- a/apps/worker/src/lib/rate-limit.ts
+++ b/apps/worker/src/lib/rate-limit.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Rolling 1-second window rate limiter for ChatRoom (SPEC §9: 100 msg/sec
+// per room). Lives in DO instance memory only — hibernation drops the
+// window, which is the desired behavior (a freshly-woken room cannot have
+// been over the limit a millisecond ago).
+
+export class RollingWindowLimiter {
+  private readonly windowMs: number;
+  private readonly limit: number;
+  private readonly hits: number[] = [];
+
+  constructor(limit: number, windowMs: number) {
+    this.limit = limit;
+    this.windowMs = windowMs;
+  }
+
+  /**
+   * Records a hit at `now` (millis) and returns whether it is permitted.
+   * Side-effecting: the hit is recorded only if it is permitted, so a
+   * rejected call does not consume capacity.
+   */
+  tryAcquire(now: number): boolean {
+    const cutoff = now - this.windowMs;
+    while (this.hits.length > 0) {
+      const head = this.hits[0];
+      if (head !== undefined && head <= cutoff) this.hits.shift();
+      else break;
+    }
+    if (this.hits.length >= this.limit) return false;
+    this.hits.push(now);
+    return true;
+  }
+
+  /** Test seam — number of hits currently inside the window. */
+  size(): number {
+    return this.hits.length;
+  }
+}

--- a/apps/worker/src/routes/rooms.ts
+++ b/apps/worker/src/routes/rooms.ts
@@ -1,34 +1,153 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { parseRoomRow } from "@loomwiki/schema/parsers";
-import { ErrorCodes, LoomwikiError, apiOk } from "@loomwiki/shared";
+// Room-scoped routes:
+//
+//   GET  /:rid             — room metadata (M1)
+//   GET  /:rid/messages    — historical scrollback from D1 (M2)
+//   GET  /:rid/ws          — WebSocket upgrade → ChatRoom DO (M2)
+//
+// Auth + membership are verified once per request here. The DO trusts the
+// upgrade because the route layer has already validated `workspace_id`,
+// room existence, and room_members. Any caller that wants to forge identity
+// must defeat the Hono auth middleware first.
+
+import { type Message, parseMessageRow, parseRoomRow } from "@loomwiki/schema/parsers";
+import { ErrorCodes, LoomwikiError, type WireMessage, apiOk } from "@loomwiki/shared";
 import { Hono } from "hono";
+import type { Env } from "../env.js";
 import { serializeRoom } from "../lib/serialize.js";
 import type { AuthEnv } from "../middleware/auth.js";
 
-export const roomsRoute = new Hono<AuthEnv>().get("/:rid", async (c) => {
-  const rid = c.req.param("rid");
+const HISTORY_DEFAULT_LIMIT = 50;
+const HISTORY_MAX_LIMIT = 200;
 
-  const row = await c.env.DB.prepare("SELECT * FROM rooms WHERE id = ?").bind(rid).first();
+function messageToWire(m: Message): WireMessage {
+  // Tombstoned: blank body on the wire so a deleted message can never leak
+  // via the historical scrollback route. D1 retains the body for any future
+  // hard-erase / GDPR path.
+  return {
+    id: m.id,
+    room_id: m.room_id,
+    user_id: m.user_id,
+    body: m.deleted_at !== null ? "" : m.body,
+    parent_id: m.parent_id,
+    created_at: m.created_at,
+    edited_at: m.edited_at,
+    deleted_at: m.deleted_at,
+  };
+}
+
+async function loadMemberRoom(
+  env: Env,
+  userId: string,
+  workspaceId: string,
+  rid: string,
+): Promise<void> {
+  const row = await env.DB.prepare("SELECT * FROM rooms WHERE id = ?").bind(rid).first();
   if (!row) {
     throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Room not found", { status: 404 });
   }
   const room = parseRoomRow(row);
-
-  // Cross-workspace defense in depth: even if a user knows a room ID outside
-  // their workspace, they get a 404 (not a 403, which would confirm existence).
-  if (room.workspace_id !== c.var.workspace.id) {
+  if (room.workspace_id !== workspaceId) {
+    // Cross-workspace defense in depth: 404, not 403, so we don't confirm
+    // existence to a caller authenticated to a different workspace.
     throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Room not found", { status: 404 });
   }
-
-  const member = await c.env.DB.prepare(
+  const member = await env.DB.prepare(
     "SELECT 1 FROM room_members WHERE room_id = ? AND user_id = ? LIMIT 1",
   )
-    .bind(rid, c.var.user.id)
+    .bind(rid, userId)
     .first();
   if (!member) {
     throw new LoomwikiError(ErrorCodes.FORBIDDEN, "Not a member of this room", { status: 403 });
   }
+}
 
-  return c.json(apiOk({ room: serializeRoom(room) }));
-});
+export const roomsRoute = new Hono<AuthEnv>()
+  .get("/:rid", async (c) => {
+    const rid = c.req.param("rid");
+
+    const row = await c.env.DB.prepare("SELECT * FROM rooms WHERE id = ?").bind(rid).first();
+    if (!row) {
+      throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Room not found", { status: 404 });
+    }
+    const room = parseRoomRow(row);
+
+    if (room.workspace_id !== c.var.workspace.id) {
+      throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Room not found", { status: 404 });
+    }
+
+    const member = await c.env.DB.prepare(
+      "SELECT 1 FROM room_members WHERE room_id = ? AND user_id = ? LIMIT 1",
+    )
+      .bind(rid, c.var.user.id)
+      .first();
+    if (!member) {
+      throw new LoomwikiError(ErrorCodes.FORBIDDEN, "Not a member of this room", { status: 403 });
+    }
+
+    return c.json(apiOk({ room: serializeRoom(room) }));
+  })
+  .get("/:rid/messages", async (c) => {
+    const rid = c.req.param("rid");
+    await loadMemberRoom(c.env, c.var.user.id, c.var.workspace.id, rid);
+
+    const before = c.req.query("before");
+    const limitRaw = c.req.query("limit");
+    let limit = HISTORY_DEFAULT_LIMIT;
+    if (limitRaw !== undefined) {
+      const parsed = Number.parseInt(limitRaw, 10);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "limit must be a positive integer", {
+          status: 400,
+        });
+      }
+      limit = Math.min(parsed, HISTORY_MAX_LIMIT);
+    }
+
+    // We fetch limit+1 so we can compute hasMore without a second query.
+    const fetched = limit + 1;
+    const rows = before
+      ? await c.env.DB.prepare(
+          "SELECT * FROM messages WHERE room_id = ? AND id < ? ORDER BY id DESC LIMIT ?",
+        )
+          .bind(rid, before, fetched)
+          .all()
+      : await c.env.DB.prepare("SELECT * FROM messages WHERE room_id = ? ORDER BY id DESC LIMIT ?")
+          .bind(rid, fetched)
+          .all();
+
+    const parsed = rows.results.map(parseMessageRow);
+    const hasMore = parsed.length > limit;
+    const trimmed = hasMore ? parsed.slice(0, limit) : parsed;
+    // Return oldest-first within the page so callers can append directly.
+    trimmed.reverse();
+
+    return c.json(apiOk({ messages: trimmed.map(messageToWire), hasMore }));
+  })
+  .get("/:rid/ws", async (c) => {
+    const rid = c.req.param("rid");
+    if (c.req.header("Upgrade") !== "websocket") {
+      throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "expected websocket upgrade", {
+        status: 426,
+      });
+    }
+    await loadMemberRoom(c.env, c.var.user.id, c.var.workspace.id, rid);
+
+    const stubId = c.env.CHAT_ROOM.idFromName(rid);
+    const stub = c.env.CHAT_ROOM.get(stubId);
+
+    // Forward to the DO with identity headers. Source headers are immutable;
+    // we synthesize a fresh Request with the originals + the trusted
+    // identity bound from auth middleware. The DO will refuse the upgrade
+    // if these are missing.
+    const headers = new Headers(c.req.raw.headers);
+    headers.set("x-loomwiki-user-id", c.var.user.id);
+    headers.set("x-loomwiki-room-id", rid);
+    const forwarded = new Request(c.req.raw.url, {
+      method: c.req.raw.method,
+      headers,
+    });
+
+    return stub.fetch(forwarded);
+  });

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,8 @@
     "./id": "./src/id.ts",
     "./error": "./src/error.ts",
     "./errors": "./src/errors.ts",
-    "./result": "./src/result.ts"
+    "./result": "./src/result.ts",
+    "./ws-protocol": "./src/ws-protocol.ts"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json --noEmit false --emitDeclarationOnly",
@@ -19,7 +20,8 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
-    "uuidv7": "^1.0.2"
+    "uuidv7": "^1.0.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "typescript": "^5.6.3",

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -4,3 +4,13 @@ export { type ApiError, type ApiResult, apiOk, apiErr } from "./result.js";
 export { LoomwikiError, type LoomwikiErrorOptions, isLoomwikiError } from "./error.js";
 export { ErrorCodes, type ErrorCode } from "./errors.js";
 export { id } from "./id.js";
+export {
+  PROTOCOL_VERSION,
+  MAX_BODY_CHARS,
+  WireMessageSchema,
+  type WireMessage,
+  ClientMsgSchema,
+  type ClientMsg,
+  ServerMsgSchema,
+  type ServerMsg,
+} from "./ws-protocol.js";

--- a/packages/shared/src/ws-protocol.ts
+++ b/packages/shared/src/ws-protocol.ts
@@ -75,14 +75,17 @@ const ClientSend = z.object({
   kind: z.literal("send"),
   /** Client-generated dedup token, echoed back in `ack` for optimistic UI. */
   tempId: z.string().min(1).max(64),
-  body: z.string().min(1).max(MAX_BODY_CHARS),
+  // Body length is enforced server-side in the DO so the rejection envelope
+  // can echo `tempId`; schema-level bound here is just min(1) to keep
+  // parsing robust against clients that send slightly oversized payloads.
+  body: z.string().min(1),
   parentId: UuidV7.optional(),
 });
 
 const ClientEdit = z.object({
   kind: z.literal("edit"),
   messageId: UuidV7,
-  body: z.string().min(1).max(MAX_BODY_CHARS),
+  body: z.string().min(1),
 });
 
 const ClientDelete = z.object({

--- a/packages/shared/src/ws-protocol.ts
+++ b/packages/shared/src/ws-protocol.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// WebSocket protocol envelopes for the ChatRoom DO (SPEC §9).
+//
+// This is the contract between `apps/worker/src/do/ChatRoom.ts` and
+// `apps/web/src/lib/ws.ts`. It is committed alone, before either side is
+// implemented, so both authors build against the same shape and drift can't
+// open up across files.
+//
+// Wire format conventions:
+//   - All timestamps are unix epoch seconds (integer). SPEC §9 specifies this
+//     for the WS surface; `apps/worker/src/lib/serialize.ts` (REST) uses ISO
+//     strings for users/workspaces/rooms but messages stay numeric end-to-end
+//     because that's what §9 mandates and the WS hot path benefits from
+//     skipping the conversion.
+//   - `kind` is a discriminator. Parse with `ClientMsgSchema.safeParse` /
+//     `ServerMsgSchema.safeParse` and switch on `kind`.
+//   - The `hello` envelope intentionally has no `userId` field — auth happens
+//     before the upgrade and the userId lives in `ws.serializeAttachment(...)`.
+//     Including it on the wire would invite a forge-the-userId attack, so we
+//     drop it from the schema entirely (deviation from SPEC §9 in service of
+//     the M2 resolved-decision "Auth happens before the upgrade … do NOT
+//     re-validate per message").
+//   - `protocolVersion: 1` is included on `hello` and `welcome` so future
+//     protocol changes can switch on it without a hard break.
+
+import { z } from "zod";
+
+export const PROTOCOL_VERSION = 1;
+
+// Message body cap matches SPEC §9 (also enforced by MessageRowSchema in
+// @loomwiki/schema). Duplicated here so the WS layer can reject before any
+// DB round-trip.
+export const MAX_BODY_CHARS = 4096;
+
+// UUIDv7 regex shared with `@loomwiki/schema`. Defined locally to keep
+// `@loomwiki/shared` free of a dep on `@loomwiki/schema` (which already
+// depends on us — circular otherwise).
+const UuidV7 = z
+  .string()
+  .regex(
+    /^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+    "must be a UUIDv7",
+  );
+
+const EpochSeconds = z.number().int().nonnegative();
+
+/**
+ * The on-wire message shape. Mirrors the D1 `messages` row, with `created_at`
+ * and friends as epoch seconds (NOT ISO-8601). Tombstoned messages have
+ * `body: ""` and a non-null `deleted_at`; clients render "[deleted]".
+ */
+export const WireMessageSchema = z.object({
+  id: UuidV7,
+  room_id: UuidV7,
+  user_id: UuidV7,
+  body: z.string().max(MAX_BODY_CHARS),
+  parent_id: UuidV7.nullable(),
+  created_at: EpochSeconds,
+  edited_at: EpochSeconds.nullable(),
+  deleted_at: EpochSeconds.nullable(),
+});
+export type WireMessage = z.infer<typeof WireMessageSchema>;
+
+// ---------- Client → Server ----------
+
+const ClientHello = z.object({
+  kind: z.literal("hello"),
+  protocolVersion: z.literal(PROTOCOL_VERSION),
+  /** Resume cursor. If omitted, server returns the most-recent N messages. */
+  sinceMessageId: UuidV7.optional(),
+});
+
+const ClientSend = z.object({
+  kind: z.literal("send"),
+  /** Client-generated dedup token, echoed back in `ack` for optimistic UI. */
+  tempId: z.string().min(1).max(64),
+  body: z.string().min(1).max(MAX_BODY_CHARS),
+  parentId: UuidV7.optional(),
+});
+
+const ClientEdit = z.object({
+  kind: z.literal("edit"),
+  messageId: UuidV7,
+  body: z.string().min(1).max(MAX_BODY_CHARS),
+});
+
+const ClientDelete = z.object({
+  kind: z.literal("delete"),
+  messageId: UuidV7,
+});
+
+const ClientPing = z.object({
+  kind: z.literal("ping"),
+});
+
+export const ClientMsgSchema = z.discriminatedUnion("kind", [
+  ClientHello,
+  ClientSend,
+  ClientEdit,
+  ClientDelete,
+  ClientPing,
+]);
+export type ClientMsg = z.infer<typeof ClientMsgSchema>;
+
+// ---------- Server → Client ----------
+
+const ServerWelcome = z.object({
+  kind: z.literal("welcome"),
+  protocolVersion: z.literal(PROTOCOL_VERSION),
+  roomId: UuidV7,
+  /** Messages the client has not yet seen. Capped at 200 to bound payload. */
+  recentMessages: z.array(WireMessageSchema),
+});
+
+const ServerMessage = z.object({
+  kind: z.literal("message"),
+  message: WireMessageSchema,
+});
+
+const ServerAck = z.object({
+  kind: z.literal("ack"),
+  tempId: z.string(),
+  messageId: UuidV7,
+});
+
+const ServerEdited = z.object({
+  kind: z.literal("edited"),
+  messageId: UuidV7,
+  body: z.string(),
+  editedAt: EpochSeconds,
+});
+
+const ServerDeleted = z.object({
+  kind: z.literal("deleted"),
+  messageId: UuidV7,
+  deletedAt: EpochSeconds,
+});
+
+const ServerError = z.object({
+  kind: z.literal("error"),
+  /** ErrorCodes constant (uppercase wire format). */
+  code: z.string(),
+  message: z.string(),
+  /**
+   * Echoed when the offending client envelope carried a tempId, so the
+   * client can mark the optimistic UI entry as failed without ambiguity.
+   */
+  tempId: z.string().optional(),
+});
+
+const ServerPong = z.object({
+  kind: z.literal("pong"),
+});
+
+export const ServerMsgSchema = z.discriminatedUnion("kind", [
+  ServerWelcome,
+  ServerMessage,
+  ServerAck,
+  ServerEdited,
+  ServerDeleted,
+  ServerError,
+  ServerPong,
+]);
+export type ServerMsg = z.infer<typeof ServerMsgSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       uuidv7:
         specifier: ^1.0.2
         version: 1.2.1
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
     devDependencies:
       typescript:
         specifier: ^5.6.3


### PR DESCRIPTION
Closes #5.

## Summary

Replaces the M0 501-stub `ChatRoom` DO with the real M2 chat surface. After this PR, two clients connected to the same room exchange messages in real time, idle rooms cost zero GB-s (Hibernation API), and message history survives server restarts via DO SQLite + write-through D1 mirror.

## Hibernation API attestation

Mandatory per [SPEC §9](SPEC.md#9-real-time-chat-surface-chatroom-durable-object) and CLAUDE.md. **Not** the legacy `ws.addEventListener` pattern.

- `ctx.acceptWebSocket(server)` — [apps/worker/src/do/ChatRoom.ts:142](apps/worker/src/do/ChatRoom.ts#L142)
- `webSocketMessage(ws, raw)` — [apps/worker/src/do/ChatRoom.ts:150](apps/worker/src/do/ChatRoom.ts#L150)
- `webSocketClose(ws, …)` — [apps/worker/src/do/ChatRoom.ts:192](apps/worker/src/do/ChatRoom.ts#L192)
- `webSocketError(ws, error)` — [apps/worker/src/do/ChatRoom.ts:203](apps/worker/src/do/ChatRoom.ts#L203)
- `fetch(request)` — [apps/worker/src/do/ChatRoom.ts:115](apps/worker/src/do/ChatRoom.ts#L115)

Per-WS identity uses `ws.serializeAttachment({ userId, roomId })` so userId survives hibernation. Fan-out iterates `ctx.getWebSockets()` — never an instance-field `Map`.

## What's in

**Shared protocol** (committed alone in 7bc21ce before fan-out so both sides build against the same contract):

- `packages/shared/src/ws-protocol.ts` — `ClientMsg` / `ServerMsg` discriminated unions + Zod schemas + `WireMessage` + `PROTOCOL_VERSION = 1` + `MAX_BODY_CHARS = 4096`.

**Worker (DO + routes + tests)** in 34ce1b7:

- `apps/worker/src/do/ChatRoom.ts` — DO with Hibernation API.
- `apps/worker/src/do/storage.ts` — `messages_local` SQLite schema + `room_meta` (alarm-recoverable roomId).
- `apps/worker/src/lib/d1-mirror.ts` — idempotent `INSERT … ON CONFLICT(id) DO UPDATE` mirror.
- `apps/worker/src/lib/rate-limit.ts` — pure rolling-window limiter.
- `apps/worker/src/routes/rooms.ts` — folds `GET /:rid/messages` (D1 scrollback) and `GET /:rid/ws` (upgrade) into the existing `roomsRoute` so the M1 auth chain (`app.use("/api/rooms/*", authMiddleware)`) continues to gate everything.
- 18 new tests across `chat-room`, `messages`, `ws-mirror`, `rate-limit`. **50 worker tests passing total.**

**Web** in a657995:

- `apps/web/src/lib/ws.ts` — typed `ChatClient` with reconnect, send-queue, heartbeat, hello-first ordering, last-server-id resume cursor.
- `apps/web/vitest.config.ts` — node env, fake-WebSocket-injected unit tests. **9 web tests passing.**

## Resolved-decision compliance

| Decision | Implementation |
|---|---|
| Hibernation API mandatory | ✅ class methods, no `addEventListener` |
| `idFromName(roomId)` routing | ✅ [routes/rooms.ts:138](apps/worker/src/routes/rooms.ts#L138) |
| `ctx.storage.sql` (no legacy KV) | ✅ both `messages_local` and `room_meta` |
| `serializeAttachment({ userId, roomId })` | ✅ [ChatRoom.ts:144](apps/worker/src/do/ChatRoom.ts#L144) |
| Auth before upgrade, never per-message | ✅ route layer; DO trusts `x-loomwiki-{user,room}-id` headers from authenticated route |
| 4096-char body cap | ✅ enforced server-side, echoes `tempId` in error |
| 100 msg/sec rolling 1s rate limit | ✅ `RollingWindowLimiter` |
| `blockConcurrencyWhile` for insert+ack | ✅ [ChatRoom.ts:240](apps/worker/src/do/ChatRoom.ts#L240) |
| D1 mirror via `waitUntil` (off ack path) | ✅ [ChatRoom.ts:265](apps/worker/src/do/ChatRoom.ts#L265) |
| Mirror failure → `pending_mirror=1`, alarm retry | ✅ 60s alarm, batches of 100 |
| Reconnect via `hello.sinceMessageId` | ✅ DO + ChatClient both implement |
| Welcome cap 200 (resume) / 50 (fresh) | ✅ |
| Pagination (50 default, 200 max) | ✅ `GET /api/rooms/:rid/messages?before=&limit=` |
| `protocolVersion: 1` on hello/welcome | ✅ |
| Reconnect backoff 250ms→30s ±20% jitter | ✅ |
| Heartbeat 30s ping / 10s pong deadline | ✅ |
| Edit/delete by author only; tombstone returns body="" | ✅ |
| Cross-workspace upgrade returns 404 (not 403) | ✅ defense in depth from M1 |

## Wire format note (deviation worth surfacing)

SPEC §9 says timestamps on the WS surface are `number` (epoch seconds). M1's REST `serialize.ts` converts to ISO-8601 for users/workspaces/rooms. M2 keeps **numbers end-to-end** for messages — both `GET /api/rooms/:rid/messages` and the WS protocol — because §9 is explicit, the WS hot path benefits, and a unified message shape lets the same client TS render both paths. M1 conventions for non-message types are unchanged.

Also: dropped `userId` from the `hello` envelope (SPEC §9 had it). The resolved decisions table already mandates "auth via attachment, do not re-validate per message," and shipping a wire-level userId field invites a forge-the-claim attack. Documented in the file header.

## Backpressure rejection envelope

Validation failure (>4096 chars):
```json
{ "kind": "error", "code": "VALIDATION_FAILED", "message": "body exceeds 4096 chars", "tempId": "<echoed>" }
```
Rate limit (>100/s):
```json
{ "kind": "error", "code": "RATE_LIMITED", "message": "100 msg/sec/room cap reached", "tempId": "<echoed>" }
```

## Verification

```
pnpm install                                       # ok
pnpm typecheck                                     # 4/4 packages clean
pnpm lint                                          # biome clean
pnpm test                                          # 50 worker + 9 web + 3 shared = 62 passing
pnpm migrate:local                                 # 0001_init.sql applied
```

Worker test coverage of the SPEC §9 acceptance criteria:

| Criterion | Test |
|---|---|
| Two clients exchange messages within 200ms | `chat-room.test.ts > two members exchange a message` |
| Reconnect resumes from `sinceMessageId` | `chat-room.test.ts > reconnect with sinceMessageId` |
| D1 mirror within 1 second | `ws-mirror.test.ts > visible in D1 within 1 second` |
| Crash mid-write doesn't lose acks | `blockConcurrencyWhile` wraps insert+ack — assertion is structural; tested via the round-trip pair where ack and broadcast both observe the durable row |
| Idle hibernation = zero GB-s | Not asserted in vitest (in-process miniflare doesn't simulate the workerd hibernation timer). Manual `wrangler tail` smoke remains a reviewer step. |

## wscat smoke (deferred)

The two-`wscat`-sessions smoke from the M2 prompt requires `.dev.vars` setup for `ALLOW_LOCAL_DEV_AUTH=true` plus interactive terminals — not driveable from a single-shell autonomous run. Equivalent paths are exercised by `chat-room.test.ts` via `SELF.fetch` with `Upgrade: websocket`, which routes through the actual auth middleware → route → DO upgrade in miniflare. Reviewers should still run the wscat smoke locally per the M2 issue's verification block before tagging done.

## Out of scope (per M2 prompt)

Frontend chat UI components (M3), threading UX, presence/typing/read receipts, attachments, reactions, cron handler (M5), wiki/Artifacts (M4), ingest agent (M7), BYOK (M8). Not implemented in this PR.

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 62 passing (50 worker + 9 web + 3 shared)
- [x] D1 migrations apply locally
- [ ] Manual two-`wscat` round-trip against `wrangler dev` (reviewer step)
- [ ] `wrangler tail` confirms zero events during 60s+ idle (reviewer step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)