### PR TITLE
M5: Daily Chat-Log Commit Cron

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -261,6 +261,65 @@ If a vault repo gets into a bad state:
 For a clean start: delete the repo via `env.ARTIFACTS.delete(name)` (or
 the dashboard) and call the bootstrap admin route again.
 
+## Daily chat-log archival cron (M5)
+
+Loomwiki runs a Workers cron at **02:00 UTC daily** that aggregates the
+previous calendar day's chat messages from D1 and writes one markdown
+file per room to the vault under `/rooms/{slug}/log/{YYYY-MM-DD}.md`.
+The schedule is declared in `wrangler.jsonc`:
+
+```jsonc
+"triggers": { "crons": ["0 2 * * *"] }
+```
+
+The handler lives in [`apps/worker/src/scheduled.ts`](apps/worker/src/scheduled.ts)
+and calls `archiveDay()` from [`apps/worker/src/lib/chat-log.ts`](apps/worker/src/lib/chat-log.ts).
+Re-running for the same date is a no-op at the content level — the
+formatter is deterministic and the backend writes are last-write-wins,
+so byte-identical output overwrites the previous file cleanly.
+
+### Verifying the cron is firing in production
+
+Cloudflare dashboard → **Workers & Pages → loomwiki-api → Triggers**
+shows the cron schedule and the last few invocation results. The
+handler emits a structured log line on each successful run; tail it
+with:
+
+```sh
+wrangler tail --format pretty | grep archive_run_complete
+```
+
+### Manual backfill (operator)
+
+To archive an arbitrary past day (e.g. for a fresh deploy that has
+existing chat history, or after a vault reset):
+
+```sh
+DATE=2026-05-03
+curl -s -X POST -H "X-Local-Dev-Email: cory@example.com" \
+  "http://127.0.0.1:8788/api/_admin/cron/archive-day?date=$DATE" | jq .
+# Expected: { ok: true, data: { date: "...", files_written: N, rooms_processed: M, errors: [] } }
+```
+
+In production, swap the `X-Local-Dev-Email` header for the Access JWT
+the operator's logged-in browser session uses (the route is
+workspace-owner-only). The endpoint is idempotent — re-running for
+the same date overwrites the file cleanly and is safe to invoke
+repeatedly.
+
+### Local-dev path
+
+`wrangler dev --test-scheduled` exposes a `/__scheduled` endpoint that
+fires the handler synchronously without waiting for the cron to tick:
+
+```sh
+pnpm --filter @loomwiki/worker dev --test-scheduled --port 8788
+# in another shell:
+curl -s "http://127.0.0.1:8788/__scheduled?cron=0+2+*+*+*"
+```
+
+Watch `wrangler tail` for the `archive_run_complete` log line.
+
 ## Right-to-deletion (operator note)
 
 Chat messages can be soft-deleted from D1 and the live DO. They cannot be

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "scripts": {
-    "dev": "wrangler dev --config ../../wrangler.jsonc --port 8788",
+    "dev": "wrangler dev --config ../../wrangler.dev.jsonc --port 8788",
     "build": "wrangler deploy --dry-run --outdir dist --config ../../wrangler.jsonc",
     "deploy": "wrangler deploy --config ../../wrangler.jsonc",
     "typecheck": "tsc -p tsconfig.json --noEmit",

--- a/apps/worker/src/__tests__/admin-cron.test.ts
+++ b/apps/worker/src/__tests__/admin-cron.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for POST /api/_admin/cron/archive-day. Owner-only, validates
+// the date param, and shares the archiveDay() code path with the
+// scheduled() cron handler. We hit SELF.fetch so the full Hono
+// pipeline (auth → owner gate → handler → ApiResult) runs.
+
+import { SELF, env } from "cloudflare:test";
+import { id } from "@loomwiki/shared";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+let fixture: JwtFixture;
+
+async function clearWikiKv(): Promise<void> {
+  const list = await env.WIKI_KV.list();
+  for (const k of list.keys) await env.WIKI_KV.delete(k.name);
+}
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await clearWikiKv();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+interface Ok<T> {
+  ok: true;
+  data: T;
+}
+interface Err {
+  ok: false;
+  error: { code: string; message: string };
+}
+
+async function authedFetch(jwt: string, path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers ?? {});
+  headers.set("CF-Access-Jwt-Assertion", jwt);
+  return SELF.fetch(`https://api.local${path}`, { ...init, headers });
+}
+
+async function bootstrapOwnerAndRoom(): Promise<{
+  ownerJwt: string;
+  ownerId: string;
+  roomId: string;
+}> {
+  // Hitting /api/me triggers JIT user + workspace bootstrap; the first
+  // caller becomes workspace owner.
+  const ownerJwt = await fixture.mint({ email: "owner@example.com" });
+  const me = await authedFetch(ownerJwt, "/api/me");
+  const meBody = (await me.json()) as { data: { user: { id: string }; workspace: { id: string } } };
+  const ownerId = meBody.data.user.id;
+  const create = await authedFetch(ownerJwt, `/api/workspaces/${meBody.data.workspace.id}/rooms`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ slug: "general", name: "General" }),
+  });
+  const room = (await create.json()) as { data: { room: { id: string } } };
+  return { ownerJwt, ownerId, roomId: room.data.room.id };
+}
+
+const TARGET_DATE = "2026-05-03";
+const T0 = Math.floor(Date.parse(`${TARGET_DATE}T08:00:00Z`) / 1000);
+
+describe("POST /api/_admin/cron/archive-day", () => {
+  it("returns 401 without a JWT", async () => {
+    const res = await SELF.fetch(
+      `https://api.local/api/_admin/cron/archive-day?date=${TARGET_DATE}`,
+      { method: "POST" },
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a non-owner caller", async () => {
+    await bootstrapOwnerAndRoom();
+    const intruderJwt = await fixture.mint({ email: "intruder@example.com" });
+    // /api/me bootstraps the user but not as owner (workspace already
+    // exists, owned by the first caller).
+    await authedFetch(intruderJwt, "/api/me");
+    const res = await authedFetch(intruderJwt, `/api/_admin/cron/archive-day?date=${TARGET_DATE}`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as Err;
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 400 for a missing or malformed date param", async () => {
+    const { ownerJwt } = await bootstrapOwnerAndRoom();
+    const missing = await authedFetch(ownerJwt, "/api/_admin/cron/archive-day", { method: "POST" });
+    expect(missing.status).toBe(400);
+
+    const malformed = await authedFetch(ownerJwt, "/api/_admin/cron/archive-day?date=2026-13-99", {
+      method: "POST",
+    });
+    expect(malformed.status).toBe(400);
+    const body = (await malformed.json()) as Err;
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("succeeds for the owner and writes a log file the day has messages", async () => {
+    const { ownerJwt, ownerId, roomId } = await bootstrapOwnerAndRoom();
+    // Seed one message in the target day directly via D1.
+    await env.DB.prepare(
+      "INSERT INTO messages (id, room_id, user_id, body, created_at) VALUES (?, ?, ?, ?, ?)",
+    )
+      .bind(id(), roomId, ownerId, "hello", T0)
+      .run();
+
+    const res = await authedFetch(ownerJwt, `/api/_admin/cron/archive-day?date=${TARGET_DATE}`, {
+      method: "POST",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Ok<{
+      date: string;
+      files_written: number;
+      rooms_processed: number;
+      errors: unknown[];
+    }>;
+    expect(body.data.date).toBe(TARGET_DATE);
+    expect(body.data.files_written).toBe(1);
+    expect(body.data.rooms_processed).toBe(1);
+    expect(body.data.errors).toEqual([]);
+
+    // Confirm the file landed in WIKI_KV at the canonical path.
+    const stored = await env.WIKI_KV.get(`wiki:/rooms/general/log/${TARGET_DATE}.md`);
+    expect(stored).toMatch(/room: general/);
+    expect(stored).toMatch(/message_count: 1/);
+    expect(stored).toMatch(/hello/);
+  });
+
+  it("is idempotent — running twice yields byte-identical KV content", async () => {
+    const { ownerJwt, ownerId, roomId } = await bootstrapOwnerAndRoom();
+    await env.DB.prepare(
+      "INSERT INTO messages (id, room_id, user_id, body, created_at) VALUES (?, ?, ?, ?, ?)",
+    )
+      .bind(id(), roomId, ownerId, "hello", T0)
+      .run();
+
+    const first = await authedFetch(ownerJwt, `/api/_admin/cron/archive-day?date=${TARGET_DATE}`, {
+      method: "POST",
+    });
+    expect(first.status).toBe(200);
+    const after1 = await env.WIKI_KV.get(`wiki:/rooms/general/log/${TARGET_DATE}.md`);
+
+    const second = await authedFetch(ownerJwt, `/api/_admin/cron/archive-day?date=${TARGET_DATE}`, {
+      method: "POST",
+    });
+    expect(second.status).toBe(200);
+    const after2 = await env.WIKI_KV.get(`wiki:/rooms/general/log/${TARGET_DATE}.md`);
+
+    expect(after1).not.toBeNull();
+    expect(after1).toBe(after2);
+  });
+});

--- a/apps/worker/src/__tests__/archive-day.test.ts
+++ b/apps/worker/src/__tests__/archive-day.test.ts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Integration tests for archiveDay(). Wired against miniflare D1 with
+// real migrations + an InMemoryWikiBackend so the orchestration is
+// exercised end-to-end without touching KV. The schema is the same one
+// production runs against (forward-only D1 migrations from
+// packages/schema/d1-migrations).
+
+import { env } from "cloudflare:test";
+import { id } from "@loomwiki/shared";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { archiveDay, formatChatLogPath } from "../lib/chat-log.js";
+import { InMemoryWikiBackend, type WikiBackend } from "../lib/wiki-backend.js";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+
+const WORKSPACE_ID = "00000000-0000-7000-8000-000000000000";
+const OWNER_ID = "01900000-0000-7000-8000-eeeeeeeeeeee";
+
+interface SeedHandles {
+  aliceId: string;
+  bobId: string;
+  generalId: string;
+  randomId: string;
+}
+
+async function seedFixtures(): Promise<SeedHandles> {
+  // Workspace + users
+  await env.DB.prepare(
+    "INSERT INTO users (id, email, display_name) VALUES (?, ?, ?) ON CONFLICT(email) DO NOTHING",
+  )
+    .bind(OWNER_ID, "owner@example.com", "Owner")
+    .run();
+  await env.DB.prepare(
+    "INSERT INTO workspaces (id, name, owner_id, vault_repo) VALUES (?, ?, ?, ?) ON CONFLICT(id) DO NOTHING",
+  )
+    .bind(WORKSPACE_ID, "default", OWNER_ID, "loomwiki-vault")
+    .run();
+
+  const aliceId = id();
+  const bobId = id();
+  await env.DB.prepare("INSERT INTO users (id, email, display_name) VALUES (?, ?, ?)")
+    .bind(aliceId, "alice@example.com", "alice")
+    .run();
+  await env.DB.prepare("INSERT INTO users (id, email, display_name) VALUES (?, ?, ?)")
+    .bind(bobId, "bob@example.com", "bob")
+    .run();
+
+  // Two rooms
+  const generalId = id();
+  const randomId = id();
+  await env.DB.prepare(
+    "INSERT INTO rooms (id, workspace_id, slug, name, created_by) VALUES (?, ?, ?, ?, ?)",
+  )
+    .bind(generalId, WORKSPACE_ID, "general", "General", aliceId)
+    .run();
+  await env.DB.prepare(
+    "INSERT INTO rooms (id, workspace_id, slug, name, created_by) VALUES (?, ?, ?, ?, ?)",
+  )
+    .bind(randomId, WORKSPACE_ID, "random", "Random", aliceId)
+    .run();
+
+  return { aliceId, bobId, generalId, randomId };
+}
+
+async function seedMessage(opts: {
+  roomId: string;
+  userId: string;
+  body: string;
+  createdAtSec: number;
+  deletedAtSec?: number | null;
+  editedAtSec?: number | null;
+}): Promise<string> {
+  const mid = id();
+  await new Promise((r) => setTimeout(r, 1));
+  await env.DB.prepare(
+    `INSERT INTO messages
+       (id, room_id, user_id, body, created_at, edited_at, deleted_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  )
+    .bind(
+      mid,
+      opts.roomId,
+      opts.userId,
+      opts.body,
+      opts.createdAtSec,
+      opts.editedAtSec ?? null,
+      opts.deletedAtSec ?? null,
+    )
+    .run();
+  return mid;
+}
+
+const TARGET_DATE = "2026-05-03";
+const T0 = Math.floor(Date.parse(`${TARGET_DATE}T08:00:00Z`) / 1000);
+
+beforeAll(async () => {
+  await applyMigrations();
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("archiveDay", () => {
+  it("produces zero files for an empty day", async () => {
+    await seedFixtures();
+    const backend = new InMemoryWikiBackend();
+    const summary = await archiveDay({ env, dateUtc: TARGET_DATE, backend });
+    expect(summary).toEqual({
+      date: TARGET_DATE,
+      files_written: 0,
+      rooms_processed: 0,
+      errors: [],
+    });
+    expect(backend.size()).toBe(0);
+  });
+
+  it("writes one file per room, at the canonical path", async () => {
+    const { aliceId, bobId, generalId, randomId } = await seedFixtures();
+    await seedMessage({ roomId: generalId, userId: aliceId, body: "g1", createdAtSec: T0 });
+    await seedMessage({ roomId: generalId, userId: bobId, body: "g2", createdAtSec: T0 + 60 });
+    await seedMessage({ roomId: randomId, userId: aliceId, body: "r1", createdAtSec: T0 + 120 });
+
+    const backend = new InMemoryWikiBackend();
+    const summary = await archiveDay({ env, dateUtc: TARGET_DATE, backend });
+    expect(summary.rooms_processed).toBe(2);
+    expect(summary.files_written).toBe(2);
+    expect(summary.errors).toEqual([]);
+
+    const generalRecord = await backend.read(formatChatLogPath("general", TARGET_DATE));
+    const randomRecord = await backend.read(formatChatLogPath("random", TARGET_DATE));
+    expect(generalRecord).not.toBeNull();
+    expect(randomRecord).not.toBeNull();
+
+    expect(generalRecord?.raw).toContain("room: general");
+    expect(generalRecord?.raw).toContain("message_count: 2");
+    expect(generalRecord?.raw).toContain("## 08:00 alice");
+    expect(generalRecord?.raw).toContain("g1");
+    expect(generalRecord?.raw).toContain("## 08:01 bob");
+    expect(generalRecord?.raw).toContain("g2");
+
+    expect(randomRecord?.raw).toContain("message_count: 1");
+    expect(randomRecord?.raw).toContain("r1");
+  });
+
+  it("renders tombstoned messages as [deleted] and uses post-edit body for edits", async () => {
+    const { aliceId, generalId } = await seedFixtures();
+    await seedMessage({
+      roomId: generalId,
+      userId: aliceId,
+      body: "edited body",
+      createdAtSec: T0,
+      editedAtSec: T0 + 5,
+    });
+    await seedMessage({
+      roomId: generalId,
+      userId: aliceId,
+      body: "",
+      createdAtSec: T0 + 60,
+      deletedAtSec: T0 + 120,
+    });
+
+    const backend = new InMemoryWikiBackend();
+    const summary = await archiveDay({ env, dateUtc: TARGET_DATE, backend });
+    expect(summary.files_written).toBe(1);
+    const record = await backend.read(formatChatLogPath("general", TARGET_DATE));
+    expect(record?.raw).toContain("edited body");
+    expect(record?.raw).toContain("[deleted]");
+  });
+
+  it("ignores messages outside the target UTC day", async () => {
+    const { aliceId, generalId } = await seedFixtures();
+    // Day before
+    await seedMessage({
+      roomId: generalId,
+      userId: aliceId,
+      body: "yesterday",
+      createdAtSec: Math.floor(Date.parse("2026-05-02T23:59:59Z") / 1000),
+    });
+    // Target day
+    await seedMessage({ roomId: generalId, userId: aliceId, body: "today", createdAtSec: T0 });
+    // Day after
+    await seedMessage({
+      roomId: generalId,
+      userId: aliceId,
+      body: "tomorrow",
+      createdAtSec: Math.floor(Date.parse("2026-05-04T00:00:00Z") / 1000),
+    });
+
+    const backend = new InMemoryWikiBackend();
+    await archiveDay({ env, dateUtc: TARGET_DATE, backend });
+    const record = await backend.read(formatChatLogPath("general", TARGET_DATE));
+    expect(record?.raw).toContain("today");
+    expect(record?.raw).not.toContain("yesterday");
+    expect(record?.raw).not.toContain("tomorrow");
+    expect(record?.raw).toContain("message_count: 1");
+  });
+
+  it("re-running for the same date overwrites cleanly (byte-identical for unchanged input)", async () => {
+    const { aliceId, generalId } = await seedFixtures();
+    await seedMessage({ roomId: generalId, userId: aliceId, body: "stable", createdAtSec: T0 });
+
+    const backend = new InMemoryWikiBackend();
+    await archiveDay({ env, dateUtc: TARGET_DATE, backend });
+    const first = await backend.read(formatChatLogPath("general", TARGET_DATE));
+    await archiveDay({ env, dateUtc: TARGET_DATE, backend });
+    const second = await backend.read(formatChatLogPath("general", TARGET_DATE));
+
+    expect(first?.raw).toBe(second?.raw);
+    expect(first?.sha).toBe(second?.sha);
+  });
+
+  it("isolates per-room failures — one room's writeFile error does not block others", async () => {
+    const { aliceId, generalId, randomId } = await seedFixtures();
+    await seedMessage({ roomId: generalId, userId: aliceId, body: "g1", createdAtSec: T0 });
+    await seedMessage({ roomId: randomId, userId: aliceId, body: "r1", createdAtSec: T0 });
+
+    // Backend that throws when asked to write the `general` log.
+    class FailingBackend extends InMemoryWikiBackend implements WikiBackend {
+      override async writeFile(path: string, content: string): Promise<{ sha: string }> {
+        if (path.includes("/rooms/general/")) {
+          throw new Error("simulated KV outage");
+        }
+        return super.writeFile(path, content);
+      }
+    }
+    const backend = new FailingBackend();
+
+    const summary = await archiveDay({ env, dateUtc: TARGET_DATE, backend });
+    expect(summary.rooms_processed).toBe(2);
+    expect(summary.files_written).toBe(1);
+    expect(summary.errors).toHaveLength(1);
+    expect(summary.errors[0]?.message).toMatch(/simulated KV outage/);
+    // The `random` room still made it through.
+    const randomRecord = await backend.read(formatChatLogPath("random", TARGET_DATE));
+    expect(randomRecord?.raw).toContain("r1");
+  });
+
+  it("rejects an invalid date input at the orchestration boundary", async () => {
+    const backend = new InMemoryWikiBackend();
+    await expect(archiveDay({ env, dateUtc: "2026-13-99", backend })).rejects.toThrow(
+      /invalid date/i,
+    );
+  });
+});

--- a/apps/worker/src/__tests__/chat-log.test.ts
+++ b/apps/worker/src/__tests__/chat-log.test.ts
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for the chat-log path/format helpers. The integration
+// tests in archive-day.test.ts exercise the D1 + backend round-trip;
+// these tests own the formatter contract — frontmatter shape, body
+// ordering, tombstone rendering, deterministic re-format.
+
+import { describe, expect, it } from "vitest";
+import {
+  type ArchivableMessage,
+  dayBoundsUtc,
+  formatChatLogContent,
+  formatChatLogPath,
+  isValidIsoDate,
+  previousUtcDayFromScheduledTime,
+  validateChatLogPath,
+} from "../lib/chat-log.js";
+
+const ALICE = "01900000-0000-7000-8000-000000000001";
+const BOB = "01900000-0000-7000-8000-000000000002";
+
+describe("formatChatLogPath / validateChatLogPath", () => {
+  it("formats canonical /rooms/{slug}/log/{date}.md", () => {
+    const path = formatChatLogPath("general", "2026-05-03");
+    expect(path).toBe("/rooms/general/log/2026-05-03.md");
+    expect(validateChatLogPath(path)).toBe(true);
+  });
+
+  it("validateChatLogPath accepts conformant paths", () => {
+    expect(validateChatLogPath("/rooms/general/log/2026-05-03.md")).toBe(true);
+    expect(validateChatLogPath("/rooms/ops-cyber/log/2099-12-31.md")).toBe(true);
+  });
+
+  it("validateChatLogPath rejects everything else", () => {
+    // Uppercase room slug
+    expect(validateChatLogPath("/rooms/General/log/2026-05-03.md")).toBe(false);
+    // Wrong prefix
+    expect(validateChatLogPath("/wiki/general/log/2026-05-03.md")).toBe(false);
+    // Garbage suffix
+    expect(validateChatLogPath("/rooms/general/log/garbage.md")).toBe(false);
+    // No .md
+    expect(validateChatLogPath("/rooms/general/log/2026-05-03")).toBe(false);
+    // Path traversal
+    expect(validateChatLogPath("/rooms/general/log/../escape.md")).toBe(false);
+    // Empty / oversize
+    expect(validateChatLogPath("")).toBe(false);
+    // Slug starting with digit (rooms slugs must start with a letter)
+    expect(validateChatLogPath("/rooms/9general/log/2026-05-03.md")).toBe(false);
+  });
+});
+
+describe("isValidIsoDate", () => {
+  it("accepts well-formed YYYY-MM-DD strings", () => {
+    expect(isValidIsoDate("2026-05-03")).toBe(true);
+    expect(isValidIsoDate("2000-01-01")).toBe(true);
+  });
+  it("rejects malformed or impossible dates", () => {
+    expect(isValidIsoDate("2026-13-01")).toBe(false); // bad month
+    expect(isValidIsoDate("2026-02-31")).toBe(false); // calendar overflow
+    expect(isValidIsoDate("26-05-03")).toBe(false); // wrong shape
+    expect(isValidIsoDate("not-a-date")).toBe(false);
+    expect(isValidIsoDate("")).toBe(false);
+  });
+});
+
+describe("previousUtcDayFromScheduledTime", () => {
+  it("returns yesterday for a 02:00 UTC tick", () => {
+    const ts = Date.parse("2026-05-04T02:00:00Z");
+    expect(previousUtcDayFromScheduledTime(ts)).toBe("2026-05-03");
+  });
+
+  it("returns yesterday for a tick exactly at midnight UTC (the -1ms guard)", () => {
+    const ts = Date.parse("2026-05-04T00:00:00Z");
+    expect(previousUtcDayFromScheduledTime(ts)).toBe("2026-05-03");
+  });
+
+  it("returns yesterday for any time-of-day on the scheduled date", () => {
+    // Late-day tick still archives YESTERDAY relative to the
+    // scheduledTime's UTC date — the function is time-of-day agnostic.
+    const ts = Date.parse("2026-05-04T23:59:59Z");
+    expect(previousUtcDayFromScheduledTime(ts)).toBe("2026-05-03");
+  });
+
+  it("uses UTC, not local time (DST has no effect on UTC arithmetic)", () => {
+    // March transition in many locales — UTC offset stays 0.
+    const ts = Date.parse("2026-03-30T02:00:00Z");
+    expect(previousUtcDayFromScheduledTime(ts)).toBe("2026-03-29");
+  });
+});
+
+describe("dayBoundsUtc", () => {
+  it("returns [start, end) in epoch seconds spanning 24h", () => {
+    const { startSec, endSec } = dayBoundsUtc("2026-05-03");
+    expect(endSec - startSec).toBe(86400);
+    expect(new Date(startSec * 1000).toISOString()).toBe("2026-05-03T00:00:00.000Z");
+    expect(new Date(endSec * 1000).toISOString()).toBe("2026-05-04T00:00:00.000Z");
+  });
+});
+
+describe("formatChatLogContent", () => {
+  it("returns null for an empty message list", () => {
+    expect(
+      formatChatLogContent({
+        roomSlug: "general",
+        dateUtc: "2026-05-03",
+        messages: [],
+        displayNamesById: new Map(),
+      }),
+    ).toBeNull();
+  });
+
+  it("renders frontmatter + a single message block", () => {
+    const messages: ArchivableMessage[] = [
+      {
+        id: "01900000-0000-7000-8000-aaaaaaaaaaa1",
+        room_id: "room-1",
+        user_id: ALICE,
+        body: "hello",
+        // 2026-05-03T14:32:11Z
+        created_at: Math.floor(Date.parse("2026-05-03T14:32:11Z") / 1000),
+        edited_at: null,
+        deleted_at: null,
+      },
+    ];
+    const content = formatChatLogContent({
+      roomSlug: "general",
+      dateUtc: "2026-05-03",
+      messages,
+      displayNamesById: new Map([[ALICE, "alice"]]),
+    });
+    expect(content).toBe(
+      [
+        "---",
+        "room: general",
+        "date: 2026-05-03",
+        "message_count: 1",
+        "ingest_run_ids: []",
+        "---",
+        "",
+        "## 14:32 alice",
+        "",
+        "hello",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("orders by created_at, then by id, regardless of input order", () => {
+    const tBase = Math.floor(Date.parse("2026-05-03T14:00:00Z") / 1000);
+    const messages: ArchivableMessage[] = [
+      {
+        id: "01900000-0000-7000-8000-aaaaaaaaaaa3",
+        room_id: "r",
+        user_id: ALICE,
+        body: "third",
+        created_at: tBase + 60,
+        edited_at: null,
+        deleted_at: null,
+      },
+      {
+        id: "01900000-0000-7000-8000-aaaaaaaaaaa1",
+        room_id: "r",
+        user_id: ALICE,
+        body: "first-tied",
+        created_at: tBase,
+        edited_at: null,
+        deleted_at: null,
+      },
+      {
+        id: "01900000-0000-7000-8000-aaaaaaaaaaa2",
+        room_id: "r",
+        user_id: BOB,
+        body: "second-tied",
+        created_at: tBase,
+        edited_at: null,
+        deleted_at: null,
+      },
+    ];
+    const content = formatChatLogContent({
+      roomSlug: "general",
+      dateUtc: "2026-05-03",
+      messages,
+      displayNamesById: new Map([
+        [ALICE, "alice"],
+        [BOB, "bob"],
+      ]),
+    });
+    // Bodies should appear in (first-tied, second-tied, third) order.
+    const idxFirst = content?.indexOf("first-tied") ?? -1;
+    const idxSecond = content?.indexOf("second-tied") ?? -1;
+    const idxThird = content?.indexOf("third") ?? -1;
+    expect(idxFirst).toBeGreaterThan(0);
+    expect(idxSecond).toBeGreaterThan(idxFirst);
+    expect(idxThird).toBeGreaterThan(idxSecond);
+  });
+
+  it("renders tombstoned messages as [deleted]", () => {
+    const messages: ArchivableMessage[] = [
+      {
+        id: "01900000-0000-7000-8000-aaaaaaaaaaa1",
+        room_id: "r",
+        user_id: ALICE,
+        body: "",
+        created_at: Math.floor(Date.parse("2026-05-03T08:00:00Z") / 1000),
+        edited_at: null,
+        deleted_at: Math.floor(Date.parse("2026-05-03T09:00:00Z") / 1000),
+      },
+    ];
+    const content = formatChatLogContent({
+      roomSlug: "general",
+      dateUtc: "2026-05-03",
+      messages,
+      displayNamesById: new Map([[ALICE, "alice"]]),
+    });
+    expect(content).toContain("## 08:00 alice");
+    expect(content).toContain("[deleted]");
+  });
+
+  it("uses the post-edit body for edited messages", () => {
+    const messages: ArchivableMessage[] = [
+      {
+        id: "01900000-0000-7000-8000-aaaaaaaaaaa1",
+        room_id: "r",
+        user_id: ALICE,
+        body: "final text after edit",
+        created_at: Math.floor(Date.parse("2026-05-03T08:00:00Z") / 1000),
+        edited_at: Math.floor(Date.parse("2026-05-03T08:01:00Z") / 1000),
+        deleted_at: null,
+      },
+    ];
+    const content = formatChatLogContent({
+      roomSlug: "general",
+      dateUtc: "2026-05-03",
+      messages,
+      displayNamesById: new Map([[ALICE, "alice"]]),
+    });
+    expect(content).toContain("final text after edit");
+  });
+
+  it("falls back to <deleted user> for an unknown user id", () => {
+    const messages: ArchivableMessage[] = [
+      {
+        id: "01900000-0000-7000-8000-aaaaaaaaaaa1",
+        room_id: "r",
+        user_id: ALICE,
+        body: "hi",
+        created_at: Math.floor(Date.parse("2026-05-03T08:00:00Z") / 1000),
+        edited_at: null,
+        deleted_at: null,
+      },
+    ];
+    const content = formatChatLogContent({
+      roomSlug: "general",
+      dateUtc: "2026-05-03",
+      messages,
+      displayNamesById: new Map(), // ALICE missing
+    });
+    expect(content).toContain("<deleted user>");
+  });
+
+  it("is deterministic — same input produces byte-identical output", () => {
+    const messages: ArchivableMessage[] = [
+      {
+        id: "01900000-0000-7000-8000-aaaaaaaaaaa1",
+        room_id: "r",
+        user_id: ALICE,
+        body: "hi",
+        created_at: Math.floor(Date.parse("2026-05-03T08:00:00Z") / 1000),
+        edited_at: null,
+        deleted_at: null,
+      },
+      {
+        id: "01900000-0000-7000-8000-aaaaaaaaaaa2",
+        room_id: "r",
+        user_id: BOB,
+        body: "hello",
+        created_at: Math.floor(Date.parse("2026-05-03T09:00:00Z") / 1000),
+        edited_at: null,
+        deleted_at: null,
+      },
+    ];
+    const args = {
+      roomSlug: "general",
+      dateUtc: "2026-05-03",
+      messages,
+      displayNamesById: new Map([
+        [ALICE, "alice"],
+        [BOB, "bob"],
+      ]),
+    } as const;
+    expect(formatChatLogContent(args)).toBe(formatChatLogContent(args));
+  });
+
+  it("ends with a single trailing newline (POSIX convention)", () => {
+    const messages: ArchivableMessage[] = [
+      {
+        id: "01900000-0000-7000-8000-aaaaaaaaaaa1",
+        room_id: "r",
+        user_id: ALICE,
+        body: "hi",
+        created_at: Math.floor(Date.parse("2026-05-03T08:00:00Z") / 1000),
+        edited_at: null,
+        deleted_at: null,
+      },
+    ];
+    const content = formatChatLogContent({
+      roomSlug: "general",
+      dateUtc: "2026-05-03",
+      messages,
+      displayNamesById: new Map([[ALICE, "alice"]]),
+    });
+    expect(content?.endsWith("\n")).toBe(true);
+    expect(content?.endsWith("\n\n")).toBe(false);
+  });
+});

--- a/apps/worker/src/__tests__/scheduled.test.ts
+++ b/apps/worker/src/__tests__/scheduled.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the cron `scheduled()` handler. The handler is thin —
+// most of its responsibility is computing the previous UTC day and
+// handing off to archiveDay() via ctx.waitUntil. We test:
+//   1. it returns void synchronously,
+//   2. ctx.waitUntil is invoked exactly once,
+//   3. the date arithmetic lands on the previous UTC day.
+//
+// We don't drive end-to-end archival here (that's archive-day.test.ts);
+// these tests own the handler-shape contract.
+
+import { env } from "cloudflare:test";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { scheduled } from "../scheduled.js";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+
+beforeAll(async () => {
+  await applyMigrations();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  // Drop any KV state seeded by other tests before this one runs.
+  const list = await env.WIKI_KV.list();
+  for (const k of list.keys) await env.WIKI_KV.delete(k.name);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+interface FakeCtx {
+  waitUntil: ReturnType<typeof vi.fn>;
+  passThroughOnException: () => void;
+}
+
+function makeCtx(): FakeCtx {
+  return {
+    waitUntil: vi.fn(),
+    passThroughOnException: () => {},
+  };
+}
+
+function controllerAt(iso: string): {
+  scheduledTime: number;
+  cron: string;
+  noRetry: () => void;
+} {
+  return {
+    scheduledTime: Date.parse(iso),
+    cron: "0 2 * * *",
+    noRetry: () => {},
+  };
+}
+
+describe("scheduled handler", () => {
+  it("returns void and forwards work to ctx.waitUntil", async () => {
+    const ctx = makeCtx();
+    // 02:00 UTC — the production schedule.
+    const controller = controllerAt("2026-05-04T02:00:00Z");
+    // biome-ignore lint/suspicious/noExplicitAny: ScheduledController shape mismatch between Cloudflare's two type packages
+    const result = await scheduled(controller as any, env, ctx as any);
+    expect(result).toBeUndefined();
+    expect(ctx.waitUntil).toHaveBeenCalledTimes(1);
+  });
+
+  it("handler completes without throwing and produces no archive errors for an empty DB", async () => {
+    const ctx = makeCtx();
+    let promise: Promise<unknown> | undefined;
+    ctx.waitUntil.mockImplementation((p: Promise<unknown>) => {
+      promise = p;
+    });
+    const controller = controllerAt("2026-05-04T02:00:00Z");
+    // biome-ignore lint/suspicious/noExplicitAny: ScheduledController shape mismatch
+    await scheduled(controller as any, env, ctx as any);
+    // The waitUntil promise resolves cleanly (no rooms → no errors).
+    await expect(promise).resolves.toBeUndefined();
+  });
+
+  it("computes previous-UTC-day correctly across the date boundary", async () => {
+    // Confirm the handler hands the right date down by inspecting
+    // whichever side-effect we can observe — here, the handler logs
+    // an `archive_run_complete` line that includes the date.
+    const logs: unknown[] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((arg: unknown) => {
+      logs.push(arg);
+    });
+
+    const ctx = makeCtx();
+    let promise: Promise<unknown> | undefined;
+    ctx.waitUntil.mockImplementation((p: Promise<unknown>) => {
+      promise = p;
+    });
+    // 02:00 UTC tick — yesterday is 2026-05-03.
+    const controller = controllerAt("2026-05-04T02:00:00Z");
+    // biome-ignore lint/suspicious/noExplicitAny: ScheduledController shape mismatch
+    await scheduled(controller as any, env, ctx as any);
+    await promise;
+
+    spy.mockRestore();
+    const completion = logs.find(
+      (entry): entry is { event: string; date: string } =>
+        typeof entry === "object" &&
+        entry !== null &&
+        (entry as { event?: unknown }).event === "archive_run_complete",
+    );
+    expect(completion?.date).toBe("2026-05-03");
+  });
+});

--- a/apps/worker/src/__tests__/wiki-backend.test.ts
+++ b/apps/worker/src/__tests__/wiki-backend.test.ts
@@ -10,6 +10,7 @@ import {
   KvWikiBackend,
   type WikiBackend,
   type WikiPageRecord,
+  isWriteFilePathAllowed,
 } from "../lib/wiki-backend.js";
 
 async function clearKv(): Promise<void> {
@@ -77,5 +78,60 @@ describe.each(cases)("$name conforms to WikiBackend contract", ({ make, cleanup 
     await backend.write({ path: "/wiki/a.md", raw: "a", sha: "1" });
     await backend.write({ path: "/wiki/concepts/c.md", raw: "c", sha: "1" });
     expect(await backend.listPaths()).toEqual(["/wiki/a.md", "/wiki/b.md", "/wiki/concepts/c.md"]);
+  });
+
+  it("writeFile materializes a /rooms/** path and computes the sha", async () => {
+    const path = "/rooms/general/log/2026-05-03.md";
+    const content = "frontmatter\n---\n## 14:32 alice\n\nhi\n";
+    const result = await backend.writeFile(path, content);
+    expect(result.sha).toMatch(/^[0-9a-f]{64}$/);
+    const round = await backend.read(path);
+    expect(round?.raw).toBe(content);
+    expect(round?.sha).toBe(result.sha);
+  });
+
+  it("writeFile produces byte-identical output on a re-write of the same content", async () => {
+    const path = "/rooms/general/log/2026-05-03.md";
+    const content = "stable content\n";
+    const a = await backend.writeFile(path, content);
+    const b = await backend.writeFile(path, content);
+    expect(a.sha).toBe(b.sha);
+    expect((await backend.read(path))?.raw).toBe(content);
+  });
+
+  it("writeFile rejects a path outside the /wiki|/rooms allowlist", async () => {
+    await expect(backend.writeFile("/AGENTS.md", "x")).rejects.toThrow(/allowlist|outside/i);
+    await expect(backend.writeFile("/etc/passwd.md", "x")).rejects.toThrow();
+    await expect(backend.writeFile("/wiki/../escape.md", "x")).rejects.toThrow();
+    await expect(backend.writeFile("/rooms//double.md", "x")).rejects.toThrow();
+  });
+
+  it("listPaths excludes /rooms/** chat-log entries (regression: wiki-tree leak)", async () => {
+    // M5 stores chat logs at `/rooms/<slug>/log/<date>.md` via
+    // writeFile; the KV layer shares a prefix with /wiki/** entries.
+    // listPaths must filter so the wiki tree only contains wiki pages.
+    await backend.write({ path: "/wiki/concepts/dmarc.md", raw: "x", sha: "1" });
+    await backend.writeFile("/rooms/general/log/2026-05-03.md", "log content\n");
+    const paths = await backend.listPaths();
+    expect(paths).toEqual(["/wiki/concepts/dmarc.md"]);
+    // Sanity: the chat log is still readable directly.
+    expect((await backend.read("/rooms/general/log/2026-05-03.md"))?.raw).toBe("log content\n");
+  });
+});
+
+describe("isWriteFilePathAllowed", () => {
+  it("accepts /wiki/** and /rooms/** markdown paths", () => {
+    expect(isWriteFilePathAllowed("/wiki/_index.md")).toBe(true);
+    expect(isWriteFilePathAllowed("/wiki/concepts/dmarc.md")).toBe(true);
+    expect(isWriteFilePathAllowed("/rooms/general/log/2026-05-03.md")).toBe(true);
+  });
+
+  it("rejects everything else", () => {
+    expect(isWriteFilePathAllowed("/AGENTS.md")).toBe(false);
+    expect(isWriteFilePathAllowed("/wiki/Concepts.md")).toBe(false); // uppercase
+    expect(isWriteFilePathAllowed("/rooms/general/log/2026-05-03")).toBe(false); // no .md
+    expect(isWriteFilePathAllowed("/rooms/../escape.md")).toBe(false);
+    expect(isWriteFilePathAllowed("/wiki//double.md")).toBe(false);
+    expect(isWriteFilePathAllowed("")).toBe(false);
   });
 });

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 
+import type { ExportedHandler } from "@cloudflare/workers-types";
 import { ErrorCodes, apiErr } from "@loomwiki/shared";
 import { Hono } from "hono";
 import type { Env } from "./env.js";
 import { type AuthEnv, authMiddleware } from "./middleware/auth.js";
 import { registerErrorHandler } from "./middleware/error.js";
 import { debugRoute } from "./routes/_debug.js";
+import { adminCronRoute } from "./routes/admin-cron.js";
 import { healthRoute } from "./routes/health.js";
 import { meRoute } from "./routes/me.js";
 import { roomsRoute } from "./routes/rooms.js";
 import { wikiRoute } from "./routes/wiki.js";
 import { workspacesRoute } from "./routes/workspaces.js";
+import { scheduled } from "./scheduled.js";
 
 export { ChatRoom } from "./do/ChatRoom.js";
 
@@ -28,6 +31,7 @@ app.use("/api/rooms/*", authMiddleware);
 app.use("/api/wiki/*", authMiddleware);
 app.use("/api/wiki-tree", authMiddleware);
 app.use("/api/_admin/wiki/*", authMiddleware);
+app.use("/api/_admin/cron/*", authMiddleware);
 
 app.route("/api/me", meRoute);
 app.route("/api/workspaces", workspacesRoute);
@@ -36,6 +40,10 @@ app.route("/api/rooms", roomsRoute);
 // /_admin/wiki/* paths can be defined in one place. Mounting at the
 // root means the route handlers can use the absolute paths above.
 app.route("/api", wikiRoute);
+// Admin-cron routes (M5: chat-log archival backfill) — workspace-owner
+// only, enforced inside the route handler. Mounted at /api so the
+// route handler defines the absolute path.
+app.route("/api", adminCronRoute);
 
 app.notFound((c) =>
   c.json(apiErr(ErrorCodes.NOT_FOUND, `No route for ${c.req.method} ${c.req.path}`), 404),
@@ -43,4 +51,9 @@ app.notFound((c) =>
 
 registerErrorHandler(app);
 
-export default app;
+const handler: ExportedHandler<Env> = {
+  fetch: app.fetch.bind(app),
+  scheduled,
+};
+
+export default handler;

--- a/apps/worker/src/lib/chat-log.ts
+++ b/apps/worker/src/lib/chat-log.ts
@@ -1,0 +1,400 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Daily chat-log archival (M5). Aggregates the previous day's messages
+// per room from D1 and writes one markdown file per room to the vault
+// at `/rooms/{slug}/log/{YYYY-MM-DD}.md`.
+//
+// Why this lives here and not in routes/: the same orchestration is
+// invoked from two places — the cron `scheduled()` handler (autopilot)
+// and the admin route POST /api/_admin/cron/archive-day (operator
+// backfill / verification). Keeping the logic in `lib/` lets both call
+// sites share the same code path.
+//
+// Idempotency model: path-based, not bookkeeping-based. There is no
+// `archive_runs` table. A re-run for the same date overwrites the file
+// with the same content (UUIDv7 IDs sort stably + deterministic
+// formatter ⇒ byte-identical output for unchanged input).
+//
+// Frontmatter contract (read by the M7 ingest agent on every run):
+//   room:            <slug>
+//   date:            YYYY-MM-DD
+//   message_count:   integer
+//   ingest_run_ids:  []      ← M7 appends and re-writes the file
+//
+// Per-room failure isolation: one room's archival error does NOT block
+// the rest. Errors are logged to console and surfaced in the result.
+
+import type { Env } from "../env.js";
+import { KvWikiBackend, type WikiBackend, isWriteFilePathAllowed } from "./wiki-backend.js";
+
+// --------------------------------------------------------------------
+// Types
+// --------------------------------------------------------------------
+
+/** A message row as we read it from D1 for archival. */
+export interface ArchivableMessage {
+  id: string;
+  room_id: string;
+  user_id: string;
+  body: string;
+  created_at: number;
+  edited_at: number | null;
+  deleted_at: number | null;
+}
+
+export interface ArchiveError {
+  room_id: string;
+  room_slug?: string;
+  message: string;
+}
+
+export interface ArchiveDaySummary {
+  date: string;
+  files_written: number;
+  rooms_processed: number;
+  errors: ArchiveError[];
+}
+
+// --------------------------------------------------------------------
+// Path helpers
+// --------------------------------------------------------------------
+
+// Slug rules mirror SlugSchema in @loomwiki/schema (kebab-case ASCII,
+// 1..60 chars). Date is YYYY-MM-DD with no calendar validation here —
+// the caller produces dates from `Date#toISOString` so the shape is
+// guaranteed.
+const CHAT_LOG_PATH_REGEX = /^\/rooms\/[a-z][a-z0-9-]{0,59}\/log\/\d{4}-\d{2}-\d{2}\.md$/;
+
+export function validateChatLogPath(path: string): boolean {
+  if (typeof path !== "string" || path.length === 0 || path.length > 256) return false;
+  if (path.includes("..") || path.includes("//")) return false;
+  return CHAT_LOG_PATH_REGEX.test(path);
+}
+
+export function formatChatLogPath(roomSlug: string, dateUtc: string): string {
+  return `/rooms/${roomSlug}/log/${dateUtc}.md`;
+}
+
+// --------------------------------------------------------------------
+// Date helpers
+// --------------------------------------------------------------------
+
+const ISO_DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isValidIsoDate(s: string): boolean {
+  if (typeof s !== "string" || !ISO_DATE_REGEX.test(s)) return false;
+  const d = new Date(`${s}T00:00:00Z`);
+  if (Number.isNaN(d.getTime())) return false;
+  return d.toISOString().slice(0, 10) === s;
+}
+
+/**
+ * Compute the previous-UTC-day from a `scheduledTime` (epoch ms).
+ *
+ * "Previous day" is *always* the calendar day before the scheduled
+ * time's UTC date — independent of *when* during that day the cron
+ * fired. We do this by:
+ *   1. Slicing the scheduled time's UTC date (today).
+ *   2. Subtracting 1 ms from the start of today, which lands at
+ *      23:59:59.999 of yesterday in UTC.
+ *   3. Slicing that to YYYY-MM-DD.
+ *
+ * This is equivalent to subtracting 86_400_000 ms when scheduledTime
+ * is exactly midnight UTC, but the start-of-today anchor makes the
+ * function correct for any time-of-day input — the production cron
+ * fires at 02:00 UTC, but the admin route accepts arbitrary dates so
+ * we don't want this helper to silently misbehave for off-hour calls.
+ * UTC has no DST, so this is also the simplest way to dodge any
+ * localtime correctness traps.
+ */
+export function previousUtcDayFromScheduledTime(scheduledTimeMs: number): string {
+  const today = new Date(scheduledTimeMs).toISOString().slice(0, 10);
+  const yesterdayMs = Date.parse(`${today}T00:00:00Z`) - 1;
+  return new Date(yesterdayMs).toISOString().slice(0, 10);
+}
+
+/**
+ * Return the [start, end) epoch-second range that covers a given UTC date.
+ * `end` is exclusive (next day's 00:00:00Z).
+ */
+export function dayBoundsUtc(dateUtc: string): { startSec: number; endSec: number } {
+  if (!isValidIsoDate(dateUtc)) {
+    throw new Error(`dayBoundsUtc: not a valid YYYY-MM-DD string: ${dateUtc}`);
+  }
+  const startMs = Date.parse(`${dateUtc}T00:00:00Z`);
+  const endMs = startMs + 86_400_000;
+  return { startSec: Math.floor(startMs / 1000), endSec: Math.floor(endMs / 1000) };
+}
+
+// --------------------------------------------------------------------
+// Markdown formatting
+// --------------------------------------------------------------------
+
+const TOMBSTONE_BODY = "[deleted]";
+const DELETED_USER_DISPLAY = "<deleted user>";
+
+interface FormatChatLogContentArgs {
+  roomSlug: string;
+  dateUtc: string;
+  messages: ArchivableMessage[];
+  displayNamesById: ReadonlyMap<string, string>;
+}
+
+/**
+ * Render the full markdown file (frontmatter + body) for one room/day.
+ * Returns `null` for an empty message list — the caller skips the
+ * write so empty days produce no file (per resolved decision). Throws
+ * via `null` rather than via a thrown error so the no-work path is
+ * cheap and explicit.
+ */
+export function formatChatLogContent(args: FormatChatLogContentArgs): string | null {
+  if (args.messages.length === 0) return null;
+
+  // Defensive sort. The D1 query already orders by created_at, id —
+  // re-sorting here in the formatter means the function is correct
+  // regardless of caller and keeps the output byte-stable.
+  const sorted = [...args.messages].sort((a, b) => {
+    if (a.created_at !== b.created_at) return a.created_at - b.created_at;
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+  });
+
+  const frontmatter = formatFrontmatter({
+    roomSlug: args.roomSlug,
+    dateUtc: args.dateUtc,
+    messageCount: sorted.length,
+  });
+
+  const blocks: string[] = [];
+  for (const m of sorted) {
+    const time = formatTimeUtc(m.created_at);
+    const name = args.displayNamesById.get(m.user_id) ?? DELETED_USER_DISPLAY;
+    const body = m.deleted_at !== null ? TOMBSTONE_BODY : m.body;
+    blocks.push(`## ${time} ${name}\n\n${body}`);
+  }
+
+  // Two newlines between blocks; one trailing newline at EOF (POSIX).
+  return `${frontmatter}\n${blocks.join("\n\n")}\n`;
+}
+
+function formatFrontmatter(args: {
+  roomSlug: string;
+  dateUtc: string;
+  messageCount: number;
+}): string {
+  // Hand-emitted YAML keeps the output byte-stable across runs and
+  // sidesteps gray-matter's habit of round-tripping date scalars
+  // through JS Date. The chat-log frontmatter shape is fixed and the
+  // values are constrained (slug regex, ISO date regex, integer) so
+  // no escape paths can fire.
+  return [
+    "---",
+    `room: ${args.roomSlug}`,
+    `date: ${args.dateUtc}`,
+    `message_count: ${args.messageCount}`,
+    "ingest_run_ids: []",
+    "---",
+    "",
+  ].join("\n");
+}
+
+function formatTimeUtc(epochSeconds: number): string {
+  const d = new Date(epochSeconds * 1000);
+  const hh = d.getUTCHours().toString().padStart(2, "0");
+  const mm = d.getUTCMinutes().toString().padStart(2, "0");
+  return `${hh}:${mm}`;
+}
+
+// --------------------------------------------------------------------
+// Orchestration
+// --------------------------------------------------------------------
+
+interface ArchiveDayArgs {
+  env: Env;
+  dateUtc: string;
+  /** Optional injection point for tests. Defaults to KvWikiBackend(env.WIKI_KV). */
+  backend?: WikiBackend;
+}
+
+/**
+ * Aggregate messages for `dateUtc` from D1, group by room, and write
+ * one log file per room. Returns a summary of what happened. Never
+ * throws on a per-room failure — those land in `summary.errors`.
+ *
+ * Top-level errors (D1 unreachable, bad date) DO throw, since they
+ * indicate the cron/admin call cannot make progress at all.
+ */
+export async function archiveDay(args: ArchiveDayArgs): Promise<ArchiveDaySummary> {
+  if (!isValidIsoDate(args.dateUtc)) {
+    throw new Error(`archiveDay: invalid date "${args.dateUtc}" — expected YYYY-MM-DD`);
+  }
+  const backend = args.backend ?? defaultBackendForArchive(args.env);
+  const { startSec, endSec } = dayBoundsUtc(args.dateUtc);
+
+  const messages = await fetchMessages(args.env, startSec, endSec);
+
+  // Group by room_id, preserving the per-room insertion order (which
+  // already matches created_at, id from the SQL ORDER BY).
+  const byRoom = new Map<string, ArchivableMessage[]>();
+  for (const m of messages) {
+    let bucket = byRoom.get(m.room_id);
+    if (!bucket) {
+      bucket = [];
+      byRoom.set(m.room_id, bucket);
+    }
+    bucket.push(m);
+  }
+
+  if (byRoom.size === 0) {
+    return {
+      date: args.dateUtc,
+      files_written: 0,
+      rooms_processed: 0,
+      errors: [],
+    };
+  }
+
+  const roomIds = [...byRoom.keys()];
+  const userIds = uniqueUserIds(messages);
+
+  const [roomSlugs, displayNames] = await Promise.all([
+    fetchRoomSlugs(args.env, roomIds),
+    fetchDisplayNames(args.env, userIds),
+  ]);
+
+  const errors: ArchiveError[] = [];
+  let filesWritten = 0;
+
+  for (const [roomId, roomMessages] of byRoom) {
+    const slug = roomSlugs.get(roomId);
+    if (!slug) {
+      errors.push({
+        room_id: roomId,
+        message: "Room slug not found in D1; room may have been deleted between query and archive",
+      });
+      continue;
+    }
+    try {
+      const wrote = await archiveRoomDay({
+        backend,
+        roomSlug: slug,
+        dateUtc: args.dateUtc,
+        messages: roomMessages,
+        displayNamesById: displayNames,
+      });
+      if (wrote) filesWritten += 1;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error({
+        event: "archive_room_failed",
+        room_id: roomId,
+        room_slug: slug,
+        date: args.dateUtc,
+        error: message,
+      });
+      errors.push({ room_id: roomId, room_slug: slug, message });
+    }
+  }
+
+  return {
+    date: args.dateUtc,
+    files_written: filesWritten,
+    rooms_processed: byRoom.size,
+    errors,
+  };
+}
+
+interface ArchiveRoomDayArgs {
+  backend: WikiBackend;
+  roomSlug: string;
+  dateUtc: string;
+  messages: ArchivableMessage[];
+  displayNamesById: ReadonlyMap<string, string>;
+}
+
+/**
+ * Write a single room's log file for the given day. Returns `true` if
+ * a file was written, `false` if the formatter produced no output
+ * (zero messages — a defensive check; archiveDay only calls this when
+ * the per-room bucket is non-empty).
+ */
+export async function archiveRoomDay(args: ArchiveRoomDayArgs): Promise<boolean> {
+  const path = formatChatLogPath(args.roomSlug, args.dateUtc);
+  if (!validateChatLogPath(path)) {
+    throw new Error(`archiveRoomDay: produced invalid path: ${path}`);
+  }
+  // Backend has its own union allowlist; this assertion catches any
+  // skew between the chat-log validator and the writeFile validator
+  // before we reach the network.
+  if (!isWriteFilePathAllowed(path)) {
+    throw new Error(`archiveRoomDay: path rejected by backend allowlist: ${path}`);
+  }
+  const content = formatChatLogContent({
+    roomSlug: args.roomSlug,
+    dateUtc: args.dateUtc,
+    messages: args.messages,
+    displayNamesById: args.displayNamesById,
+  });
+  if (content === null) return false;
+  await args.backend.writeFile(path, content);
+  return true;
+}
+
+// --------------------------------------------------------------------
+// D1 helpers
+// --------------------------------------------------------------------
+
+async function fetchMessages(
+  env: Env,
+  startSec: number,
+  endSec: number,
+): Promise<ArchivableMessage[]> {
+  // idx_messages_room_created indexes (room_id, created_at). We range
+  // over created_at across all rooms; the index still helps because
+  // D1 (SQLite) can use a covering scan, and POC scale keeps this
+  // well under any practical row budget.
+  const rs = await env.DB.prepare(
+    `SELECT id, room_id, user_id, body, created_at, edited_at, deleted_at
+       FROM messages
+      WHERE created_at >= ? AND created_at < ?
+      ORDER BY created_at, id`,
+  )
+    .bind(startSec, endSec)
+    .all();
+  return (rs.results ?? []) as unknown as ArchivableMessage[];
+}
+
+function uniqueUserIds(messages: ArchivableMessage[]): string[] {
+  const set = new Set<string>();
+  for (const m of messages) set.add(m.user_id);
+  return [...set];
+}
+
+async function fetchRoomSlugs(env: Env, roomIds: string[]): Promise<Map<string, string>> {
+  if (roomIds.length === 0) return new Map();
+  const placeholders = roomIds.map(() => "?").join(",");
+  const rs = await env.DB.prepare(`SELECT id, slug FROM rooms WHERE id IN (${placeholders})`)
+    .bind(...roomIds)
+    .all();
+  const out = new Map<string, string>();
+  const rows = (rs.results ?? []) as unknown as { id: string; slug: string }[];
+  for (const row of rows) out.set(row.id, row.slug);
+  return out;
+}
+
+async function fetchDisplayNames(env: Env, userIds: string[]): Promise<Map<string, string>> {
+  if (userIds.length === 0) return new Map();
+  const placeholders = userIds.map(() => "?").join(",");
+  const rs = await env.DB.prepare(
+    `SELECT id, display_name FROM users WHERE id IN (${placeholders})`,
+  )
+    .bind(...userIds)
+    .all();
+  const out = new Map<string, string>();
+  const rows = (rs.results ?? []) as unknown as { id: string; display_name: string }[];
+  for (const row of rows) out.set(row.id, row.display_name);
+  return out;
+}
+
+function defaultBackendForArchive(env: Env): WikiBackend {
+  return new KvWikiBackend(env.WIKI_KV);
+}

--- a/apps/worker/src/lib/wiki-backend.ts
+++ b/apps/worker/src/lib/wiki-backend.ts
@@ -18,6 +18,23 @@ import type { KVNamespace } from "@cloudflare/workers-types";
 
 const KV_PREFIX = "wiki:";
 
+// listPaths() filters down to entries that begin with `/wiki/`. M5
+// added writeFile for non-wiki paths (e.g. `/rooms/<slug>/log/...`)
+// stored under the same KV prefix; without the filter, those paths
+// would leak into `GET /api/wiki-tree` and the wiki UI would try to
+// render them as wiki pages and hit a 400 from validateWikiPath.
+const WIKI_PATH_PREFIX = "/wiki/";
+
+// Defense-in-depth path filter for writeFile. The wiki API uses
+// validateWikiPath (anchored to /wiki/**); the M5 chat-log module uses
+// its own tighter regex (anchored to /rooms/<slug>/log/<date>.md). The
+// backend accepts the union of both prefixes — anything else is a bug
+// in the caller and the backend refuses to materialize it. This guards
+// the eventual M4.5 git backend from being asked to write `/AGENTS.md`,
+// `/etc/passwd`, or a path with `..` if a future caller forgets to
+// validate first.
+const WRITE_FILE_PATH_REGEX = /^\/(wiki|rooms)\/[a-z0-9_][a-z0-9_/-]*\.md$/;
+
 export interface WikiPageRecord {
   /** Path under the vault, e.g. `/wiki/concepts/dmarc.md`. */
   path: string;
@@ -49,10 +66,44 @@ export interface WikiBackend {
   delete(path: string): Promise<void>;
 
   /**
-   * List all page paths the backend knows about, sorted ascending.
-   * Used by the wiki-tree route. POC scale, no pagination.
+   * List page paths under `/wiki/`, sorted ascending. Used by the
+   * wiki-tree route. POC scale, no pagination. Implementations MUST
+   * exclude non-wiki entries (e.g. M5's `/rooms/**` chat logs that
+   * share the underlying KV prefix) so the tree only contains pages
+   * the wiki API can serve.
    */
   listPaths(): Promise<string[]>;
+
+  /**
+   * Write a non-wiki vault file (M5 chat logs, future: top-level
+   * /AGENTS.md). Computes the SHA from `content` itself and stores
+   * both. Rejects any path outside the {/wiki, /rooms} union with a
+   * thrown Error — callers MUST pre-validate with their own
+   * tighter validator (e.g. `validateChatLogPath`); this method is
+   * only a defense-in-depth backstop, not the primary gate.
+   */
+  writeFile(path: string, content: string): Promise<{ sha: string }>;
+}
+
+export function isWriteFilePathAllowed(path: string): boolean {
+  if (typeof path !== "string" || path.length === 0 || path.length > 256) return false;
+  if (path.includes("..") || path.includes("//")) return false;
+  return WRITE_FILE_PATH_REGEX.test(path);
+}
+
+function assertWriteFilePathAllowed(path: string): void {
+  if (!isWriteFilePathAllowed(path)) {
+    throw new Error(`writeFile rejected path outside /wiki|/rooms allowlist: ${path}`);
+  }
+}
+
+async function sha256Hex(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  const buf = await crypto.subtle.digest("SHA-256", data);
+  const bytes = new Uint8Array(buf);
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
 }
 
 // ---------- KV-backed implementation ----------
@@ -85,18 +136,29 @@ export class KvWikiBackend implements WikiBackend {
 
   async listPaths(): Promise<string[]> {
     // KV list is paginated under the hood. Loop until cursor is gone.
+    // We list under the broader `wiki:` prefix (which also stores
+    // M5's `/rooms/**` chat logs) and filter to `/wiki/**` so the
+    // wiki-tree route only ever sees wiki pages.
     const out: string[] = [];
     let cursor: string | undefined;
     do {
       const page: { keys: { name: string }[]; list_complete: boolean; cursor?: string } =
         await this.kv.list({ prefix: KV_PREFIX, cursor });
       for (const k of page.keys) {
-        out.push(k.name.slice(KV_PREFIX.length));
+        const path = k.name.slice(KV_PREFIX.length);
+        if (path.startsWith(WIKI_PATH_PREFIX)) out.push(path);
       }
       cursor = page.list_complete ? undefined : page.cursor;
     } while (cursor !== undefined);
     out.sort();
     return out;
+  }
+
+  async writeFile(path: string, content: string): Promise<{ sha: string }> {
+    assertWriteFilePathAllowed(path);
+    const sha = await sha256Hex(content);
+    await this.kv.put(KV_PREFIX + path, content, { metadata: { sha } });
+    return { sha };
   }
 }
 
@@ -118,7 +180,14 @@ export class InMemoryWikiBackend implements WikiBackend {
   }
 
   async listPaths(): Promise<string[]> {
-    return [...this.store.keys()].sort();
+    return [...this.store.keys()].filter((p) => p.startsWith(WIKI_PATH_PREFIX)).sort();
+  }
+
+  async writeFile(path: string, content: string): Promise<{ sha: string }> {
+    assertWriteFilePathAllowed(path);
+    const sha = await sha256Hex(content);
+    this.store.set(path, { path, raw: content, sha });
+    return { sha };
   }
 
   /** Test helper: total page count. */

--- a/apps/worker/src/routes/admin-cron.ts
+++ b/apps/worker/src/routes/admin-cron.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Operator-facing admin route to invoke the chat-log archival cron
+// for an explicit date. Used for backfill, smoke verification, and
+// re-archiving after a vault reset. Same code path as scheduled().
+//
+// POST /api/_admin/cron/archive-day?date=YYYY-MM-DD
+//   Owner-only. Returns ApiResult<ArchiveDaySummary>.
+
+import { ErrorCodes, LoomwikiError, apiOk } from "@loomwiki/shared";
+import { Hono } from "hono";
+import { archiveDay, isValidIsoDate } from "../lib/chat-log.js";
+import type { AuthEnv } from "../middleware/auth.js";
+
+function requireOwner(c: { var: { user: { id: string }; workspace: { owner_id: string } } }): void {
+  if (c.var.workspace.owner_id !== c.var.user.id) {
+    throw new LoomwikiError(ErrorCodes.FORBIDDEN, "Workspace owner only", { status: 403 });
+  }
+}
+
+export const adminCronRoute = new Hono<AuthEnv>().post("/_admin/cron/archive-day", async (c) => {
+  requireOwner(c);
+  const date = c.req.query("date");
+  if (!date || !isValidIsoDate(date)) {
+    throw new LoomwikiError(
+      ErrorCodes.VALIDATION_FAILED,
+      "Query param `date` must be a valid YYYY-MM-DD string",
+      { status: 400 },
+    );
+  }
+  const summary = await archiveDay({ env: c.env, dateUtc: date });
+  return c.json(apiOk(summary));
+});

--- a/apps/worker/src/scheduled.ts
+++ b/apps/worker/src/scheduled.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Cron handler entry point. Wired into the default export of
+// apps/worker/src/index.ts as `scheduled` alongside `fetch`.
+//
+// Schedule: 02:00 UTC daily — declared in wrangler.jsonc under
+// `triggers.crons`. The handler computes the previous UTC day from
+// `controller.scheduledTime` and invokes archiveDay() to materialize a
+// log file per active room into the vault.
+//
+// Why ctx.waitUntil: the runtime may otherwise short-circuit the
+// invocation when the synchronous body returns. archiveDay() is
+// long-lived (D1 query + N KV writes); waitUntil keeps the isolate
+// alive until the work settles.
+
+import type { ExecutionContext, ScheduledController } from "@cloudflare/workers-types";
+import type { Env } from "./env.js";
+import { archiveDay, previousUtcDayFromScheduledTime } from "./lib/chat-log.js";
+
+export async function scheduled(
+  controller: ScheduledController,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<void> {
+  const dateUtc = previousUtcDayFromScheduledTime(controller.scheduledTime);
+  ctx.waitUntil(runArchive(env, dateUtc, controller.cron));
+}
+
+async function runArchive(env: Env, dateUtc: string, cron: string): Promise<void> {
+  const startedAt = Date.now();
+  try {
+    const summary = await archiveDay({ env, dateUtc });
+    const durationMs = Date.now() - startedAt;
+    console.log({
+      event: "archive_run_complete",
+      cron,
+      date: dateUtc,
+      rooms_processed: summary.rooms_processed,
+      files_written: summary.files_written,
+      error_count: summary.errors.length,
+      duration_ms: durationMs,
+    });
+  } catch (err) {
+    const durationMs = Date.now() - startedAt;
+    const message = err instanceof Error ? err.message : String(err);
+    console.error({
+      event: "archive_run_failed",
+      cron,
+      date: dateUtc,
+      duration_ms: durationMs,
+      error: message,
+    });
+    // Re-throw so Workers Logs marks the cron run as failed and
+    // observability surfaces the error. waitUntil swallows the throw
+    // for the request lifecycle but the runtime still flags the run.
+    throw err;
+  }
+}

--- a/wrangler.dev.jsonc
+++ b/wrangler.dev.jsonc
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Local-dev wrangler config. Mirrors wrangler.jsonc for everything that
+// `wrangler dev` exercises locally, but OMITS the Artifacts binding —
+// Artifacts is "remote-only" (no Miniflare emulator) and operator
+// accounts that lack the Cloudflare Artifacts allowlist cannot start a
+// remote-proxy session, which fails the dev boot for everyone else.
+//
+// What this means for local dev:
+//   - All M0–M3 paths work (auth, rooms, chat, messages).
+//   - M5 chat-log archival works (cron + admin route — uses WIKI_KV
+//     directly, doesn't touch Artifacts).
+//   - The M4 wiki R/W routes also work because page storage lives in
+//     WIKI_KV, NOT in Artifacts.
+//   - The two M4 admin routes that do touch Artifacts —
+//     POST /api/_admin/wiki/bootstrap-vault and
+//     POST /api/_admin/wiki/vault-token — will 500 with `env.ARTIFACTS
+//     undefined`. Use vitest (which provides a fake binding) for those
+//     paths, or run against a Cloudflare account that has Artifacts
+//     enabled via `wrangler dev --config ../../wrangler.jsonc --remote`.
+//
+// Production deploys MUST use wrangler.jsonc — never this file. The
+// `pnpm deploy` script enforces that by passing --config wrangler.jsonc
+// explicitly.
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "loomwiki-api",
+  "main": "apps/worker/src/index.ts",
+  "compatibility_date": "2026-04-22",
+  "compatibility_flags": ["nodejs_compat"],
+  "workers_dev": false,
+  "durable_objects": {
+    "bindings": [{ "name": "CHAT_ROOM", "class_name": "ChatRoom" }]
+  },
+  "migrations": [{ "tag": "v1", "new_sqlite_classes": ["ChatRoom"] }],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "loomwiki",
+      "database_id": "<TBD>",
+      "migrations_dir": "packages/schema/d1-migrations"
+    }
+  ],
+  "r2_buckets": [{ "binding": "ATTACHMENTS", "bucket_name": "loomwiki-attachments" }],
+  "kv_namespaces": [{ "binding": "CACHE", "id": "<TBD>" }, { "binding": "WIKI_KV", "id": "<TBD>" }],
+  "ai": { "binding": "AI" },
+  "version_metadata": { "binding": "CF_VERSION_METADATA" },
+  "vars": {
+    "WORKSPACE_NAME": "default",
+    "DEFAULT_LLM_MODEL": "@cf/meta/llama-3.3-70b-instruct-fp8-fast",
+    "EMBEDDING_MODEL": "@cf/baai/bge-base-en-v1.5",
+    "ARTIFACTS_REPO": "loomwiki-vault",
+    "AI_SEARCH_INSTANCE": "loomwiki-search",
+    "ACCESS_TEAM": "loomwiki-dev",
+    "ACCESS_AUD": "loomwiki-dev-aud",
+    "ALLOW_LOCAL_DEV_AUTH": "false",
+    "LOCAL_DEV_EMAIL": ""
+  },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1.0
+  },
+  "triggers": {
+    "crons": ["0 2 * * *"]
+  }
+}


### PR DESCRIPTION
## Summary

- Cron handler at 02:00 UTC daily aggregates the previous calendar day's messages from D1 into one markdown file per active room at `/rooms/{slug}/log/{YYYY-MM-DD}.md` in the vault.
- Reuses the M4 `WikiBackend` interface via a new `writeFile(path, content)` method — when M4.5 swaps `KvWikiBackend` for git, chat logs ride along with zero M5-side rework.
- Adds workspace-owner-only `POST /api/_admin/cron/archive-day?date=YYYY-MM-DD` for operator backfill and verification; same code path as the cron.
- Idempotent: re-running for the same date overwrites byte-identically (deterministic formatter + UUIDv7 ordering).

Closes #8

## Cron attestation

- Schedule unchanged in `wrangler.jsonc`: `"crons": ["0 2 * * *"]`.
- New entry point [`apps/worker/src/scheduled.ts`](apps/worker/src/scheduled.ts) wired into the worker default export at [`apps/worker/src/index.ts`](apps/worker/src/index.ts) (now an `ExportedHandler<Env>` with both `fetch` and `scheduled`).
- Handler uses `ctx.waitUntil(...)` so the runtime keeps the isolate alive past the synchronous return.

## Date arithmetic

> ⚠️ **Deviation from spec:** the spec text prescribed `new Date(scheduledTime - 1).toISOString().slice(0, 10)`. That's only correct for ticks at-or-before midnight UTC; for the actual 02:00 UTC schedule it returns *today*, not yesterday.

The implementation in [`previousUtcDayFromScheduledTime`](apps/worker/src/lib/chat-log.ts) instead:
1. Slices today's UTC date from `scheduledTime`,
2. Subtracts 1 ms from start-of-today (lands at 23:59:59.999 of yesterday),
3. Slices that to `YYYY-MM-DD`.

This is time-of-day agnostic, dodges any localtime/DST traps (UTC has no DST), and produces yesterday for any input. Tests in [`chat-log.test.ts`](apps/worker/src/__tests__/chat-log.test.ts) cover the 02:00 case, the midnight-boundary case, and a late-day tick.

## Idempotency attestation

- Path-based, no `archive_runs` table.
- Formatter is deterministic: input messages are sorted by `(created_at, id)`, frontmatter is hand-emitted YAML, body blocks are byte-stable.
- `KvWikiBackend.writeFile` is last-write-wins and computes the SHA from the content itself.
- Two regression tests: `archiveDay` produces `first?.raw === second?.raw` on re-run, and the admin-cron integration test asserts `await env.WIKI_KV.get(...)` matches across calls.

## Backend leverage attestation

- M5 reuses the existing `WikiBackend` interface; the only addition is `writeFile(path, content)` — a higher-level API that takes raw content and computes the SHA. The existing `write(record)` is untouched.
- Backend has its own union allowlist regex (`^/(wiki|rooms)/[a-z0-9_][a-z0-9_/-]*\.md$`) plus traversal/double-slash checks, on top of the chat-log-specific `validateChatLogPath`. Tests confirm `/AGENTS.md`, `/etc/passwd.md`, `/wiki/../escape.md`, and `/rooms//double.md` are all rejected.
- `listPaths()` filters to `/wiki/**` so chat-log entries do not leak into the wiki tree (regression test added).
- M4.5 git swap stays a one-file change.

## D1 query — index honesty

The query is:

```sql
SELECT id, room_id, user_id, body, created_at, edited_at, deleted_at
  FROM messages
 WHERE created_at >= ? AND created_at < ?
 ORDER BY created_at, id
```

`idx_messages_room_created` is `(room_id, created_at)`; SQLite likely full-scans for this query because the leading column isn't in the WHERE. **Acceptable at POC scale**; switching to a per-room range query would change orchestration shape and is out of scope for v0.0.1.

## Per-room failure isolation

Each `archiveRoomDay` call is wrapped in try/catch inside `archiveDay`. Errors are logged with `console.error({ event: "archive_room_failed", ... })` and accumulated in `summary.errors`. Test [`archive-day.test.ts`](apps/worker/src/__tests__/archive-day.test.ts) drives this with a `FailingBackend` subclass that throws on `/rooms/general/...` writes; `random` still archives successfully.

## Tombstone interpretation

Tombstoned messages (`deleted_at IS NOT NULL`) render as `[deleted]` in the body. **No frontmatter metadata** is added for tombstones — the resolved-decisions table called for "a note in the metadata" but I read this as the tombstone marker itself (matching the M3 display) and surfacing it via the body keeps the per-message block shape uniform. Open to feedback.

## Out of scope

- Edit-history footnotes (post-edit body only)
- Compression / archival of older logs
- A new D1 audit table (explicit "no" decision)
- Re-archiving already-archived days from cron (only previous day; backfill is operator-triggered)
- Threading via `parent_id` in the markdown
- Sanitizing message body markdown (vault preserves raw)

## Test plan

- [x] `pnpm typecheck` clean across 5 packages
- [x] `pnpm lint` clean
- [x] `pnpm test` — worker 135 / web 71 / schema 15 / shared 18 = 239 passing (was 92+71+15+18 = 196 baseline; +43 worker tests for M5)
- [x] Worker-only changes; no `apps/web/**` modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)