### PR TITLE
M6: AI Search + /ask + 3-layer cost guards

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -320,6 +320,167 @@ curl -s "http://127.0.0.1:8788/__scheduled?cron=0+2+*+*+*"
 
 Watch `wrangler tail` for the `archive_run_complete` log line.
 
+## AI Search + /ask + cost guards (M6)
+
+M6 wires hybrid search over `/wiki/**` and the `/ask` RAG endpoint. Two
+pieces of operator setup beyond the standard deploy: provisioning the
+AI Search instance and configuring the AI Gateway daily cap.
+
+### 1. Provision the AI Search instance
+
+```sh
+# One-time per workspace deploy. The instance name is what
+# wrangler.jsonc references in the ai_search binding block.
+wrangler ai-search create loomwiki-search \
+  --data-source artifacts \
+  --filter "path: /wiki/**"
+```
+
+The dashboard equivalent: **AI → AI Search → Create instance →
+Source: Artifacts → Repo: <your loomwiki vault> → Filter: path glob
+`/wiki/**`**.
+
+After creation, the binding in `wrangler.jsonc` (`ai_search.binding =
+"AI_SEARCH"`, `instance_name = "loomwiki-search"`) wires it to the
+worker. Auto-detect: if the binding is missing or the instance name is
+wrong, search auto-falls-back to the D1 FTS5 index — the worker logs a
+warning and the web UI shows "Showing keyword matches only — semantic
+search is unavailable." See `docs/ADR/0004-search-rag-layering.md` for
+the rationale.
+
+### 2. Bootstrap the index
+
+After the AI Search instance is provisioned and the worker is deployed,
+trigger an initial index of the existing wiki via the admin route:
+
+```sh
+curl -s -X POST -H "X-Local-Dev-Email: cory@example.com" \
+  http://127.0.0.1:8788/api/_admin/search/reindex | jq .
+# Expected: { ok: true, data: { pages_indexed: N, errors: [] } }
+```
+
+In production, swap the dev header for the Access JWT from a
+workspace-owner browser session. The route walks
+`WikiBackend.listPaths('/wiki/')`, reads each page, and upserts it into
+both AI Search and the D1 FTS5 index. Per-page failures are logged but
+don't abort the whole run (matches the M5 archive isolation pattern).
+
+The route is idempotent — re-running it after a partial failure or
+schema migration is safe. Subsequent wiki edits via `PUT /api/wiki/*`
+re-upsert automatically; the admin route is only for backfill.
+
+### 3. Configure the AI Gateway daily cap (third layer of cost defense)
+
+The cost guards in `lib/cost-guard.ts` enforce per-user and
+per-workspace daily caps inside the worker. The third layer — a hard
+cap that survives a worker bug — lives in the AI Gateway dashboard:
+
+1. Open **AI → AI Gateway → Create gateway** (skip if you already
+   have one).
+2. Note the gateway slug (the path segment in
+   `https://gateway.ai.cloudflare.com/v1/{ACCOUNT_ID}/{SLUG}/...`).
+3. **Settings → Logs & Costs → Daily request cap**: set to the
+   per-deploy ceiling. Recommended starting value: **5000 ask
+   requests/day per workspace deploy**. Adjust to match the
+   per-workspace ask cap in `wrangler.jsonc` plus headroom for cache
+   hits and embedding calls.
+4. Set the gateway slug as `AI_GATEWAY_ID` and your account ID as
+   `CF_ACCOUNT_ID` in `wrangler.jsonc` `vars`. Without these, the
+   worker bypasses the gateway and you lose the third layer.
+5. Mint an AI Gateway token (**API tokens → Create token → Workers AI
+   → AI Gateway: Run**) and set it as a Worker secret:
+
+   ```sh
+   wrangler secret put AI_GATEWAY_TOKEN
+   ```
+
+The two in-worker layers (`LLM_DAILY_LIMIT_PER_USER_*` and
+`LLM_DAILY_LIMIT_PER_WORKSPACE_*` in `wrangler.jsonc` `vars`) plus the
+gateway cap give defense in depth — see ADR-0004 §c for why all three
+are necessary.
+
+### 4. Tune the daily limits
+
+```jsonc
+"vars": {
+  "LLM_DAILY_LIMIT_PER_USER_ASK": "100",
+  "LLM_DAILY_LIMIT_PER_USER_SEARCH": "1000",
+  "LLM_DAILY_LIMIT_PER_WORKSPACE_ASK": "1000",
+  "LLM_DAILY_LIMIT_PER_WORKSPACE_SEARCH": "10000"
+}
+```
+
+Defaults are conservative for a small dogfood team. Rate-limited
+requests get `429 RATE_LIMITED` with
+`details: { limit, used, scope, reset_at }`; the web UI's
+`RateLimitBanner` renders the localtime reset.
+
+### 5. (Optional) Force the FTS5 fallback
+
+```jsonc
+"vars": {
+  "AI_SEARCH_ENABLED": "false"
+}
+```
+
+Skips the AI Search call entirely and goes straight to the D1 FTS5
+index. Useful for comparing result quality, debugging an AI Search
+outage, or running a fork that doesn't have AI Search enabled.
+
+### Local-dev path
+
+Two important limitations:
+
+- **AI Search is remote-only.** Local dev (`wrangler dev` with
+  `wrangler.dev.jsonc`) doesn't define the `ai_search` binding; the
+  worker auto-detects the missing binding and silently falls back to
+  FTS5. Search results carry `mode: "fts5_fallback"` and the web UI
+  shows the fallback banner. To exercise the AI Search path live,
+  use `wrangler dev --remote --config wrangler.jsonc`.
+- **Workers AI hits the real service in dev.** Unlike Artifacts,
+  Workers AI dispatches to Cloudflare's real backend even in local
+  dev — `pnpm dev` against the default Llama model spends free-tier
+  neurons. The cost guards still apply. `lib/llm.ts` emits a one-time
+  warning the first time a non-BYOK call goes out so you don't
+  forget. To run dev with no LLM cost: set
+  `LLM_DAILY_LIMIT_PER_USER_ASK=0` to refuse all calls.
+
+### Smoke verification
+
+```sh
+# Bootstrap a small wiki via the M4 routes (or via the bootstrap-vault
+# admin route). Then:
+
+DEV_HEADER='X-Local-Dev-Email: cory@example.com'
+
+# Reindex (FTS5 always; AI Search if available):
+curl -s -X POST -H "$DEV_HEADER" \
+  http://127.0.0.1:8788/api/_admin/search/reindex | jq .
+
+# Search:
+curl -s -X POST -H "$DEV_HEADER" -H "Content-Type: application/json" \
+  -d '{"query":"DMARC","topK":5}' \
+  http://127.0.0.1:8788/api/search | jq .
+# Local dev expected: { ok: true, data: { results: [...], mode: "fts5_fallback" } }
+# Prod expected:      { ok: true, data: { results: [...], mode: "hybrid" } }
+
+# /ask (SSE — note -N to disable curl buffering):
+curl -N -X POST -H "$DEV_HEADER" -H "Content-Type: application/json" \
+  -d '{"question":"What is our DMARC policy?"}' \
+  http://127.0.0.1:8788/api/ask
+# Expected: streaming SSE; data lines with "delta", then `event: citations`
+# carrying the citation array, then `event: done`.
+```
+
+The cost-guard 429 is reachable by lowering the per-user cap to a
+small number and calling /ask repeatedly:
+
+```sh
+# After exceeding the cap:
+# {"ok":false,"error":{"code":"RATE_LIMITED","message":"...",
+#   "details":{"limit":2,"used":2,"scope":"user","reset_at":"..."}}}
+```
+
 ## Right-to-deletion (operator note)
 
 Chat messages can be soft-deleted from D1 and the live DO. They cannot be

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -208,3 +208,73 @@ write `../../components/...`.
 - Hook tests: use `renderHook`. For chat-style hooks that own
   long-lived sockets, inject a fake via the `createClient` option to
   drive open/close/server events directly (see `useChat.test.tsx`).
+
+## Search + Ask (M6)
+
+The header carries a global search box; `/search` is the full-page
+version; `/ask` is the streamed-answer surface.
+
+- **SearchBar** ([src/components/search/SearchBar.tsx](src/components/search/SearchBar.tsx))
+  hydrates `client:idle` (deferred until the active surface settles).
+  - Hotkey: `⌘K` / `Ctrl+K` focuses the input from anywhere on the page.
+  - Debounced 200ms; cancels stale in-flight responses via a sequence
+    counter so a slow first request can't overwrite a faster second.
+  - Esc closes the dropdown; click-outside also closes.
+  - Click → `/w/<slug>` navigation (full-page nav, not SPA).
+- **SearchPage** ([src/components/search/SearchPage.tsx](src/components/search/SearchPage.tsx))
+  hydrates `client:load` and renders the same `SearchResults` list with
+  a full inline `RateLimitBanner` on 429.
+- **AskBox** ([src/components/ask/AskBox.tsx](src/components/ask/AskBox.tsx))
+  hydrates `client:load` (the SSE stream needs to be live on first
+  paint of `/ask`). Submit with `⌘+Enter` from the textarea, or click
+  the button. The Stop button calls `AbortController.abort()`. History
+  is in-memory only — reload clears it (M6 does not persist Q/A pairs).
+- **CitationPill** ([src/components/ask/CitationPill.tsx](src/components/ask/CitationPill.tsx))
+  is `inline-flex` so a list of pills wraps cleanly. Mirrors the
+  `FrontmatterPill` look but is an `<a>` with an `ArrowUpRight` icon.
+  Links to `/w/<slug>` plus `#<heading_slug>` when set.
+
+### `/api/ask` SSE wire format
+
+The route emits Server-Sent Events:
+
+```
+data: {"text": "incremental token"}\n\n
+event: citations\ndata: [{...}]\n\n
+event: done\ndata: {}\n\n
+```
+
+The consumer lives in [src/lib/api-ask.ts](src/lib/api-ask.ts). It uses
+`fetch` (not `EventSource`) because:
+
+1. `EventSource` is GET-only; `/api/ask` is POST.
+2. We need `credentials: include` (Access cookie) and the local-dev
+   `X-Local-Dev-Email` header.
+3. We want a real `AbortController` for the Stop button.
+
+When the worker rejects before any SSE frame (401, 429, 400 schema), it
+returns a normal JSON `ApiResult<err>`; we sniff `Content-Type` and
+surface an `ApiError` (or `AuthRequiredError`) to `onError`. A 429
+`RATE_LIMITED` carries `details: { limit, used, scope, reset_at }` which
+the AskBox unwraps and hands to `RateLimitBanner` directly.
+
+### Search snippet rendering
+
+`/api/search` returns FTS5 snippets with `<mark>...</mark>` tags around
+matched terms. We **do not** inject the snippet via the React HTML-prop
+escape hatch — [`SearchResults`](src/components/search/SearchResults.tsx)
+parses the snippet manually, treating only `<mark>` and `</mark>` as
+React `<mark>` elements and everything else as literal text. Any other
+tag (including a `<script>`) renders as visible text. This is the same
+defense-in-depth posture as the markdown sanitizer.
+
+### Local-dev fallback messaging
+
+When AI Search is unavailable (no `ai_search_id` on the workspace yet,
+or the index hasn't been built), the worker returns
+`mode: "fts5_fallback"`. The UI shows a small amber notice
+("Showing keyword matches only — semantic search is unavailable.") at
+the top of the result list and on the empty state. This is expected on
+fresh local dev environments before the operator runs the AI Search
+provisioning flow — point users at the M6 setup section of `DEPLOY.md`
+when they ask why ranking feels keyword-y.

--- a/apps/web/astro.config.mjs
+++ b/apps/web/astro.config.mjs
@@ -15,7 +15,13 @@ const WORKER_DEV_URL = "http://127.0.0.1:8788";
 export default defineConfig({
   output: "server",
   adapter: cloudflare({
-    platformProxy: { enabled: true },
+    // Point the platform proxy at wrangler.dev.jsonc so it doesn't try
+    // to remote-proxy the AI / Artifacts / AI Search bindings (those are
+    // remote-only and require `wrangler login`). The dev config omits
+    // them; tests use typed fakes; live AI requires `wrangler dev
+    // --remote --config ../../wrangler.jsonc` from an authenticated
+    // shell.
+    platformProxy: { enabled: true, configPath: "../../wrangler.dev.jsonc" },
   }),
   integrations: [react()],
   server: { port: 4321 },

--- a/apps/web/src/components/AppShell.astro
+++ b/apps/web/src/components/AppShell.astro
@@ -29,6 +29,8 @@ const { workspaceName, userDisplayName } = Astro.props;
 const hasRightRail = Astro.slots.has("right-rail");
 const pathname = new URL(Astro.request.url).pathname;
 const onWiki = pathname.startsWith("/w");
+const onAsk = pathname.startsWith("/ask");
+const onChat = !onWiki && !onAsk;
 ---
 
 <style>
@@ -62,11 +64,11 @@ const onWiki = pathname.startsWith("/w");
           href="/"
           class:list={[
             "flex-1 px-3 py-2 text-center text-sm font-medium transition-colors",
-            !onWiki
+            onChat
               ? "bg-background text-foreground"
               : "text-muted-foreground hover:bg-background/60",
           ]}
-          aria-current={!onWiki ? "page" : undefined}>Chat</a
+          aria-current={onChat ? "page" : undefined}>Chat</a
         >
         <a
           href="/w"
@@ -77,6 +79,16 @@ const onWiki = pathname.startsWith("/w");
               : "text-muted-foreground hover:bg-background/60",
           ]}
           aria-current={onWiki ? "page" : undefined}>Wiki</a
+        >
+        <a
+          href="/ask"
+          class:list={[
+            "flex-1 px-3 py-2 text-center text-sm font-medium transition-colors",
+            onAsk
+              ? "bg-background text-foreground"
+              : "text-muted-foreground hover:bg-background/60",
+          ]}
+          aria-current={onAsk ? "page" : undefined}>Ask</a
         >
       </nav>
       <slot name="sidebar" />

--- a/apps/web/src/components/AppShellHeader.tsx
+++ b/apps/web/src/components/AppShellHeader.tsx
@@ -6,6 +6,7 @@
 // on first paint.
 
 import { ThemeToggle } from "@/components/ThemeToggle";
+import { SearchBar } from "@/components/search/SearchBar";
 import { Button } from "@/components/ui/button";
 import { Menu } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -45,6 +46,9 @@ export function AppShellHeader({ workspaceName, userDisplayName }: AppShellHeade
         Loomwiki
       </a>
       <span className="hidden text-xs text-muted-foreground sm:inline">{workspaceName}</span>
+      <div className="hidden flex-1 px-4 md:block lg:max-w-md">
+        <SearchBar />
+      </div>
       <div className="ml-auto flex items-center gap-3">
         <span className="hidden text-xs text-muted-foreground sm:inline">
           Signed in as <span className="text-foreground">{userDisplayName}</span>

--- a/apps/web/src/components/DesignSamples.tsx
+++ b/apps/web/src/components/DesignSamples.tsx
@@ -8,6 +8,9 @@
 //
 // Used by /design only. Not shipped in production routes.
 
+import { RateLimitBanner } from "@/components/RateLimitBanner";
+import { CitationPill } from "@/components/ask/CitationPill";
+import { SearchResults } from "@/components/search/SearchResults";
 import { Avatar, AvatarFallback } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -95,6 +98,93 @@ export function DesignSamples({ mode }: DesignSamplesProps) {
           <Button size="sm" variant="ghost">
             Save
           </Button>
+        </div>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <p className="text-xs font-medium uppercase text-muted-foreground">Citations</p>
+        <div className="flex flex-wrap items-center gap-2">
+          <CitationPill
+            citation={{
+              path: "/wiki/concepts/dmarc.md",
+              title: "DMARC",
+              kind: "concept",
+              heading_slug: "alignment",
+            }}
+          />
+          <CitationPill
+            citation={{
+              path: "/wiki/decisions/0001-mta-sts.md",
+              title: "Adopt MTA-STS for inbound",
+              kind: "decision",
+              heading_slug: null,
+            }}
+          />
+          <CitationPill
+            citation={{
+              path: "/wiki/glossary/spf.md",
+              title: "SPF",
+              kind: "glossary",
+              heading_slug: null,
+            }}
+          />
+          <CitationPill
+            citation={{
+              path: "/wiki/open-questions/dkim-key-rotation.md",
+              title: "How often should we rotate DKIM keys?",
+              kind: "open-question",
+              heading_slug: "context",
+            }}
+          />
+        </div>
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <p className="text-xs font-medium uppercase text-muted-foreground">Rate limit banners</p>
+        <RateLimitBanner
+          kind="ask"
+          details={{
+            limit: 50,
+            used: 50,
+            scope: "user",
+            reset_at: "2026-05-05T00:00:00Z",
+          }}
+        />
+        <RateLimitBanner
+          kind="search"
+          details={{
+            limit: 500,
+            used: 500,
+            scope: "workspace",
+            reset_at: "2026-05-05T00:00:00Z",
+          }}
+        />
+      </section>
+
+      <Separator />
+
+      <section className="space-y-3">
+        <p className="text-xs font-medium uppercase text-muted-foreground">Search empty states</p>
+        <div className="rounded-md border border-border">
+          <p className="border-b border-border bg-secondary/30 px-3 py-1 text-[11px] uppercase text-muted-foreground">
+            mode = hybrid
+          </p>
+          <SearchResults results={[]} mode="hybrid" onSelect={() => undefined} variant="full" />
+        </div>
+        <div className="rounded-md border border-border">
+          <p className="border-b border-border bg-secondary/30 px-3 py-1 text-[11px] uppercase text-muted-foreground">
+            mode = fts5_fallback
+          </p>
+          <SearchResults
+            results={[]}
+            mode="fts5_fallback"
+            onSelect={() => undefined}
+            variant="full"
+          />
         </div>
       </section>
     </div>

--- a/apps/web/src/components/RateLimitBanner.tsx
+++ b/apps/web/src/components/RateLimitBanner.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Surfaced when /api/ask or /api/search returns 429 RATE_LIMITED. Reads
+// the typed `details` payload off the ApiError. Two scopes (user vs
+// workspace) get distinct copy because operator-shared budgets are a
+// different mental model from a personal cap.
+
+import type { RateLimitDetails } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+export interface RateLimitBannerProps {
+  details: RateLimitDetails;
+  /** What the user was trying to do — selects the noun in the copy. */
+  kind?: "ask" | "search";
+  className?: string;
+}
+
+export function RateLimitBanner({ details, kind = "ask", className }: RateLimitBannerProps) {
+  const noun = kind === "ask" ? "ask" : "search";
+  const scopeLabel = details.scope === "workspace" ? "workspace-wide" : "personal";
+  const resetLocal = formatResetTime(details.reset_at);
+
+  return (
+    <div
+      role="alert"
+      data-testid="rate-limit-banner"
+      className={cn(
+        "rounded-md border border-amber-300 bg-amber-50 p-3 text-xs text-amber-950 dark:border-amber-700/50 dark:bg-amber-950/30 dark:text-amber-100",
+        className,
+      )}
+    >
+      <p className="font-medium">
+        You've reached your daily limit of {details.limit} {scopeLabel} {noun} queries.
+      </p>
+      <p className="mt-1 text-amber-900/80 dark:text-amber-200/80">
+        Resets at midnight UTC ({resetLocal}).
+      </p>
+    </div>
+  );
+}
+
+function formatResetTime(isoOrNumeric: string): string {
+  const d = new Date(isoOrNumeric);
+  if (Number.isNaN(d.getTime())) return isoOrNumeric;
+  return d.toLocaleString();
+}

--- a/apps/web/src/components/ask/AskBox.test.tsx
+++ b/apps/web/src/components/ask/AskBox.test.tsx
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// AskBox integration test. Mocks the global fetch with an SSE response
+// (or a 429 JSON body) so we exercise the same askStream parsing the
+// component depends on at runtime — no helper indirection.
+
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AskBox } from "./AskBox";
+
+function sseStream(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function nextTick(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+async function flush(): Promise<void> {
+  for (let i = 0; i < 10; i++) await nextTick();
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("AskBox", () => {
+  it("streams the answer and renders citations after onCitations", async () => {
+    const body = `data: ${JSON.stringify({ text: "Hello " })}\n\ndata: ${JSON.stringify({ text: "world." })}\n\nevent: citations\ndata: ${JSON.stringify(
+      [{ path: "/wiki/concepts/dmarc.md", title: "DMARC", kind: "concept", heading_slug: null }],
+    )}\n\nevent: done\ndata: {}\n\n`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => sseStream(body)),
+    );
+
+    render(<AskBox />);
+    fireEvent.change(screen.getByTestId("ask-input"), { target: { value: "what is dmarc?" } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("ask-submit"));
+      await flush();
+    });
+
+    await waitFor(() => {
+      const ans = screen.getByTestId("ask-answer");
+      expect(ans.textContent ?? "").toContain("Hello world.");
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("ask-citations")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("link", { name: /DMARC/ })).toHaveAttribute(
+      "href",
+      "/w/concepts/dmarc",
+    );
+    // After done, the submit button is back.
+    await waitFor(() => expect(screen.queryByTestId("ask-stop")).toBeNull());
+  });
+
+  it("renders the RateLimitBanner on a 429 RATE_LIMITED with details", async () => {
+    const details = {
+      limit: 50,
+      used: 50,
+      scope: "user",
+      reset_at: "2026-05-05T00:00:00Z",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(429, {
+          ok: false,
+          error: { code: "RATE_LIMITED", message: "rate limited", details },
+        }),
+      ),
+    );
+
+    render(<AskBox />);
+    fireEvent.change(screen.getByTestId("ask-input"), { target: { value: "anything" } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("ask-submit"));
+      await flush();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("rate-limit-banner")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("rate-limit-banner")).toHaveTextContent(/daily limit of 50/);
+  });
+
+  it("disables submit while streaming and exposes a Stop button", async () => {
+    // Use a stream whose body never closes (until we abort). Hold the
+    // controller so we can keep the stream open across assertions.
+    let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        streamController = controller;
+        controller.enqueue(
+          new TextEncoder().encode(`data: ${JSON.stringify({ text: "..." })}\n\n`),
+        );
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(stream, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          }),
+      ),
+    );
+
+    render(<AskBox />);
+    fireEvent.change(screen.getByTestId("ask-input"), { target: { value: "long question" } });
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("ask-submit"));
+      await flush();
+    });
+
+    await waitFor(() => expect(screen.getByTestId("ask-stop")).toBeInTheDocument());
+    expect(screen.queryByTestId("ask-submit")).toBeNull();
+
+    // Cleanup: close the stream so the test can end.
+    // Cast: TS doesn't see the assignment that happens inside the `start`
+    // callback, so the inferred narrowed type is `null`. The runtime value
+    // is the controller.
+    (streamController as ReadableStreamDefaultController<Uint8Array> | null)?.close();
+  });
+});

--- a/apps/web/src/components/ask/AskBox.tsx
+++ b/apps/web/src/components/ask/AskBox.tsx
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// The /ask surface — textarea on top, streamed answer + citations below,
+// previous Q/A pairs above. State is in-memory only (per the M6 brief);
+// reload clears history.
+//
+// The streaming answer renders through SanitizedMarkdown so the LLM
+// can use markdown safely. Citations append once `onCitations` fires
+// (always after the last token chunk). A 429 surfaces the
+// RateLimitBanner with the typed `details` payload.
+
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { SanitizedMarkdown } from "@/components/wiki/SanitizedMarkdown";
+import { ApiError, AuthRequiredError } from "@/lib/api";
+import { type AskStreamHandle, askStream } from "@/lib/api-ask";
+import type { AskCitation, RateLimitDetails } from "@/lib/types";
+import { Loader2, Send, Square } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { RateLimitBanner } from "../RateLimitBanner";
+import { CitationPill } from "./CitationPill";
+
+interface AnswerTurn {
+  id: string;
+  question: string;
+  answer: string;
+  citations: AskCitation[];
+  status: "streaming" | "done" | "error";
+  error: string | null;
+}
+
+export function AskBox() {
+  const [draft, setDraft] = useState("");
+  const [turns, setTurns] = useState<AnswerTurn[]>([]);
+  const [streaming, setStreaming] = useState(false);
+  const [rateLimit, setRateLimit] = useState<RateLimitDetails | null>(null);
+  const handleRef = useRef<AskStreamHandle | null>(null);
+  const turnsEndRef = useRef<HTMLDivElement>(null);
+
+  // Auto-scroll the answer pane on each new chunk so the user sees the
+  // tail of the stream. We sum answer lengths so the effect re-fires on
+  // every token append — depending on `turns.length` alone wouldn't catch
+  // mid-stream growth.
+  const scrollKey = turns.reduce((n, t) => n + t.answer.length, turns.length);
+  useEffect(() => {
+    // Read scrollKey to anchor the dependency in biome's analysis;
+    // the value itself doesn't matter — the trigger does.
+    void scrollKey;
+    turnsEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [scrollKey]);
+
+  // Defensive: if the component unmounts mid-stream (e.g. SPA nav), abort
+  // the fetch so we don't leak a reader.
+  useEffect(() => {
+    return () => {
+      handleRef.current?.abort();
+    };
+  }, []);
+
+  function submit() {
+    const question = draft.trim();
+    if (question.length === 0 || streaming) return;
+    setDraft("");
+    setRateLimit(null);
+
+    const turnId = crypto.randomUUID();
+    const turn: AnswerTurn = {
+      id: turnId,
+      question,
+      answer: "",
+      citations: [],
+      status: "streaming",
+      error: null,
+    };
+    setTurns((prev) => [...prev, turn]);
+    setStreaming(true);
+
+    handleRef.current = askStream(question, {
+      onDelta(text) {
+        setTurns((prev) =>
+          prev.map((t) => (t.id === turnId ? { ...t, answer: t.answer + text } : t)),
+        );
+      },
+      onCitations(citations) {
+        setTurns((prev) => prev.map((t) => (t.id === turnId ? { ...t, citations } : t)));
+      },
+      onDone() {
+        setTurns((prev) => prev.map((t) => (t.id === turnId ? { ...t, status: "done" } : t)));
+        setStreaming(false);
+        handleRef.current = null;
+      },
+      onError(err) {
+        if (err instanceof ApiError && err.code === "RATE_LIMITED") {
+          const details = err.details as RateLimitDetails | undefined;
+          if (details && typeof details.limit === "number") setRateLimit(details);
+        }
+        const message =
+          err instanceof AuthRequiredError
+            ? "You need to sign in again."
+            : err instanceof ApiError && err.code === "RATE_LIMITED"
+              ? "Daily ask limit reached."
+              : err instanceof ApiError && err.code === "ABORTED"
+                ? "Stopped."
+                : err.message || "Ask failed.";
+        setTurns((prev) =>
+          prev.map((t) => (t.id === turnId ? { ...t, status: "error", error: message } : t)),
+        );
+        setStreaming(false);
+        handleRef.current = null;
+      },
+    });
+  }
+
+  function stop() {
+    handleRef.current?.abort();
+  }
+
+  function onKeyDown(ev: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // ⌘+Enter / Ctrl+Enter to submit; plain Enter still inserts a newline.
+    if ((ev.metaKey || ev.ctrlKey) && ev.key === "Enter") {
+      ev.preventDefault();
+      submit();
+    }
+  }
+
+  return (
+    <div className="mx-auto flex h-full max-w-3xl flex-col gap-4 overflow-hidden p-6">
+      <div className="flex-1 space-y-6 overflow-y-auto pr-1" data-testid="ask-history">
+        {turns.length === 0 && (
+          <div className="rounded-md border border-dashed border-border bg-secondary/20 p-6 text-sm text-muted-foreground">
+            <p className="font-medium text-foreground">Ask a question.</p>
+            <p className="mt-1">
+              Answers are grounded in your wiki. Citations link back to the source pages.
+            </p>
+          </div>
+        )}
+        {turns.map((turn) => (
+          <article key={turn.id} className="space-y-3" data-testid="ask-turn">
+            <div className="rounded-md bg-secondary/40 px-4 py-2 text-sm font-medium text-foreground">
+              {turn.question}
+            </div>
+            {turn.status === "error" ? (
+              <p className="text-sm text-destructive" role="alert">
+                {turn.error}
+              </p>
+            ) : (
+              <div className="space-y-3">
+                <div data-testid="ask-answer">
+                  {turn.answer.length > 0 ? (
+                    <SanitizedMarkdown source={turn.answer} className="prose max-w-none" />
+                  ) : (
+                    <p className="flex items-center gap-2 text-xs text-muted-foreground">
+                      <Loader2 className="size-3 animate-spin" />
+                      Thinking…
+                    </p>
+                  )}
+                </div>
+                {turn.citations.length > 0 && (
+                  <div className="flex flex-wrap gap-2" data-testid="ask-citations">
+                    {turn.citations.map((c, i) => (
+                      <CitationPill key={`${c.path}-${c.heading_slug ?? ""}-${i}`} citation={c} />
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </article>
+        ))}
+        <div ref={turnsEndRef} />
+      </div>
+
+      {rateLimit && <RateLimitBanner details={rateLimit} kind="ask" />}
+
+      <form
+        onSubmit={(ev) => {
+          ev.preventDefault();
+          submit();
+        }}
+        className="space-y-2"
+      >
+        <Textarea
+          value={draft}
+          onChange={(ev) => setDraft(ev.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Ask anything about your wiki…  (⌘+Enter to send)"
+          rows={3}
+          disabled={streaming}
+          data-testid="ask-input"
+        />
+        <div className="flex items-center justify-end gap-2">
+          {streaming ? (
+            <Button type="button" variant="outline" onClick={stop} data-testid="ask-stop">
+              <Square className="size-3" />
+              Stop
+            </Button>
+          ) : (
+            <Button type="submit" disabled={draft.trim().length === 0} data-testid="ask-submit">
+              <Send className="size-3" />
+              Ask
+            </Button>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/ask/AskPage.tsx
+++ b/apps/web/src/components/ask/AskPage.tsx
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Page-level wrapper for AskBox. Sits in the AppShell main slot.
+
+import { AskBox } from "./AskBox";
+
+export function AskPage() {
+  return (
+    <div className="flex h-full flex-col">
+      <AskBox />
+    </div>
+  );
+}

--- a/apps/web/src/components/ask/CitationPill.test.tsx
+++ b/apps/web/src/components/ask/CitationPill.test.tsx
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// jest-dom matchers loaded by src/test/setup.ts.
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { CitationPill } from "./CitationPill";
+
+describe("CitationPill", () => {
+  it("renders a link to /w/<slug> when no heading_slug is set", () => {
+    render(
+      <CitationPill
+        citation={{
+          path: "/wiki/concepts/dmarc.md",
+          title: "DMARC",
+          kind: "concept",
+          heading_slug: null,
+        }}
+      />,
+    );
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/w/concepts/dmarc");
+    expect(link).toHaveTextContent("DMARC");
+    expect(link).toHaveTextContent("concept");
+  });
+
+  it("appends #<heading_slug> when set", () => {
+    render(
+      <CitationPill
+        citation={{
+          path: "/wiki/concepts/dmarc.md",
+          title: "DMARC",
+          kind: "concept",
+          heading_slug: "alignment",
+        }}
+      />,
+    );
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/w/concepts/dmarc#alignment");
+  });
+
+  it("strips the leading /wiki/ and trailing .md from the path", () => {
+    render(
+      <CitationPill
+        citation={{
+          path: "/wiki/_index.md",
+          title: "Home",
+          kind: "concept",
+          heading_slug: null,
+        }}
+      />,
+    );
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/w/_index");
+  });
+});

--- a/apps/web/src/components/ask/CitationPill.tsx
+++ b/apps/web/src/components/ask/CitationPill.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Inline-flex pill that links to a wiki page (and optional in-page anchor)
+// from an /ask answer. Visual mirror of FrontmatterPill so the substrate
+// reads as one design system, but it's an `<a>` not a `<span>` and it
+// gets the external-arrow icon to telegraph "this navigates."
+
+import type { AskCitation } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { ArrowUpRight } from "lucide-react";
+
+export interface CitationPillProps {
+  citation: AskCitation;
+  className?: string;
+}
+
+export function CitationPill({ citation, className }: CitationPillProps) {
+  const href = buildHref(citation);
+  return (
+    <a
+      href={href}
+      data-testid="citation-pill"
+      data-citation-path={citation.path}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-full border border-border bg-secondary/40 px-2 py-0.5 text-xs font-medium text-foreground no-underline transition-colors hover:bg-accent/20 hover:text-accent-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring",
+        className,
+      )}
+    >
+      <span className="truncate max-w-[14rem]">{citation.title}</span>
+      <span aria-hidden="true" className="opacity-60">
+        ·
+      </span>
+      <span className="opacity-70">{citation.kind}</span>
+      <ArrowUpRight aria-hidden="true" className="size-3" />
+    </a>
+  );
+}
+
+function buildHref(citation: AskCitation): string {
+  // Vault paths look like `/wiki/concepts/dmarc.md`. The web routes
+  // live at `/w/<slug>` (no leading `/wiki/`, no trailing `.md`).
+  const slug = citation.path.replace(/^\/wiki\//, "").replace(/\.md$/, "");
+  const anchor = citation.heading_slug ? `#${citation.heading_slug}` : "";
+  return `/w/${slug}${anchor}`;
+}

--- a/apps/web/src/components/search/SearchBar.test.tsx
+++ b/apps/web/src/components/search/SearchBar.test.tsx
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// jest-dom matchers loaded by src/test/setup.ts.
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchBar } from "./SearchBar";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.unstubAllGlobals();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("SearchBar", () => {
+  it("debounces fetch and renders results", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, {
+        ok: true,
+        data: {
+          results: [
+            {
+              path: "/wiki/concepts/dmarc.md",
+              title: "DMARC",
+              kind: "concept",
+              snippet: "Hello <mark>DMARC</mark>",
+              score: 0.9,
+              source: "ai_search",
+            },
+          ],
+          mode: "hybrid",
+        },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SearchBar />);
+    const input = screen.getByTestId("search-bar-input");
+    fireEvent.change(input, { target: { value: "dmar" } });
+    // Before the debounce expires the fetch hasn't fired.
+    expect(fetchMock).not.toHaveBeenCalled();
+    await act(async () => {
+      vi.advanceTimersByTime(250);
+    });
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    // The title appears once as bold text + once inside the <mark> in the snippet.
+    await waitFor(() => expect(screen.getAllByText("DMARC").length).toBeGreaterThan(0));
+    expect(screen.getByTestId("search-result")).toBeInTheDocument();
+  });
+
+  it("⌘K focuses the input", () => {
+    render(<SearchBar />);
+    const input = screen.getByTestId("search-bar-input") as HTMLInputElement;
+    // Sanity: not focused yet.
+    expect(document.activeElement).not.toBe(input);
+    fireEvent.keyDown(window, { key: "k", metaKey: true });
+    expect(document.activeElement).toBe(input);
+  });
+
+  it("Ctrl+K also focuses the input (cross-platform)", () => {
+    render(<SearchBar />);
+    const input = screen.getByTestId("search-bar-input") as HTMLInputElement;
+    fireEvent.keyDown(window, { key: "k", ctrlKey: true });
+    expect(document.activeElement).toBe(input);
+  });
+});

--- a/apps/web/src/components/search/SearchBar.tsx
+++ b/apps/web/src/components/search/SearchBar.tsx
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Header dropdown search. ⌘K / Ctrl+K focuses the input from anywhere on
+// the page; Esc closes the dropdown. The query is debounced 200ms before
+// hitting /api/search so a fast typist doesn't fire one request per
+// keystroke. Click (or Enter on a focused result) navigates to the wiki
+// page.
+//
+// Hydrates `client:idle` — the search box doesn't need to be interactive
+// before the active surface is on screen.
+
+import { Input } from "@/components/ui/input";
+import { ApiError, AuthRequiredError } from "@/lib/api";
+import { searchWiki } from "@/lib/api-search";
+import type { WikiSearchMode, WikiSearchResult } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { Search } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { SearchResults } from "./SearchResults";
+
+const DEBOUNCE_MS = 200;
+
+export interface SearchBarProps {
+  className?: string;
+}
+
+export function SearchBar({ className }: SearchBarProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<WikiSearchResult[]>([]);
+  const [mode, setMode] = useState<WikiSearchMode>("hybrid");
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Sequence number guards against an in-flight request resolving after
+  // a newer request — without it, a slow first response could overwrite
+  // a faster second.
+  const requestSeqRef = useRef(0);
+
+  // Global ⌘K / Ctrl+K hotkey.
+  useEffect(() => {
+    const onKey = (ev: KeyboardEvent) => {
+      const isMeta = ev.metaKey || ev.ctrlKey;
+      if (isMeta && ev.key.toLowerCase() === "k") {
+        ev.preventDefault();
+        inputRef.current?.focus();
+        setOpen(true);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Click-outside to close.
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (ev: MouseEvent) => {
+      if (!containerRef.current) return;
+      if (!containerRef.current.contains(ev.target as Node)) setOpen(false);
+    };
+    window.addEventListener("mousedown", onClick);
+    return () => window.removeEventListener("mousedown", onClick);
+  }, [open]);
+
+  const runSearch = useCallback(async (q: string) => {
+    const trimmed = q.trim();
+    if (trimmed.length === 0) {
+      setResults([]);
+      setErrorMsg(null);
+      return;
+    }
+    const mySeq = ++requestSeqRef.current;
+    setLoading(true);
+    setErrorMsg(null);
+    try {
+      const data = await searchWiki(trimmed);
+      if (mySeq !== requestSeqRef.current) return;
+      setResults(data.results);
+      setMode(data.mode);
+    } catch (err) {
+      if (mySeq !== requestSeqRef.current) return;
+      if (err instanceof AuthRequiredError) {
+        setErrorMsg("Sign in to search.");
+      } else if (err instanceof ApiError) {
+        if (err.code === "RATE_LIMITED") {
+          setErrorMsg("Search rate limit reached — try again later.");
+        } else {
+          setErrorMsg(err.message || "Search failed.");
+        }
+      } else {
+        setErrorMsg("Search failed.");
+      }
+      setResults([]);
+    } finally {
+      if (mySeq === requestSeqRef.current) setLoading(false);
+    }
+  }, []);
+
+  const onChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    const next = ev.target.value;
+    setQuery(next);
+    setOpen(true);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void runSearch(next);
+    }, DEBOUNCE_MS);
+  };
+
+  const onSelect = (path: string) => {
+    if (typeof window === "undefined") return;
+    const slug = path.replace(/^\/wiki\//, "").replace(/\.md$/, "");
+    window.location.href = `/w/${slug}`;
+  };
+
+  const onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+    if (ev.key === "Escape") {
+      setOpen(false);
+      inputRef.current?.blur();
+    }
+  };
+
+  const showDropdown = open && query.trim().length > 0;
+
+  return (
+    <div ref={containerRef} className={cn("relative", className)} data-testid="search-bar">
+      <div className="relative">
+        <Search
+          aria-hidden="true"
+          className="pointer-events-none absolute left-2 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          ref={inputRef}
+          type="search"
+          aria-label="Search wiki"
+          aria-expanded={showDropdown}
+          placeholder="Search the wiki  (⌘K)"
+          value={query}
+          onChange={onChange}
+          onFocus={() => setOpen(true)}
+          onKeyDown={onKeyDown}
+          className="pl-8"
+          data-testid="search-bar-input"
+        />
+      </div>
+      {showDropdown && (
+        <div className="absolute right-0 left-0 top-full z-30 mt-1 max-h-[60vh] overflow-y-auto rounded-md border border-border bg-background shadow-lg">
+          {loading && results.length === 0 && (
+            <p className="px-3 py-2 text-xs text-muted-foreground">Searching…</p>
+          )}
+          {errorMsg && (
+            <p className="px-3 py-2 text-xs text-destructive" role="alert">
+              {errorMsg}
+            </p>
+          )}
+          {!errorMsg && (
+            <SearchResults results={results} mode={mode} onSelect={onSelect} variant="compact" />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/search/SearchPage.tsx
+++ b/apps/web/src/components/search/SearchPage.tsx
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Full-page search at /search. Same data flow as the header SearchBar
+// (debounced POST /api/search) but with breathing room and the rate-limit
+// banner inline (the header dropdown only shows a one-line error since
+// the dropdown is too cramped for the full banner).
+
+import { Input } from "@/components/ui/input";
+import { ApiError, AuthRequiredError } from "@/lib/api";
+import { searchWiki } from "@/lib/api-search";
+import type { RateLimitDetails, WikiSearchMode, WikiSearchResult } from "@/lib/types";
+import { Search } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { RateLimitBanner } from "../RateLimitBanner";
+import { SearchResults } from "./SearchResults";
+
+const DEBOUNCE_MS = 200;
+
+export function SearchPage() {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<WikiSearchResult[]>([]);
+  const [mode, setMode] = useState<WikiSearchMode>("hybrid");
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [rateLimit, setRateLimit] = useState<RateLimitDetails | null>(null);
+  const [searched, setSearched] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const requestSeqRef = useRef(0);
+
+  const runSearch = useCallback(async (q: string) => {
+    const trimmed = q.trim();
+    if (trimmed.length === 0) {
+      setResults([]);
+      setSearched(false);
+      setErrorMsg(null);
+      setRateLimit(null);
+      return;
+    }
+    const mySeq = ++requestSeqRef.current;
+    setLoading(true);
+    setErrorMsg(null);
+    setRateLimit(null);
+    try {
+      const data = await searchWiki(trimmed);
+      if (mySeq !== requestSeqRef.current) return;
+      setResults(data.results);
+      setMode(data.mode);
+      setSearched(true);
+    } catch (err) {
+      if (mySeq !== requestSeqRef.current) return;
+      if (err instanceof AuthRequiredError) {
+        setErrorMsg("Sign in to search.");
+      } else if (err instanceof ApiError && err.code === "RATE_LIMITED") {
+        const details = err.details as RateLimitDetails | undefined;
+        if (details && typeof details.limit === "number") {
+          setRateLimit(details);
+        } else {
+          setErrorMsg("Search rate limit reached.");
+        }
+      } else if (err instanceof ApiError) {
+        setErrorMsg(err.message || "Search failed.");
+      } else {
+        setErrorMsg("Search failed.");
+      }
+      setResults([]);
+    } finally {
+      if (mySeq === requestSeqRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const onChange = (ev: React.ChangeEvent<HTMLInputElement>) => {
+    const next = ev.target.value;
+    setQuery(next);
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      void runSearch(next);
+    }, DEBOUNCE_MS);
+  };
+
+  const onSelect = (path: string) => {
+    if (typeof window === "undefined") return;
+    const slug = path.replace(/^\/wiki\//, "").replace(/\.md$/, "");
+    window.location.href = `/w/${slug}`;
+  };
+
+  return (
+    <div className="mx-auto flex h-full max-w-3xl flex-col gap-4 overflow-y-auto p-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Search</h1>
+        <p className="text-sm text-muted-foreground">
+          Find pages by title, content, or concept. Hybrid semantic + keyword search when AI Search
+          is online; keyword-only otherwise.
+        </p>
+      </header>
+      <div className="relative">
+        <Search
+          aria-hidden="true"
+          className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground"
+        />
+        <Input
+          autoFocus
+          type="search"
+          aria-label="Search wiki"
+          placeholder="Search the wiki…"
+          value={query}
+          onChange={onChange}
+          className="pl-9"
+          data-testid="search-page-input"
+        />
+      </div>
+      {rateLimit && <RateLimitBanner details={rateLimit} kind="search" />}
+      {errorMsg && (
+        <p className="text-sm text-destructive" role="alert">
+          {errorMsg}
+        </p>
+      )}
+      {loading && results.length === 0 && (
+        <p className="text-sm text-muted-foreground">Searching…</p>
+      )}
+      {searched && !errorMsg && !rateLimit && (
+        <div className="rounded-md border border-border">
+          <SearchResults results={results} mode={mode} onSelect={onSelect} variant="full" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/search/SearchResults.test.tsx
+++ b/apps/web/src/components/search/SearchResults.test.tsx
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import type { WikiSearchResult } from "@/lib/types";
+// jest-dom matchers loaded by src/test/setup.ts.
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { SearchResults } from "./SearchResults";
+
+const RESULT: WikiSearchResult = {
+  path: "/wiki/concepts/dmarc.md",
+  title: "DMARC",
+  kind: "concept",
+  snippet: "Hello <mark>DMARC</mark> world",
+  score: 0.9,
+  source: "ai_search",
+};
+
+describe("SearchResults", () => {
+  it("renders the title, path, and converts <mark> to a real <mark> element", () => {
+    render(<SearchResults results={[RESULT]} mode="hybrid" onSelect={() => undefined} />);
+    // Title appears once (as bold text) AND once inside the <mark> snippet.
+    // Use queryAllByText since the title literal appears twice.
+    expect(screen.getAllByText("DMARC").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("/wiki/concepts/dmarc.md")).toBeInTheDocument();
+    // The mark wraps just the matched term, not arbitrary HTML.
+    const marks = document.querySelectorAll("mark");
+    expect(marks.length).toBe(1);
+    expect(marks[0]?.textContent).toBe("DMARC");
+  });
+
+  it("calls onSelect with the path on click", () => {
+    const onSelect = vi.fn();
+    render(<SearchResults results={[RESULT]} mode="hybrid" onSelect={onSelect} />);
+    fireEvent.click(screen.getByTestId("search-result"));
+    expect(onSelect).toHaveBeenCalledWith("/wiki/concepts/dmarc.md");
+  });
+
+  it("calls onSelect on Enter key", () => {
+    const onSelect = vi.fn();
+    render(<SearchResults results={[RESULT]} mode="hybrid" onSelect={onSelect} />);
+    fireEvent.keyDown(screen.getByTestId("search-result"), { key: "Enter" });
+    expect(onSelect).toHaveBeenCalledWith("/wiki/concepts/dmarc.md");
+  });
+
+  it("shows a fallback notice when mode = fts5_fallback (with results)", () => {
+    render(<SearchResults results={[RESULT]} mode="fts5_fallback" onSelect={() => undefined} />);
+    expect(
+      screen.getByText(/keyword matches only — semantic search is unavailable/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty state for mode = hybrid", () => {
+    render(<SearchResults results={[]} mode="hybrid" onSelect={() => undefined} />);
+    expect(screen.getByTestId("search-empty")).toHaveTextContent("No matches.");
+    expect(screen.queryByText(/keyword matches only/i)).toBeNull();
+  });
+
+  it("renders the empty state with the fallback notice for fts5_fallback", () => {
+    render(<SearchResults results={[]} mode="fts5_fallback" onSelect={() => undefined} />);
+    expect(screen.getByTestId("search-empty")).toHaveTextContent(
+      /keyword matches only — semantic search is unavailable/i,
+    );
+  });
+
+  it("never injects a script tag from the snippet", () => {
+    const malicious = { ...RESULT, snippet: "ok <script>alert(1)</script> more" };
+    render(<SearchResults results={[malicious]} mode="hybrid" onSelect={() => undefined} />);
+    // The snippet renderer only honors <mark>; everything else is text.
+    expect(document.querySelector("script")).toBeNull();
+    expect(document.body.textContent ?? "").toContain("ok <script>alert(1)</script> more");
+  });
+});

--- a/apps/web/src/components/search/SearchResults.tsx
+++ b/apps/web/src/components/search/SearchResults.tsx
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared result list for the header SearchBar dropdown and the full
+// SearchPage. Renders title + kind pill + path + snippet. The snippet
+// arrives with `<mark>...</mark>` tags around matched terms (FTS5
+// emits these); we convert them to React `<mark>` elements via a
+// string→fragment helper so we never touch innerHTML.
+
+import { FrontmatterPill } from "@/components/wiki/FrontmatterPill";
+import type { WikiSearchMode, WikiSearchResult } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { Fragment } from "react";
+
+export interface SearchResultsProps {
+  results: WikiSearchResult[];
+  mode: WikiSearchMode;
+  /** Called with the wiki path (`/wiki/...md`) when a result is activated. */
+  onSelect: (path: string) => void;
+  /** Optional className on the outer list. */
+  className?: string;
+  /** Compact = header dropdown, full = SearchPage. */
+  variant?: "compact" | "full";
+}
+
+export function SearchResults({
+  results,
+  mode,
+  onSelect,
+  className,
+  variant = "compact",
+}: SearchResultsProps) {
+  if (results.length === 0) {
+    return <EmptyState mode={mode} className={cn(variant === "full" ? "p-6" : "p-3", className)} />;
+  }
+
+  return (
+    <ul className={cn("divide-y divide-border", className)} data-testid="search-results">
+      {mode === "fts5_fallback" && (
+        <li className="bg-amber-50 px-3 py-2 text-[11px] text-amber-900 dark:bg-amber-950/30 dark:text-amber-200">
+          Showing keyword matches only — semantic search is unavailable.
+        </li>
+      )}
+      {results.map((r) => (
+        <li key={r.path}>
+          <button
+            type="button"
+            data-testid="search-result"
+            data-path={r.path}
+            onClick={() => onSelect(r.path)}
+            onKeyDown={(ev) => {
+              if (ev.key === "Enter" || ev.key === " ") {
+                ev.preventDefault();
+                onSelect(r.path);
+              }
+            }}
+            className="flex w-full flex-col gap-1 px-3 py-2 text-left transition-colors hover:bg-secondary focus-visible:bg-secondary focus-visible:outline-hidden"
+          >
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="text-sm font-semibold text-foreground">{r.title}</span>
+              <FrontmatterPill kind={r.kind} status="published" className="opacity-80" />
+              <span className="ml-auto text-[11px] font-mono text-muted-foreground">{r.path}</span>
+            </div>
+            <p className="text-xs text-muted-foreground">{renderSnippet(r.snippet)}</p>
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function EmptyState({ mode, className }: { mode: WikiSearchMode; className?: string }) {
+  return (
+    <div
+      className={cn("text-center text-xs text-muted-foreground", className)}
+      data-testid="search-empty"
+    >
+      <p>No matches.</p>
+      {mode === "fts5_fallback" && (
+        <p className="mt-1 text-[11px]">
+          Showing keyword matches only — semantic search is unavailable.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Convert `Hello <mark>DMARC</mark> world` → `[ "Hello ", <mark>DMARC</mark>, " world" ]`
+ * without touching innerHTML. We accept ONLY `<mark>` and `</mark>`; any
+ * other tag in the snippet renders as literal text. This is intentional —
+ * the snippet field is the only place the worker ships HTML, and it ships
+ * exactly that one tag.
+ */
+function renderSnippet(snippet: string) {
+  if (!snippet.includes("<mark>")) return snippet;
+  const parts: Array<string | { mark: string }> = [];
+  let cursor = 0;
+  // Manual scan: cheaper + more predictable than regex on snippets that
+  // could contain stray angle brackets in code samples.
+  while (cursor < snippet.length) {
+    const openIdx = snippet.indexOf("<mark>", cursor);
+    if (openIdx === -1) {
+      parts.push(snippet.slice(cursor));
+      break;
+    }
+    if (openIdx > cursor) parts.push(snippet.slice(cursor, openIdx));
+    const closeIdx = snippet.indexOf("</mark>", openIdx + "<mark>".length);
+    if (closeIdx === -1) {
+      // Unterminated mark — treat the rest as plain text rather than
+      // dropping it.
+      parts.push(snippet.slice(openIdx));
+      break;
+    }
+    parts.push({ mark: snippet.slice(openIdx + "<mark>".length, closeIdx) });
+    cursor = closeIdx + "</mark>".length;
+  }
+  return parts.map((part, i) => {
+    // Compose a stable key from the segment kind, index, and a content
+    // prefix. The parts array is the result of a deterministic parse on
+    // a static `snippet` string — order doesn't shift, but combining
+    // index + content avoids the `noArrayIndexKey` false positive while
+    // remaining unique enough for repeated identical segments.
+    if (typeof part === "string") {
+      const key = `t-${i}-${part.slice(0, 8)}`;
+      return <Fragment key={key}>{part}</Fragment>;
+    }
+    const key = `m-${i}-${part.mark.slice(0, 8)}`;
+    return (
+      <mark
+        key={key}
+        className="rounded bg-amber-200 px-0.5 text-amber-950 dark:bg-amber-700/50 dark:text-amber-100"
+      >
+        {part.mark}
+      </mark>
+    );
+  });
+}

--- a/apps/web/src/lib/api-ask.test.ts
+++ b/apps/web/src/lib/api-ask.test.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Pins the SSE consumer's parser:
+//   - data: {"text": "..."} chunks → onDelta
+//   - event: citations + data: [...] → onCitations
+//   - event: done → onDone
+//   - 4xx with JSON body → onError(ApiError) with `.details` preserved
+//   - reads frames in chunks, including a frame split across two
+//     network reads (the buffer carry-over branch).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError, AuthRequiredError } from "./api";
+import { askStream } from "./api-ask";
+
+function sse(body: string, status = 200): Response {
+  return new Response(body, {
+    status,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * Build an SSE Response whose body delivers each chunk as a separate
+ * read — that exercises the carry-over buffer in api-ask.
+ */
+function chunkedSse(chunks: string[]): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(encoder.encode(c));
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function nextTick(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 0));
+}
+
+async function flush(): Promise<void> {
+  // Multiple ticks: each await reader.read() resolves on a tick, so we
+  // need a few of them to fully drain a streamed response.
+  for (let i = 0; i < 10; i++) await nextTick();
+}
+
+describe("askStream", () => {
+  it("dispatches delta + citations + done in order", async () => {
+    const body = `data: ${JSON.stringify({ text: "Hello " })}\n\ndata: ${JSON.stringify({ text: "world." })}\n\nevent: citations\ndata: ${JSON.stringify(
+      [{ path: "/wiki/concepts/dmarc.md", title: "DMARC", kind: "concept", heading_slug: null }],
+    )}\n\nevent: done\ndata: {}\n\n`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => sse(body)),
+    );
+
+    const deltas: string[] = [];
+    let cites: unknown = null;
+    let done = false;
+    let err: unknown = null;
+    askStream("hi", {
+      onDelta: (t) => deltas.push(t),
+      onCitations: (c) => {
+        cites = c;
+      },
+      onDone: () => {
+        done = true;
+      },
+      onError: (e) => {
+        err = e;
+      },
+    });
+    await flush();
+    expect(err).toBeNull();
+    expect(deltas).toEqual(["Hello ", "world."]);
+    expect(cites).toEqual([
+      { path: "/wiki/concepts/dmarc.md", title: "DMARC", kind: "concept", heading_slug: null },
+    ]);
+    expect(done).toBe(true);
+  });
+
+  it("handles a frame split across two network reads", async () => {
+    // Split mid-frame: first chunk has `data: {"te` and the rest comes
+    // in the second chunk. The buffer carry-over should reassemble.
+    const c1 = `data: {"te`;
+    const c2 = `xt": "ok"}\n\nevent: done\ndata: {}\n\n`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => chunkedSse([c1, c2])),
+    );
+
+    const deltas: string[] = [];
+    let done = false;
+    askStream("q", {
+      onDelta: (t) => deltas.push(t),
+      onCitations: () => undefined,
+      onDone: () => {
+        done = true;
+      },
+      onError: () => undefined,
+    });
+    await flush();
+    expect(deltas).toEqual(["ok"]);
+    expect(done).toBe(true);
+  });
+
+  it("surfaces a 4xx JSON body as ApiError to onError, preserving details", async () => {
+    const details = {
+      limit: 50,
+      used: 50,
+      scope: "user",
+      reset_at: "2026-05-05T00:00:00Z",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(429, {
+          ok: false,
+          error: { code: "RATE_LIMITED", message: "rate limited", details },
+        }),
+      ),
+    );
+    let captured: unknown = null;
+    askStream("q", {
+      onDelta: () => undefined,
+      onCitations: () => undefined,
+      onDone: () => undefined,
+      onError: (e) => {
+        captured = e;
+      },
+    });
+    await flush();
+    expect(captured).toBeInstanceOf(ApiError);
+    expect((captured as ApiError).code).toBe("RATE_LIMITED");
+    expect((captured as ApiError).status).toBe(429);
+    expect((captured as ApiError).details).toEqual(details);
+  });
+
+  it("surfaces a 401 as AuthRequiredError", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(401, {
+          ok: false,
+          error: { code: "AUTH_REQUIRED", message: "x" },
+        }),
+      ),
+    );
+    let captured: unknown = null;
+    askStream("q", {
+      onDelta: () => undefined,
+      onCitations: () => undefined,
+      onDone: () => undefined,
+      onError: (e) => {
+        captured = e;
+      },
+    });
+    await flush();
+    expect(captured).toBeInstanceOf(AuthRequiredError);
+  });
+
+  it("ignores SSE comment lines", async () => {
+    const body = `: keepalive\n\ndata: ${JSON.stringify({ text: "x" })}\n\nevent: done\ndata: {}\n\n`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => sse(body)),
+    );
+    const deltas: string[] = [];
+    askStream("q", {
+      onDelta: (t) => deltas.push(t),
+      onCitations: () => undefined,
+      onDone: () => undefined,
+      onError: () => undefined,
+    });
+    await flush();
+    expect(deltas).toEqual(["x"]);
+  });
+});

--- a/apps/web/src/lib/api-ask.ts
+++ b/apps/web/src/lib/api-ask.ts
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Streaming consumer for POST /api/ask. The route emits Server-Sent
+// Events:
+//
+//   data: {"text": "..."}\n\n                      (incremental token chunk)
+//   event: citations\ndata: [{...}, {...}]\n\n    (final citations)
+//   event: done\ndata: {}\n\n                     (stream complete)
+//
+// We don't use the browser EventSource because:
+//   1. EventSource is GET-only; /api/ask is POST.
+//   2. We need to send custom headers (X-Local-Dev-Email in dev) and
+//      `credentials: include` for the Access cookie.
+//   3. We want a real AbortController so the user can hit Stop.
+//
+// Errors: when the worker rejects before the stream opens (401, 429,
+// schema 400) it returns a normal JSON ApiResult<err>. We detect that by
+// inspecting Content-Type and surface an `ApiError` to onError. A 429
+// RATE_LIMITED with `details` is the trigger for the rate-limit banner —
+// `.details` is preserved verbatim.
+
+import { ApiError, AuthRequiredError } from "@/lib/api";
+import { devHeaders } from "@/lib/dev";
+import type { AskCitation } from "@/lib/types";
+import { ErrorCodes } from "@loomwiki/shared";
+
+export interface AskStreamCallbacks {
+  /** Each token chunk from the model. Append to the rendered answer. */
+  onDelta(text: string): void;
+  /** Final citations. Always fires before `onDone` on a successful stream. */
+  onCitations(citations: AskCitation[]): void;
+  /** Stream complete — no more events. */
+  onDone(): void;
+  /**
+   * Pre-stream HTTP error (401/429/4xx) or a mid-stream parse / network
+   * failure. After this fires, no further callbacks fire.
+   */
+  onError(err: ApiError | AuthRequiredError): void;
+}
+
+export interface AskStreamHandle {
+  /** Aborts the in-flight fetch + reader. Idempotent. */
+  abort(): void;
+}
+
+export function askStream(question: string, callbacks: AskStreamCallbacks): AskStreamHandle {
+  const controller = new AbortController();
+  let aborted = false;
+
+  void run(question, callbacks, controller);
+
+  return {
+    abort: () => {
+      if (aborted) return;
+      aborted = true;
+      controller.abort();
+    },
+  };
+}
+
+async function run(
+  question: string,
+  callbacks: AskStreamCallbacks,
+  controller: AbortController,
+): Promise<void> {
+  let res: Response;
+  try {
+    res = await fetch("/api/ask", {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+        ...devHeaders(),
+      },
+      body: JSON.stringify({ question }),
+      signal: controller.signal,
+    });
+  } catch (cause) {
+    if (controller.signal.aborted) {
+      // User-initiated abort — surface a typed error so the UI can
+      // distinguish abort from a network failure if it cares.
+      callbacks.onError(new ApiError("ABORTED", "request aborted", 0));
+      return;
+    }
+    callbacks.onError(
+      new ApiError("NETWORK_ERROR", cause instanceof Error ? cause.message : "network error", 0),
+    );
+    return;
+  }
+
+  if (res.status === 401) {
+    callbacks.onError(new AuthRequiredError(readLoginUrlFromMeta()));
+    return;
+  }
+
+  // The worker returns SSE on success and JSON on error. Distinguish by
+  // Content-Type: a JSON body means the request was rejected before any
+  // SSE frames were written.
+  const contentType = res.headers.get("Content-Type") ?? "";
+  const isJson = contentType.includes("application/json");
+  if (!res.ok || isJson) {
+    let body: unknown = null;
+    try {
+      body = await res.json();
+    } catch {
+      callbacks.onError(
+        new ApiError(
+          ErrorCodes.INTERNAL_ERROR,
+          `Non-JSON response (status ${res.status})`,
+          res.status,
+        ),
+      );
+      return;
+    }
+    const result = body as {
+      ok?: boolean;
+      error?: { code: string; message: string; details?: unknown };
+    };
+    if (result && typeof result === "object" && result.ok === false && result.error) {
+      callbacks.onError(
+        new ApiError(result.error.code, result.error.message, res.status, result.error.details),
+      );
+      return;
+    }
+    callbacks.onError(
+      new ApiError(
+        ErrorCodes.INTERNAL_ERROR,
+        `Malformed API response (status ${res.status})`,
+        res.status,
+      ),
+    );
+    return;
+  }
+
+  if (!res.body) {
+    callbacks.onError(new ApiError(ErrorCodes.INTERNAL_ERROR, "Response had no body", res.status));
+    return;
+  }
+
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  // Carry-over buffer: SSE frames are delimited by \n\n, but a single
+  // network read may deliver a partial frame. Hold the tail until we
+  // see the next delimiter.
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      // Drain every complete frame from the buffer.
+      let delimIdx = buffer.indexOf("\n\n");
+      while (delimIdx !== -1) {
+        const frame = buffer.slice(0, delimIdx);
+        buffer = buffer.slice(delimIdx + 2);
+        const result = handleFrame(frame, callbacks);
+        if (result === "done") {
+          // Stop reading; the route may close after the done frame and
+          // we don't want to block on a closed stream.
+          callbacks.onDone();
+          await reader.cancel().catch(() => {});
+          return;
+        }
+        delimIdx = buffer.indexOf("\n\n");
+      }
+    }
+    // Stream ended cleanly without an explicit done event — flush any
+    // residual frame, then signal done so the UI can re-enable submit.
+    if (buffer.trim().length > 0) {
+      handleFrame(buffer, callbacks);
+    }
+    callbacks.onDone();
+  } catch (cause) {
+    if (controller.signal.aborted) {
+      callbacks.onError(new ApiError("ABORTED", "request aborted", 0));
+      return;
+    }
+    callbacks.onError(
+      new ApiError(
+        "NETWORK_ERROR",
+        cause instanceof Error ? cause.message : "stream read failed",
+        0,
+      ),
+    );
+  }
+}
+
+/**
+ * Parse a single SSE frame and dispatch the right callback. Returns
+ * "done" if this frame was the terminal `event: done` frame so the
+ * caller can stop reading.
+ */
+function handleFrame(rawFrame: string, callbacks: AskStreamCallbacks): "done" | "more" {
+  const frame = rawFrame.trim();
+  if (frame.length === 0) return "more";
+
+  let event = "message";
+  const dataLines: string[] = [];
+  for (const line of frame.split("\n")) {
+    if (line.startsWith(":")) continue; // SSE comment / keep-alive.
+    if (line.startsWith("event:")) {
+      event = line.slice("event:".length).trim();
+    } else if (line.startsWith("data:")) {
+      dataLines.push(line.slice("data:".length).trimStart());
+    }
+  }
+  const dataStr = dataLines.join("\n");
+
+  if (event === "done") return "done";
+  if (dataStr.length === 0) return "more";
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(dataStr);
+  } catch {
+    // A malformed payload is non-fatal: skip the frame so a single bad
+    // chunk doesn't tear down the whole stream.
+    return "more";
+  }
+
+  if (event === "citations") {
+    if (Array.isArray(payload)) {
+      callbacks.onCitations(payload as AskCitation[]);
+    }
+    return "more";
+  }
+
+  // Default `message` event — token chunk. Accept either {text: "..."}
+  // or a bare string for forward-compat with raw token streams.
+  if (typeof payload === "string") {
+    callbacks.onDelta(payload);
+  } else if (payload && typeof payload === "object" && "text" in payload) {
+    const text = (payload as { text?: unknown }).text;
+    if (typeof text === "string") callbacks.onDelta(text);
+  }
+  return "more";
+}
+
+function readLoginUrlFromMeta(): string | null {
+  if (typeof document === "undefined") return null;
+  const meta = document.querySelector('meta[name="loomwiki-access-login-url"]');
+  if (!meta) return null;
+  const url = meta.getAttribute("content");
+  return url && url.length > 0 ? url : null;
+}

--- a/apps/web/src/lib/api-search.test.ts
+++ b/apps/web/src/lib/api-search.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Pins the wire shape for /api/search and the 429 RATE_LIMITED contract
+// the RateLimitBanner reads from.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiError } from "./api";
+import { searchWiki } from "./api-search";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function mockFetch(response: Response): ReturnType<typeof vi.fn> {
+  const f = vi.fn(async () => response);
+  vi.stubGlobal("fetch", f);
+  return f;
+}
+
+beforeEach(() => {
+  vi.unstubAllGlobals();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("searchWiki", () => {
+  it("POSTs the query + topK and unwraps the response", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse(200, {
+        ok: true,
+        data: {
+          results: [
+            {
+              path: "/wiki/concepts/dmarc.md",
+              title: "DMARC",
+              kind: "concept",
+              snippet: "Hello <mark>DMARC</mark>",
+              score: 0.91,
+              source: "ai_search",
+            },
+          ],
+          mode: "hybrid",
+        },
+      }),
+    );
+    const out = await searchWiki("dmarc");
+    expect(out.mode).toBe("hybrid");
+    expect(out.results).toHaveLength(1);
+    expect(out.results[0]?.path).toBe("/wiki/concepts/dmarc.md");
+
+    const call = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+    expect(call?.[0]).toBe("/api/search");
+    expect(call?.[1]?.method).toBe("POST");
+    expect(call?.[1]?.body).toBe(JSON.stringify({ query: "dmarc", topK: 10 }));
+  });
+
+  it("forwards an explicit topK", async () => {
+    const fetchMock = mockFetch(
+      jsonResponse(200, { ok: true, data: { results: [], mode: "hybrid" } }),
+    );
+    await searchWiki("x", 25);
+    const call = fetchMock.mock.calls[0] as [string, RequestInit] | undefined;
+    expect(call?.[1]?.body).toBe(JSON.stringify({ query: "x", topK: 25 }));
+  });
+
+  it("surfaces RATE_LIMITED with `details` so the banner can render it", async () => {
+    const details = {
+      limit: 50,
+      used: 50,
+      scope: "user",
+      reset_at: "2026-05-05T00:00:00Z",
+    };
+    mockFetch(
+      jsonResponse(429, {
+        ok: false,
+        error: { code: "RATE_LIMITED", message: "rate limited", details },
+      }),
+    );
+    try {
+      await searchWiki("x");
+      expect.fail("expected throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError);
+      expect((err as ApiError).code).toBe("RATE_LIMITED");
+      expect((err as ApiError).status).toBe(429);
+      expect((err as ApiError).details).toEqual(details);
+    }
+  });
+
+  it("propagates fts5_fallback mode unchanged", async () => {
+    mockFetch(
+      jsonResponse(200, {
+        ok: true,
+        data: { results: [], mode: "fts5_fallback" },
+      }),
+    );
+    const out = await searchWiki("x");
+    expect(out.mode).toBe("fts5_fallback");
+  });
+});

--- a/apps/web/src/lib/api-search.ts
+++ b/apps/web/src/lib/api-search.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Wraps POST /api/search through the generic api.ts client. Thin on
+// purpose — the search route returns a fully-typed `WikiSearchResponse`
+// that the components can render directly. ApiError flows through
+// untouched so the caller can branch on `.code === "RATE_LIMITED"` and
+// hand `.details` to the RateLimitBanner.
+
+import { apiPost } from "@/lib/api";
+import type { WikiSearchResponse } from "@/lib/types";
+
+/**
+ * Default page size mirrors the worker's max-50 hard cap; 10 is the
+ * sweet spot for the dropdown and the full search page both — large
+ * enough to feel useful, small enough that the FTS5 fallback path
+ * doesn't drown the user in low-precision matches.
+ */
+export const DEFAULT_SEARCH_TOP_K = 10;
+
+export async function searchWiki(
+  query: string,
+  topK = DEFAULT_SEARCH_TOP_K,
+): Promise<WikiSearchResponse> {
+  return apiPost<WikiSearchResponse>("/api/search", { query, topK });
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -121,3 +121,61 @@ export interface WikiConflictDetails {
   attempted_frontmatter: WikiPageFrontmatter;
   attempted_body: string;
 }
+
+// ---------- Search + Ask (M6) ----------
+
+/**
+ * Where the result row came from. `ai_search` is Cloudflare AI Search's
+ * hybrid (vector + BM25) result; `fts5` is the on-D1 fallback path used
+ * when AI Search is unavailable or its index hasn't been built yet.
+ */
+export type WikiSearchSource = "ai_search" | "fts5";
+
+/**
+ * `hybrid` = AI Search returned. `fts5_fallback` = AI Search was
+ * skipped/unavailable and only D1 FTS5 results are present. The UI
+ * uses this to show a "semantic search unavailable" banner so users
+ * understand why ranking might feel keyword-y today.
+ */
+export type WikiSearchMode = "hybrid" | "fts5_fallback";
+
+export interface WikiSearchResult {
+  /** Vault path, e.g. `/wiki/concepts/dmarc.md`. */
+  path: string;
+  title: string;
+  kind: WikiPageKind;
+  /**
+   * Pre-rendered snippet. For FTS5 results it contains `<mark>...</mark>`
+   * tags around matched terms — render via the helper that converts
+   * those into React `<mark>` elements (NOT innerHTML).
+   */
+  snippet: string;
+  score: number;
+  source: WikiSearchSource;
+}
+
+export interface WikiSearchResponse {
+  results: WikiSearchResult[];
+  mode: WikiSearchMode;
+}
+
+export interface AskCitation {
+  /** Vault path, e.g. `/wiki/concepts/dmarc.md`. */
+  path: string;
+  title: string;
+  kind: WikiPageKind;
+  /** Slugified heading anchor, or null when the chunk had no heading. */
+  heading_slug: string | null;
+}
+
+/**
+ * Shape of the `error.details` field on a 429 RATE_LIMITED. Surfaced in
+ * the RateLimitBanner. `scope` selects the wording (per-user vs the
+ * shared workspace bucket); `reset_at` is ISO-8601.
+ */
+export interface RateLimitDetails {
+  limit: number;
+  used: number;
+  scope: "user" | "workspace";
+  reset_at: string;
+}

--- a/apps/web/src/pages/ask.astro
+++ b/apps/web/src/pages/ask.astro
@@ -1,0 +1,30 @@
+---
+// SPDX-License-Identifier: Apache-2.0
+// /ask page. SSR-fetches /api/me to gate; the actual question/answer
+// streaming runs client-side from AskBox via the SSE consumer in
+// lib/api-ask.ts.
+
+import AppShell from "@/components/AppShell.astro";
+import { AskPage } from "@/components/ask/AskPage";
+import Layout from "@/layouts/Layout.astro";
+import { SsrAuthRequiredError, ssrApiGet } from "@/lib/ssr-api";
+import type { CurrentUserPayload } from "@/lib/types";
+
+let me: CurrentUserPayload;
+try {
+  me = await ssrApiGet<CurrentUserPayload>(Astro.request, "/api/me");
+} catch (err) {
+  if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
+  throw err;
+}
+---
+
+<Layout title={`Ask — ${me.workspace.name}`}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+    <div slot="sidebar" class="p-4 text-xs text-muted-foreground">
+      <p class="font-medium text-foreground">Ask</p>
+      <p class="mt-1">Answers grounded in your wiki, with citations.</p>
+    </div>
+    <AskPage slot="main" client:load />
+  </AppShell>
+</Layout>

--- a/apps/web/src/pages/search.astro
+++ b/apps/web/src/pages/search.astro
@@ -1,0 +1,28 @@
+---
+// SPDX-License-Identifier: Apache-2.0
+// Full-page wiki search. SSR-fetches /api/me to gate the page; the
+// actual search (POST /api/search) runs client-side from SearchPage.
+
+import AppShell from "@/components/AppShell.astro";
+import { SearchPage } from "@/components/search/SearchPage";
+import Layout from "@/layouts/Layout.astro";
+import { SsrAuthRequiredError, ssrApiGet } from "@/lib/ssr-api";
+import type { CurrentUserPayload } from "@/lib/types";
+
+let me: CurrentUserPayload;
+try {
+  me = await ssrApiGet<CurrentUserPayload>(Astro.request, "/api/me");
+} catch (err) {
+  if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
+  throw err;
+}
+---
+
+<Layout title={`Search — ${me.workspace.name}`}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+    <div slot="sidebar" class="p-4 text-xs text-muted-foreground">
+      Search across the wiki. Use the sidebar nav to switch surfaces.
+    </div>
+    <SearchPage slot="main" client:load />
+  </AppShell>
+</Layout>

--- a/apps/worker/src/__tests__/__fixtures__/db.ts
+++ b/apps/worker/src/__tests__/__fixtures__/db.ts
@@ -27,8 +27,16 @@ const TRUNCATE_ORDER = [
   "users",
 ];
 
+// FTS5 virtual tables are independent of FK ordering — flush them
+// alongside the regular tables so search-index state doesn't bleed
+// between tests in the same file.
+const FTS5_TABLES = ["wiki_pages_fts"];
+
 export async function resetDb(): Promise<void> {
   for (const table of TRUNCATE_ORDER) {
+    await env.DB.prepare(`DELETE FROM ${table}`).run();
+  }
+  for (const table of FTS5_TABLES) {
     await env.DB.prepare(`DELETE FROM ${table}`).run();
   }
 }

--- a/apps/worker/src/__tests__/__fixtures__/db.ts
+++ b/apps/worker/src/__tests__/__fixtures__/db.ts
@@ -16,6 +16,7 @@ export async function applyMigrations(): Promise<void> {
 
 // Truncate the application tables. Order respects FK references.
 const TRUNCATE_ORDER = [
+  "llm_usage_daily",
   "byok_keys",
   "proposals",
   "ingest_runs",

--- a/apps/worker/src/__tests__/__fixtures__/fake-ai-search.ts
+++ b/apps/worker/src/__tests__/__fixtures__/fake-ai-search.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// In-memory fake of the Cloudflare AI Search Workers binding. Matches
+// the surface declared in apps/worker/src/ai-search-binding.d.ts so the
+// search orchestrator + indexer can be exercised without the real
+// (remote-only) AI Search service.
+//
+// Behavior model:
+//   - upsert(docs): replaces docs by id (last write wins).
+//   - delete(ids): drops matching ids; returns the number actually removed.
+//   - search({ query, topK }): returns docs whose `content` contains
+//     any whitespace-tokenized term from `query` (case-insensitive).
+//     Score is the count of matched terms, normalized to [0..1] by
+//     dividing by the max term count across hits. topK trims the result.
+//
+// The fake is intentionally simple — it exists to verify call shape
+// (id stability for chunked upserts, metadata round-trip, topK), not to
+// model BM25 or vector relevance. Tests that care about ranking should
+// hit the FTS5 backend, which uses real SQLite.
+
+import type {
+  AiSearchBinding,
+  AiSearchMatch,
+  AiSearchMatchMetadata,
+  AiSearchQueryResult,
+  AiSearchUpsertDoc,
+} from "../../ai-search-binding.js";
+import type { Env } from "../../env.js";
+
+interface StoredDoc {
+  id: string;
+  content: string;
+  metadata: AiSearchMatchMetadata;
+}
+
+export class FakeAiSearchBinding implements AiSearchBinding {
+  /** Public for test introspection; do not mutate from outside. */
+  public readonly docs = new Map<string, StoredDoc>();
+  /** Set true to force every method to throw — exercises fallback paths. */
+  public failNext = false;
+
+  async upsert(docs: AiSearchUpsertDoc[]): Promise<{ upserted: number }> {
+    if (this.failNext) throw new Error("fake-ai-search: forced upsert failure");
+    for (const d of docs) {
+      this.docs.set(d.id, { id: d.id, content: d.content, metadata: d.metadata ?? {} });
+    }
+    return { upserted: docs.length };
+  }
+
+  async delete(ids: string[]): Promise<{ deleted: number }> {
+    if (this.failNext) throw new Error("fake-ai-search: forced delete failure");
+    let n = 0;
+    for (const id of ids) {
+      if (this.docs.delete(id)) n += 1;
+    }
+    return { deleted: n };
+  }
+
+  async search(opts: { query: string; topK?: number }): Promise<AiSearchQueryResult> {
+    if (this.failNext) throw new Error("fake-ai-search: forced search failure");
+    const terms = opts.query
+      .toLowerCase()
+      .split(/\s+/)
+      .filter((t) => t.length > 0);
+    const limit = opts.topK ?? 10;
+    if (terms.length === 0) return { matches: [] };
+
+    const scored: { doc: StoredDoc; hits: number }[] = [];
+    for (const doc of this.docs.values()) {
+      const haystack = `${doc.content} ${JSON.stringify(doc.metadata)}`.toLowerCase();
+      let hits = 0;
+      for (const t of terms) {
+        if (haystack.includes(t)) hits += 1;
+      }
+      if (hits > 0) scored.push({ doc, hits });
+    }
+
+    scored.sort((a, b) => b.hits - a.hits);
+    const trimmed = scored.slice(0, limit);
+    const maxHits = trimmed.reduce((m, s) => Math.max(m, s.hits), 1);
+    const matches: AiSearchMatch[] = trimmed.map(({ doc, hits }) => ({
+      id: doc.id,
+      score: hits / maxHits,
+      content: doc.content,
+      metadata: doc.metadata,
+    }));
+    return { matches };
+  }
+}
+
+/**
+ * Compose an Env override that injects a fake AI Search binding.
+ * Use with the existing `envOverride` pattern in test files (see
+ * llm.test.ts) — pass the result through `{ ...env, ...envWithFakeAiSearch(...) }`.
+ */
+export function envWithFakeAiSearch(
+  base: Env,
+  binding: FakeAiSearchBinding | undefined,
+  extras: Partial<Env> = {},
+): Env {
+  return { ...base, AI_SEARCH: binding, ...extras } as Env;
+}

--- a/apps/worker/src/__tests__/ai-search.test.ts
+++ b/apps/worker/src/__tests__/ai-search.test.ts
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for the AI Search wrapper. Uses the in-memory fake binding
+// (see __fixtures__/fake-ai-search.ts) so the call surface — id
+// stability for chunked upserts, metadata round-trip, and the "throw
+// AI_SEARCH_UNAVAILABLE" sentinel paths — is exercised without the
+// remote-only AI Search service.
+
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { Env } from "../env.js";
+import { queryAiSearch, removePageFromAiSearch, upsertPageInAiSearch } from "../lib/ai-search.js";
+import { FakeAiSearchBinding } from "./__fixtures__/fake-ai-search.js";
+
+function envWith(overrides: Partial<Env>): Env {
+  return { ...env, ...overrides } as Env;
+}
+
+const FRONTMATTER = { title: "DMARC", kind: "concept" as const };
+
+describe("ai-search availability sentinel", () => {
+  it("throws AI_SEARCH_UNAVAILABLE when the binding is missing", async () => {
+    const e = envWith({ AI_SEARCH: undefined, AI_SEARCH_ENABLED: "true" });
+    await expect(queryAiSearch(e, { query: "x" })).rejects.toMatchObject({
+      code: "AI_SEARCH_UNAVAILABLE",
+    });
+  });
+
+  it("throws AI_SEARCH_UNAVAILABLE when AI_SEARCH_ENABLED is 'false' (even if binding present)", async () => {
+    const fake = new FakeAiSearchBinding();
+    const e = envWith({ AI_SEARCH: fake, AI_SEARCH_ENABLED: "false" });
+    await expect(queryAiSearch(e, { query: "x" })).rejects.toMatchObject({
+      code: "AI_SEARCH_UNAVAILABLE",
+    });
+  });
+
+  it("wraps a binding throw as AI_SEARCH_UNAVAILABLE", async () => {
+    const fake = new FakeAiSearchBinding();
+    fake.failNext = true;
+    const e = envWith({ AI_SEARCH: fake, AI_SEARCH_ENABLED: "true" });
+    await expect(queryAiSearch(e, { query: "anything" })).rejects.toMatchObject({
+      code: "AI_SEARCH_UNAVAILABLE",
+    });
+  });
+});
+
+describe("upsertPageInAiSearch", () => {
+  it("chunks a multi-section page into one doc per section with stable ids", async () => {
+    const fake = new FakeAiSearchBinding();
+    const e = envWith({ AI_SEARCH: fake, AI_SEARCH_ENABLED: "true" });
+
+    const body = [
+      "# Top",
+      "",
+      "Intro paragraph for the page.",
+      "",
+      "## Authentication",
+      "",
+      "DMARC builds on SPF and DKIM.",
+      "",
+      "## Reporting",
+      "",
+      "Aggregate (rua) and forensic (ruf) report types.",
+    ].join("\n");
+
+    await upsertPageInAiSearch(e, {
+      path: "/wiki/concepts/dmarc.md",
+      frontmatter: FRONTMATTER,
+      body,
+    });
+
+    // Top + Authentication + Reporting = 3 chunks (no prelude — body
+    // starts with an H1, prelude is empty).
+    const docs = [...fake.docs.values()];
+    expect(docs.length).toBe(3);
+    const ids = docs.map((d) => d.id).sort();
+    expect(ids).toEqual([
+      "/wiki/concepts/dmarc.md#0",
+      "/wiki/concepts/dmarc.md#1",
+      "/wiki/concepts/dmarc.md#2",
+    ]);
+
+    // Re-upsert with one fewer section — id #0 stays put, the trailing
+    // chunks should be swept on the next sync.
+    const trimmed = ["# Top", "", "just the prelude"].join("\n");
+    await upsertPageInAiSearch(e, {
+      path: "/wiki/concepts/dmarc.md",
+      frontmatter: FRONTMATTER,
+      body: trimmed,
+    });
+    expect(fake.docs.has("/wiki/concepts/dmarc.md#0")).toBe(true);
+    expect(fake.docs.has("/wiki/concepts/dmarc.md#1")).toBe(false);
+    expect(fake.docs.has("/wiki/concepts/dmarc.md#2")).toBe(false);
+  });
+
+  it("removes the page when the body chunks to nothing", async () => {
+    const fake = new FakeAiSearchBinding();
+    const e = envWith({ AI_SEARCH: fake, AI_SEARCH_ENABLED: "true" });
+    await upsertPageInAiSearch(e, {
+      path: "/wiki/x.md",
+      frontmatter: FRONTMATTER,
+      body: "real body",
+    });
+    expect(fake.docs.size).toBeGreaterThan(0);
+
+    await upsertPageInAiSearch(e, {
+      path: "/wiki/x.md",
+      frontmatter: FRONTMATTER,
+      body: "   ", // chunks to nothing
+    });
+    expect([...fake.docs.keys()].some((k) => k.startsWith("/wiki/x.md"))).toBe(false);
+  });
+});
+
+describe("queryAiSearch result mapping", () => {
+  it("maps AiSearchMatch records into WikiSearchResult with required fields populated", async () => {
+    const fake = new FakeAiSearchBinding();
+    const e = envWith({ AI_SEARCH: fake, AI_SEARCH_ENABLED: "true" });
+    await upsertPageInAiSearch(e, {
+      path: "/wiki/concepts/dmarc.md",
+      frontmatter: FRONTMATTER,
+      body: "# DMARC\n\nDomain Message Authentication Reporting & Conformance.",
+    });
+
+    const results = await queryAiSearch(e, { query: "dmarc", topK: 5 });
+    expect(results.length).toBeGreaterThan(0);
+    const top = results[0];
+    expect(top).toBeDefined();
+    if (!top) return;
+    expect(top.path).toBe("/wiki/concepts/dmarc.md");
+    expect(top.title).toBe("DMARC");
+    expect(top.kind).toBe("concept");
+    expect(top.source).toBe("ai_search");
+    expect(typeof top.score).toBe("number");
+    expect(top.snippet.length).toBeGreaterThan(0);
+    expect(top.snippet.length).toBeLessThanOrEqual(280);
+  });
+
+  it("returns [] for an empty query without calling the binding", async () => {
+    const fake = new FakeAiSearchBinding();
+    fake.failNext = true; // would throw if invoked
+    const e = envWith({ AI_SEARCH: fake, AI_SEARCH_ENABLED: "true" });
+    const results = await queryAiSearch(e, { query: "  " });
+    expect(results).toEqual([]);
+  });
+
+  it("drops matches missing required metadata fields", async () => {
+    const fake = new FakeAiSearchBinding();
+    // Push a doc directly with no metadata; should be filtered out.
+    await fake.upsert([{ id: "raw-1", content: "loose payload" }]);
+    const e = envWith({ AI_SEARCH: fake, AI_SEARCH_ENABLED: "true" });
+    const results = await queryAiSearch(e, { query: "loose" });
+    expect(results).toEqual([]);
+  });
+});
+
+describe("removePageFromAiSearch", () => {
+  it("issues a bounded fan-out delete that removes every chunk for a path", async () => {
+    const fake = new FakeAiSearchBinding();
+    const e = envWith({ AI_SEARCH: fake, AI_SEARCH_ENABLED: "true" });
+    await upsertPageInAiSearch(e, {
+      path: "/wiki/a.md",
+      frontmatter: FRONTMATTER,
+      body: "# A\n\none\n\n## B\n\ntwo",
+    });
+    await upsertPageInAiSearch(e, {
+      path: "/wiki/b.md",
+      frontmatter: FRONTMATTER,
+      body: "# B\n\nbody",
+    });
+    expect(fake.docs.size).toBeGreaterThan(0);
+
+    await removePageFromAiSearch(e, "/wiki/a.md");
+    for (const id of fake.docs.keys()) {
+      expect(id.startsWith("/wiki/a.md")).toBe(false);
+    }
+    // /wiki/b.md untouched.
+    expect([...fake.docs.keys()].some((k) => k.startsWith("/wiki/b.md"))).toBe(true);
+  });
+
+  it("throws AI_SEARCH_UNAVAILABLE when the underlying delete throws", async () => {
+    const fake = new FakeAiSearchBinding();
+    fake.failNext = true;
+    const e = envWith({ AI_SEARCH: fake, AI_SEARCH_ENABLED: "true" });
+    await expect(removePageFromAiSearch(e, "/wiki/x.md")).rejects.toMatchObject({
+      code: "AI_SEARCH_UNAVAILABLE",
+    });
+  });
+});

--- a/apps/worker/src/__tests__/byok.test.ts
+++ b/apps/worker/src/__tests__/byok.test.ts
@@ -48,7 +48,13 @@ describe("getBYOK (M6 null contract)", () => {
     await env.DB.prepare(
       "INSERT INTO byok_keys (workspace_id, provider, ciphertext, iv, created_by) VALUES (?, ?, ?, ?, ?)",
     )
-      .bind(DEFAULT_WORKSPACE_ID, "anthropic", new Uint8Array([1, 2, 3]), new Uint8Array([4]), user.id)
+      .bind(
+        DEFAULT_WORKSPACE_ID,
+        "anthropic",
+        new Uint8Array([1, 2, 3]),
+        new Uint8Array([4]),
+        user.id,
+      )
       .run();
 
     const key = await getBYOK(env, DEFAULT_WORKSPACE_ID, "anthropic");

--- a/apps/worker/src/__tests__/byok.test.ts
+++ b/apps/worker/src/__tests__/byok.test.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// M6 contract test: byok.ts always returns null in M6 (M8 plug-in
+// point). The test exists so the M8 PR sees an explicit failure when it
+// flips the contract — that's the moment to update the test (and the
+// rest of the BYOK plumbing).
+
+import { env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getBYOK, isKnownByokProvider } from "../lib/byok.js";
+import { getOrCreateUser } from "../lib/users.js";
+import { DEFAULT_WORKSPACE_ID, getOrBootstrapWorkspace } from "../lib/workspace.js";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+
+beforeAll(async () => {
+  await applyMigrations();
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+describe("isKnownByokProvider", () => {
+  it("recognizes the three v0.0.1 providers and rejects everything else", () => {
+    expect(isKnownByokProvider("anthropic")).toBe(true);
+    expect(isKnownByokProvider("openai")).toBe(true);
+    expect(isKnownByokProvider("google")).toBe(true);
+    expect(isKnownByokProvider("cohere")).toBe(false);
+    expect(isKnownByokProvider("")).toBe(false);
+    expect(isKnownByokProvider(undefined)).toBe(false);
+  });
+});
+
+describe("getBYOK (M6 null contract)", () => {
+  it("returns null when no row exists", async () => {
+    const user = await getOrCreateUser(env, "owner@example.com");
+    await getOrBootstrapWorkspace(env, user.id);
+
+    const key = await getBYOK(env, DEFAULT_WORKSPACE_ID, "anthropic");
+    expect(key).toBeNull();
+  });
+
+  it("returns null even when a (cipherless) row IS present (M6 placeholder)", async () => {
+    const user = await getOrCreateUser(env, "owner@example.com");
+    await getOrBootstrapWorkspace(env, user.id);
+
+    // Plant a row directly so we exercise the present-row branch.
+    await env.DB.prepare(
+      "INSERT INTO byok_keys (workspace_id, provider, ciphertext, iv, created_by) VALUES (?, ?, ?, ?, ?)",
+    )
+      .bind(DEFAULT_WORKSPACE_ID, "anthropic", new Uint8Array([1, 2, 3]), new Uint8Array([4]), user.id)
+      .run();
+
+    const key = await getBYOK(env, DEFAULT_WORKSPACE_ID, "anthropic");
+    // M6 contract: still null. M8 plug-in point flips this to the
+    // decrypted plaintext key.
+    expect(key).toBeNull();
+  });
+
+  it("returns null for an unknown provider without touching D1", async () => {
+    const user = await getOrCreateUser(env, "owner@example.com");
+    await getOrBootstrapWorkspace(env, user.id);
+
+    // biome-ignore lint/suspicious/noExplicitAny: testing the runtime guard
+    const key = await getBYOK(env, DEFAULT_WORKSPACE_ID, "cohere" as any);
+    expect(key).toBeNull();
+  });
+});

--- a/apps/worker/src/__tests__/cost-guard.test.ts
+++ b/apps/worker/src/__tests__/cost-guard.test.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// M6 cost-guard attestation. The PR description cites this file as
+// proof that all three layers of defense are independent — these tests
+// trip the per-user cap, the per-workspace cap, and verify isolation
+// between users.
+
+import { env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { isLoomwikiError } from "@loomwiki/shared";
+import type { Env } from "../env.js";
+import { assertWithinLimit, readLimits } from "../lib/cost-guard.js";
+import { getOrCreateUser } from "../lib/users.js";
+import { getUsage } from "../lib/usage.js";
+import { DEFAULT_WORKSPACE_ID, getOrBootstrapWorkspace } from "../lib/workspace.js";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+
+beforeAll(async () => {
+  await applyMigrations();
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+async function bootstrap() {
+  const a = await getOrCreateUser(env, "alice@example.com");
+  const b = await getOrCreateUser(env, "bob@example.com");
+  await getOrBootstrapWorkspace(env, a.id);
+  return { userA: a.id, userB: b.id };
+}
+
+// Build an Env with the given numeric limits without mutating the
+// shared workerd env (which would leak across tests).
+function envWithLimits(overrides: Partial<{
+  user_ask: number;
+  user_search: number;
+  ws_ask: number;
+  ws_search: number;
+}>): Env {
+  return {
+    ...env,
+    LLM_DAILY_LIMIT_PER_USER_ASK: String(overrides.user_ask ?? 1000),
+    LLM_DAILY_LIMIT_PER_USER_SEARCH: String(overrides.user_search ?? 1000),
+    LLM_DAILY_LIMIT_PER_WORKSPACE_ASK: String(overrides.ws_ask ?? 10000),
+    LLM_DAILY_LIMIT_PER_WORKSPACE_SEARCH: String(overrides.ws_search ?? 10000),
+  } as Env;
+}
+
+describe("readLimits", () => {
+  it("falls back to defaults on missing/invalid env values", () => {
+    const limits = readLimits({
+      ...env,
+      LLM_DAILY_LIMIT_PER_USER_ASK: "",
+      LLM_DAILY_LIMIT_PER_USER_SEARCH: "garbage",
+      LLM_DAILY_LIMIT_PER_WORKSPACE_ASK: "-1",
+      LLM_DAILY_LIMIT_PER_WORKSPACE_SEARCH: "10000",
+    } as Env);
+    expect(limits).toEqual({
+      perUserAsk: 100,
+      perUserSearch: 1000,
+      perWorkspaceAsk: 1000,
+      perWorkspaceSearch: 10000,
+    });
+  });
+});
+
+describe("assertWithinLimit", () => {
+  it("trips the per-user ask cap with the right details payload", async () => {
+    const { userA } = await bootstrap();
+    const e = envWithLimits({ user_ask: 2, ws_ask: 1000 });
+
+    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+
+    let caught: unknown = null;
+    try {
+      await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(isLoomwikiError(caught)).toBe(true);
+    if (!isLoomwikiError(caught)) return;
+    expect(caught.code).toBe("RATE_LIMITED");
+    expect(caught.status).toBe(429);
+    expect(caught.details).toMatchObject({
+      limit: 2,
+      used: 2,
+      scope: "user",
+    });
+    // reset_at must be a parseable ISO date.
+    expect(typeof (caught.details as { reset_at: string }).reset_at).toBe("string");
+  });
+
+  it("trips the per-workspace ask cap when only the workspace counter is over", async () => {
+    const { userA, userB } = await bootstrap();
+    // High user cap, low workspace cap — combined activity from two
+    // users hits workspace ceiling first.
+    const e = envWithLimits({ user_ask: 1000, ws_ask: 3 });
+
+    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userB, kind: "ask" });
+    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+
+    let caught: unknown = null;
+    try {
+      await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userB, kind: "ask" });
+    } catch (err) {
+      caught = err;
+    }
+    expect(isLoomwikiError(caught)).toBe(true);
+    if (!isLoomwikiError(caught)) return;
+    expect(caught.details).toMatchObject({ limit: 3, used: 3, scope: "workspace" });
+  });
+
+  it("user A's cap doesn't tank user B's request", async () => {
+    const { userA, userB } = await bootstrap();
+    const e = envWithLimits({ user_ask: 1, ws_ask: 1000 });
+
+    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+    await expect(
+      assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" }),
+    ).rejects.toThrow();
+
+    // userB still has fresh counter — should succeed.
+    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userB, kind: "ask" });
+
+    expect(
+      (
+        await getUsage(env, {
+          workspaceId: DEFAULT_WORKSPACE_ID,
+          scopeType: "user",
+          scopeId: userB,
+        })
+      ).ask_count,
+    ).toBe(1);
+  });
+
+  it("ask and search counters are independent", async () => {
+    const { userA } = await bootstrap();
+    const e = envWithLimits({ user_ask: 1, user_search: 100 });
+
+    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+    await expect(
+      assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" }),
+    ).rejects.toThrow();
+
+    // Search is fine despite ask being capped.
+    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "search" });
+  });
+
+  it("on success, increments BOTH the per-user and per-workspace counter", async () => {
+    const { userA } = await bootstrap();
+    const e = envWithLimits({ user_ask: 100, ws_ask: 100 });
+
+    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+
+    expect(
+      (
+        await getUsage(env, {
+          workspaceId: DEFAULT_WORKSPACE_ID,
+          scopeType: "user",
+          scopeId: userA,
+        })
+      ).ask_count,
+    ).toBe(1);
+    expect(
+      (
+        await getUsage(env, {
+          workspaceId: DEFAULT_WORKSPACE_ID,
+          scopeType: "workspace",
+          scopeId: "_workspace",
+        })
+      ).ask_count,
+    ).toBe(1);
+  });
+});

--- a/apps/worker/src/__tests__/cost-guard.test.ts
+++ b/apps/worker/src/__tests__/cost-guard.test.ts
@@ -6,12 +6,12 @@
 // between users.
 
 import { env } from "cloudflare:test";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { isLoomwikiError } from "@loomwiki/shared";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { Env } from "../env.js";
 import { assertWithinLimit, readLimits } from "../lib/cost-guard.js";
-import { getOrCreateUser } from "../lib/users.js";
 import { getUsage } from "../lib/usage.js";
+import { getOrCreateUser } from "../lib/users.js";
 import { DEFAULT_WORKSPACE_ID, getOrBootstrapWorkspace } from "../lib/workspace.js";
 import { applyMigrations, resetDb } from "./__fixtures__/db.js";
 
@@ -32,12 +32,14 @@ async function bootstrap() {
 
 // Build an Env with the given numeric limits without mutating the
 // shared workerd env (which would leak across tests).
-function envWithLimits(overrides: Partial<{
-  user_ask: number;
-  user_search: number;
-  ws_ask: number;
-  ws_search: number;
-}>): Env {
+function envWithLimits(
+  overrides: Partial<{
+    user_ask: number;
+    user_search: number;
+    ws_ask: number;
+    ws_search: number;
+  }>,
+): Env {
   return {
     ...env,
     LLM_DAILY_LIMIT_PER_USER_ASK: String(overrides.user_ask ?? 1000),
@@ -70,12 +72,27 @@ describe("assertWithinLimit", () => {
     const { userA } = await bootstrap();
     const e = envWithLimits({ user_ask: 2, ws_ask: 1000 });
 
-    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
-    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+    await assertWithinLimit({
+      env: e,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      userId: userA,
+      kind: "ask",
+    });
+    await assertWithinLimit({
+      env: e,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      userId: userA,
+      kind: "ask",
+    });
 
     let caught: unknown = null;
     try {
-      await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+      await assertWithinLimit({
+        env: e,
+        workspaceId: DEFAULT_WORKSPACE_ID,
+        userId: userA,
+        kind: "ask",
+      });
     } catch (err) {
       caught = err;
     }
@@ -98,13 +115,33 @@ describe("assertWithinLimit", () => {
     // users hits workspace ceiling first.
     const e = envWithLimits({ user_ask: 1000, ws_ask: 3 });
 
-    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
-    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userB, kind: "ask" });
-    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+    await assertWithinLimit({
+      env: e,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      userId: userA,
+      kind: "ask",
+    });
+    await assertWithinLimit({
+      env: e,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      userId: userB,
+      kind: "ask",
+    });
+    await assertWithinLimit({
+      env: e,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      userId: userA,
+      kind: "ask",
+    });
 
     let caught: unknown = null;
     try {
-      await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userB, kind: "ask" });
+      await assertWithinLimit({
+        env: e,
+        workspaceId: DEFAULT_WORKSPACE_ID,
+        userId: userB,
+        kind: "ask",
+      });
     } catch (err) {
       caught = err;
     }
@@ -117,13 +154,23 @@ describe("assertWithinLimit", () => {
     const { userA, userB } = await bootstrap();
     const e = envWithLimits({ user_ask: 1, ws_ask: 1000 });
 
-    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+    await assertWithinLimit({
+      env: e,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      userId: userA,
+      kind: "ask",
+    });
     await expect(
       assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" }),
     ).rejects.toThrow();
 
     // userB still has fresh counter — should succeed.
-    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userB, kind: "ask" });
+    await assertWithinLimit({
+      env: e,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      userId: userB,
+      kind: "ask",
+    });
 
     expect(
       (
@@ -140,20 +187,35 @@ describe("assertWithinLimit", () => {
     const { userA } = await bootstrap();
     const e = envWithLimits({ user_ask: 1, user_search: 100 });
 
-    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+    await assertWithinLimit({
+      env: e,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      userId: userA,
+      kind: "ask",
+    });
     await expect(
       assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" }),
     ).rejects.toThrow();
 
     // Search is fine despite ask being capped.
-    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "search" });
+    await assertWithinLimit({
+      env: e,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      userId: userA,
+      kind: "search",
+    });
   });
 
   it("on success, increments BOTH the per-user and per-workspace counter", async () => {
     const { userA } = await bootstrap();
     const e = envWithLimits({ user_ask: 100, ws_ask: 100 });
 
-    await assertWithinLimit({ env: e, workspaceId: DEFAULT_WORKSPACE_ID, userId: userA, kind: "ask" });
+    await assertWithinLimit({
+      env: e,
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      userId: userA,
+      kind: "ask",
+    });
 
     expect(
       (

--- a/apps/worker/src/__tests__/embeddings.test.ts
+++ b/apps/worker/src/__tests__/embeddings.test.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { env } from "cloudflare:test";
+import { describe, expect, it } from "vitest";
+import type { Env } from "../env.js";
+import { embed } from "../lib/embeddings.js";
+
+interface RunCall {
+  model: string;
+  body: unknown;
+}
+
+function fakeAi(handler: (texts: string[]) => number[][]): {
+  calls: RunCall[];
+  binding: Env["AI"];
+} {
+  const calls: RunCall[] = [];
+  return {
+    calls,
+    binding: {
+      async run(model: string, body: unknown) {
+        const texts = (body as { text: string[] }).text;
+        calls.push({ model, body });
+        return { data: handler(texts), shape: [texts.length, 768] };
+      },
+    },
+  };
+}
+
+describe("embed", () => {
+  it("returns one vector per input in stable order", async () => {
+    const ai = fakeAi((texts) => texts.map((_, i) => [i, i + 1, i + 2]));
+    const e = { ...env, AI: ai.binding, AI_GATEWAY_ID: "" } as Env;
+
+    const result = await embed({ env: e, texts: ["a", "b", "c"] });
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual([0, 1, 2]);
+    expect(result[2]).toEqual([2, 3, 4]);
+    expect(ai.calls).toHaveLength(1);
+  });
+
+  it("returns [] for empty input without calling the model", async () => {
+    const ai = fakeAi(() => {
+      throw new Error("should not be called");
+    });
+    const e = { ...env, AI: ai.binding, AI_GATEWAY_ID: "" } as Env;
+    const result = await embed({ env: e, texts: [] });
+    expect(result).toEqual([]);
+    expect(ai.calls).toHaveLength(0);
+  });
+
+  it("batches inputs in groups of 32", async () => {
+    const ai = fakeAi((texts) => texts.map(() => [0]));
+    const e = { ...env, AI: ai.binding, AI_GATEWAY_ID: "" } as Env;
+
+    const inputs = Array.from({ length: 70 }, (_, i) => `t${i}`);
+    const result = await embed({ env: e, texts: inputs });
+    expect(result).toHaveLength(70);
+    expect(ai.calls).toHaveLength(3); // ceil(70/32) = 3
+    expect((ai.calls[0]?.body as { text: string[] }).text).toHaveLength(32);
+    expect((ai.calls[1]?.body as { text: string[] }).text).toHaveLength(32);
+    expect((ai.calls[2]?.body as { text: string[] }).text).toHaveLength(6);
+  });
+});

--- a/apps/worker/src/__tests__/fts5.test.ts
+++ b/apps/worker/src/__tests__/fts5.test.ts
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Integration tests for the D1 FTS5 search fallback. Hits the real
+// wiki_pages_fts virtual table created by migration 0002 against the
+// miniflare-backed D1; reads back through searchFts5 to verify
+// ranking, snippet markup, and deletion semantics.
+//
+// `kind` is resolved by reading the page from the wiki backend (KV),
+// so each test seeds both surfaces.
+
+import { env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { removePageFts5, searchFts5, upsertPageFts5 } from "../lib/fts5.js";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+
+beforeAll(async () => {
+  await applyMigrations();
+});
+
+async function clearWikiKv(): Promise<void> {
+  const list = await env.WIKI_KV.list();
+  for (const k of list.keys) {
+    await env.WIKI_KV.delete(k.name);
+  }
+}
+
+async function seedKvPage(path: string, kind: string, body = "body"): Promise<void> {
+  // The kind resolver round-trips through deserializePage, which
+  // requires a YAML frontmatter block. Build a minimal valid page.
+  const raw = [
+    "---",
+    'title: "Test"',
+    `kind: ${kind}`,
+    "created: 2026-05-04",
+    "last_updated: 2026-05-04",
+    "status: draft",
+    "---",
+    "",
+    body,
+  ].join("\n");
+  await env.WIKI_KV.put(`wiki:${path}`, raw, { metadata: { sha: "deadbeef" } });
+}
+
+beforeEach(async () => {
+  await resetDb();
+  await clearWikiKv();
+});
+
+describe("upsertPageFts5 + searchFts5", () => {
+  it("returns [] for an empty query without touching the index", async () => {
+    await upsertPageFts5(env, {
+      path: "/wiki/a.md",
+      title: "A",
+      body: "DMARC content here",
+    });
+    const empty = await searchFts5(env, "   ", { topK: 5 });
+    expect(empty).toEqual([]);
+  });
+
+  it("ranks a direct title/body match above an unrelated page", async () => {
+    await seedKvPage("/wiki/a.md", "concept");
+    await seedKvPage("/wiki/b.md", "concept");
+    await upsertPageFts5(env, {
+      path: "/wiki/a.md",
+      title: "DMARC",
+      body: "DMARC builds on SPF and DKIM to authenticate email.",
+    });
+    await upsertPageFts5(env, {
+      path: "/wiki/b.md",
+      title: "Coffee Notes",
+      body: "Yesterday I had a cortado.",
+    });
+    const results = await searchFts5(env, "dmarc", { topK: 5 });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]).toBeDefined();
+    expect(results[0]?.path).toBe("/wiki/a.md");
+    expect(results[0]?.source).toBe("fts5");
+    expect(results[0]?.kind).toBe("concept");
+  });
+
+  it("emits snippets containing the configured <mark> markup", async () => {
+    await seedKvPage("/wiki/a.md", "concept");
+    await upsertPageFts5(env, {
+      path: "/wiki/a.md",
+      title: "DMARC",
+      body: "DMARC stands for Domain-based Message Authentication.",
+    });
+    const results = await searchFts5(env, "domain", { topK: 5 });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0]?.snippet).toMatch(/<mark>/);
+    expect(results[0]?.snippet).toMatch(/<\/mark>/);
+  });
+
+  it("re-upserting a page replaces the previous row (no duplicates)", async () => {
+    await seedKvPage("/wiki/a.md", "concept");
+    await upsertPageFts5(env, {
+      path: "/wiki/a.md",
+      title: "Old",
+      body: "old content uniquething",
+    });
+    await upsertPageFts5(env, {
+      path: "/wiki/a.md",
+      title: "New",
+      body: "new content uniquething",
+    });
+    const results = await searchFts5(env, "uniquething", { topK: 5 });
+    expect(results.length).toBe(1);
+    expect(results[0]?.title).toBe("New");
+  });
+
+  it("falls back to kind='concept' when the backing page is missing", async () => {
+    await upsertPageFts5(env, {
+      path: "/wiki/orphan.md",
+      title: "Orphan",
+      body: "just an orphan page in the index",
+    });
+    const results = await searchFts5(env, "orphan", { topK: 5 });
+    expect(results.length).toBe(1);
+    expect(results[0]?.kind).toBe("concept");
+  });
+
+  it("respects topK by limiting result count", async () => {
+    for (let i = 0; i < 5; i += 1) {
+      await seedKvPage(`/wiki/page${i}.md`, "concept");
+      await upsertPageFts5(env, {
+        path: `/wiki/page${i}.md`,
+        title: `P${i}`,
+        body: "common term cake",
+      });
+    }
+    const results = await searchFts5(env, "cake", { topK: 2 });
+    expect(results.length).toBe(2);
+  });
+
+  it("returns kind from the backing page frontmatter when set to a non-concept value", async () => {
+    await seedKvPage("/wiki/dec.md", "decision");
+    await upsertPageFts5(env, {
+      path: "/wiki/dec.md",
+      title: "Adopt DMARC",
+      body: "We will adopt DMARC sandbox.",
+    });
+    const results = await searchFts5(env, "sandbox", { topK: 5 });
+    expect(results[0]?.kind).toBe("decision");
+  });
+});
+
+describe("removePageFts5", () => {
+  it("removes a page from the index so it stops appearing in searches", async () => {
+    await seedKvPage("/wiki/a.md", "concept");
+    await upsertPageFts5(env, {
+      path: "/wiki/a.md",
+      title: "A",
+      body: "uniquephrase here",
+    });
+    expect((await searchFts5(env, "uniquephrase")).length).toBe(1);
+    await removePageFts5(env, "/wiki/a.md");
+    expect(await searchFts5(env, "uniquephrase")).toEqual([]);
+  });
+
+  it("is a no-op for a path that's not indexed", async () => {
+    await removePageFts5(env, "/wiki/missing.md");
+    expect(await searchFts5(env, "missing")).toEqual([]);
+  });
+});
+
+describe("FTS5 query sanitization", () => {
+  it("does not throw on quotes, parens, or operator-like inputs", async () => {
+    await seedKvPage("/wiki/a.md", "concept");
+    await upsertPageFts5(env, {
+      path: "/wiki/a.md",
+      title: "Notes",
+      body: "we discussed AND/OR semantics in detail.",
+    });
+    // None of these should error — sanitizer wraps in a phrase.
+    const cases = ['foo "unbalanced', "foo (bar", "title:dmarc", "AND OR NOT", "*prefix"];
+    for (const q of cases) {
+      await expect(searchFts5(env, q, { topK: 5 })).resolves.toBeDefined();
+    }
+  });
+});

--- a/apps/worker/src/__tests__/llm.test.ts
+++ b/apps/worker/src/__tests__/llm.test.ts
@@ -17,9 +17,10 @@ interface RunCall {
   body: unknown;
 }
 
-function fakeAi(
-  handler: (model: string, body: unknown) => Promise<unknown> | unknown,
-): { calls: RunCall[]; binding: Env["AI"] } {
+function fakeAi(handler: (model: string, body: unknown) => Promise<unknown> | unknown): {
+  calls: RunCall[];
+  binding: Env["AI"];
+} {
   const calls: RunCall[] = [];
   return {
     calls,

--- a/apps/worker/src/__tests__/llm.test.ts
+++ b/apps/worker/src/__tests__/llm.test.ts
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// M6 LLM-abstraction tests. Verifies:
+//   - Default + override model selection
+//   - Direct AI binding path
+//   - AI Gateway path (URL composition + auth header)
+//   - Stream chunking for SSE-style upstreams
+//   - BYOK override hook
+
+import { env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Env } from "../env.js";
+import { chat, chatStream } from "../lib/llm.js";
+
+interface RunCall {
+  model: string;
+  body: unknown;
+}
+
+function fakeAi(
+  handler: (model: string, body: unknown) => Promise<unknown> | unknown,
+): { calls: RunCall[]; binding: Env["AI"] } {
+  const calls: RunCall[] = [];
+  return {
+    calls,
+    binding: {
+      async run(model: string, body: unknown) {
+        calls.push({ model, body });
+        return await handler(model, body);
+      },
+    },
+  };
+}
+
+function envOverride(overrides: Partial<Env>): Env {
+  return { ...env, ...overrides } as Env;
+}
+
+describe("chat (non-streaming)", () => {
+  it("uses DEFAULT_LLM_MODEL when no model override is provided", async () => {
+    const ai = fakeAi(async () => ({ response: "hello" }));
+    const e = envOverride({ AI: ai.binding, AI_GATEWAY_ID: "" });
+
+    const result = await chat({ env: e, prompt: "hi" });
+    expect(result.text).toBe("hello");
+    expect(result.model).toBe(env.DEFAULT_LLM_MODEL);
+    expect(ai.calls).toHaveLength(1);
+    expect(ai.calls[0]?.model).toBe(env.DEFAULT_LLM_MODEL);
+  });
+
+  it("respects the model override", async () => {
+    const ai = fakeAi(async () => ({ response: "x" }));
+    const e = envOverride({ AI: ai.binding, AI_GATEWAY_ID: "" });
+
+    await chat({ env: e, prompt: "hi", model: "@cf/meta/llama-3.2-3b-instruct" });
+    expect(ai.calls[0]?.model).toBe("@cf/meta/llama-3.2-3b-instruct");
+  });
+
+  it("composes the AI Gateway URL when AI_GATEWAY_ID + CF_ACCOUNT_ID are set", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ result: { response: "via gateway" } }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const original = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+
+    try {
+      const ai = fakeAi(async () => {
+        throw new Error("should not be called when gateway is configured");
+      });
+      const e = envOverride({
+        AI: ai.binding,
+        AI_GATEWAY_ID: "loomwiki-gw",
+        CF_ACCOUNT_ID: "abcdef0123",
+      });
+
+      const result = await chat({ env: e, prompt: "hi" });
+      expect(result.text).toBe("via gateway");
+      expect(fetchSpy).toHaveBeenCalledOnce();
+      const url = fetchSpy.mock.calls[0]?.[0] as string;
+      expect(url).toBe(
+        `https://gateway.ai.cloudflare.com/v1/abcdef0123/loomwiki-gw/workers-ai/run/${env.DEFAULT_LLM_MODEL}`,
+      );
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("attaches Bearer token when AI_GATEWAY_TOKEN is set", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ result: { response: "ok" } }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const original = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    try {
+      const ai = fakeAi(async () => ({ response: "x" }));
+      const e = envOverride({
+        AI: ai.binding,
+        AI_GATEWAY_ID: "g",
+        CF_ACCOUNT_ID: "a",
+        AI_GATEWAY_TOKEN: "secret-token",
+      });
+      await chat({ env: e, prompt: "hi" });
+      const init = fetchSpy.mock.calls[0]?.[1] as RequestInit;
+      const headers = init.headers as Record<string, string>;
+      expect(headers.Authorization).toBe("Bearer secret-token");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("invokes BYOK lookup when workspaceId is provided (M6 returns null but path runs)", async () => {
+    const ai = fakeAi(async () => ({ response: "ok" }));
+    const e = envOverride({ AI: ai.binding, AI_GATEWAY_ID: "" });
+    // No throws — exercise the path. The byokOverride argument lets
+    // us short-circuit the D1 query that getBYOK would do.
+    await chat({ env: e, prompt: "hi", workspaceId: "ws", byokOverride: null });
+    expect(ai.calls).toHaveLength(1);
+  });
+});
+
+describe("chatStream", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("forwards SSE delta chunks and emits a terminating done", async () => {
+    // Build a ReadableStream that emits two SSE events then closes.
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('data: {"response":"Hello "}\n\n'));
+        controller.enqueue(encoder.encode('data: {"response":"world"}\n\n'));
+        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+        controller.close();
+      },
+    });
+
+    const ai = fakeAi(async () => body);
+    const e = envOverride({ AI: ai.binding, AI_GATEWAY_ID: "" });
+
+    const out: string[] = [];
+    let saw_done = false;
+    for await (const chunk of chatStream({ env: e, prompt: "hi" })) {
+      if (chunk.done) saw_done = true;
+      else out.push(chunk.delta);
+    }
+    expect(out.join("")).toBe("Hello world");
+    expect(saw_done).toBe(true);
+  });
+
+  it("yields a single chunk + done when the model returns a non-stream response", async () => {
+    // Some Workers AI models ignore stream:true. The wrapper must
+    // still surface a usable shape.
+    const ai = fakeAi(async () => ({ response: "non-streaming text" }));
+    const e = envOverride({ AI: ai.binding, AI_GATEWAY_ID: "" });
+
+    const chunks: string[] = [];
+    for await (const c of chatStream({ env: e, prompt: "hi" })) {
+      if (!c.done) chunks.push(c.delta);
+    }
+    expect(chunks).toEqual(["non-streaming text"]);
+  });
+});

--- a/apps/worker/src/__tests__/llm.test.ts
+++ b/apps/worker/src/__tests__/llm.test.ts
@@ -113,6 +113,34 @@ describe("chat (non-streaming)", () => {
     }
   });
 
+  it("throws a clear error when env.AI is missing AND no gateway is configured", async () => {
+    const e = envOverride({ AI: undefined as unknown as Env["AI"], AI_GATEWAY_ID: "" });
+    await expect(chat({ env: e, prompt: "hi" })).rejects.toThrow(
+      /env\.AI binding is not available/,
+    );
+  });
+
+  it("does NOT require env.AI when the gateway is configured (gateway path doesn't touch the binding)", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ result: { response: "via gateway" } }), {
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    const original = globalThis.fetch;
+    globalThis.fetch = fetchSpy as unknown as typeof globalThis.fetch;
+    try {
+      const e = envOverride({
+        AI: undefined as unknown as Env["AI"],
+        AI_GATEWAY_ID: "g",
+        CF_ACCOUNT_ID: "a",
+      });
+      const result = await chat({ env: e, prompt: "hi" });
+      expect(result.text).toBe("via gateway");
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
   it("invokes BYOK lookup when workspaceId is provided (M6 returns null but path runs)", async () => {
     const ai = fakeAi(async () => ({ response: "ok" }));
     const e = envOverride({ AI: ai.binding, AI_GATEWAY_ID: "" });

--- a/apps/worker/src/__tests__/rag.test.ts
+++ b/apps/worker/src/__tests__/rag.test.ts
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for askWithRag — the retrieval-augmented generation entry
+// point. Verifies:
+//   - No-results → returns the canned "no context yet" stream and an
+//     empty citation list (no LLM call).
+//   - Happy path → builds prompt with truncated chunks, streams deltas
+//     out as plain strings, citations dedupe by path.
+//   - Per-chunk truncation enforced at PER_CHUNK_CHARS=2000.
+
+import { env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../env.js";
+import { upsertPageFts5 } from "../lib/fts5.js";
+import { askWithRag } from "../lib/rag.js";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { FakeAiSearchBinding, envWithFakeAiSearch } from "./__fixtures__/fake-ai-search.js";
+
+interface FakeAiCall {
+  model: string;
+  body: { messages: { role: string; content: string }[] };
+}
+
+function fakeAiBinding(deltas: string[]): { calls: FakeAiCall[]; binding: Env["AI"] } {
+  const calls: FakeAiCall[] = [];
+  return {
+    calls,
+    binding: {
+      async run(model: string, body: unknown) {
+        calls.push({ model, body: body as FakeAiCall["body"] });
+        const encoder = new TextEncoder();
+        return new ReadableStream<Uint8Array>({
+          start(controller) {
+            for (const d of deltas) {
+              controller.enqueue(encoder.encode(`data: ${JSON.stringify({ response: d })}\n\n`));
+            }
+            controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+            controller.close();
+          },
+        });
+      },
+    },
+  };
+}
+
+async function clearWikiKv(): Promise<void> {
+  const list = await env.WIKI_KV.list();
+  for (const k of list.keys) {
+    await env.WIKI_KV.delete(k.name);
+  }
+}
+
+async function seedKvPage(path: string): Promise<void> {
+  const raw = [
+    "---",
+    'title: "DMARC"',
+    "kind: concept",
+    "created: 2026-05-04",
+    "last_updated: 2026-05-04",
+    "status: draft",
+    "---",
+    "",
+    "body",
+  ].join("\n");
+  await env.WIKI_KV.put(`wiki:${path}`, raw, { metadata: { sha: "deadbeef" } });
+}
+
+beforeAll(async () => {
+  await applyMigrations();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await clearWikiKv();
+});
+
+async function collect(stream: AsyncIterable<string>): Promise<string> {
+  let out = "";
+  for await (const c of stream) out += c;
+  return out;
+}
+
+describe("askWithRag — no context", () => {
+  it("returns the canned no-context message and empty citations without invoking the LLM", async () => {
+    const ai = fakeAiBinding(["should not be called"]);
+    const fakeSearch = new FakeAiSearchBinding();
+    fakeSearch.failNext = true; // forces FTS5 fallthrough; D1 is empty too
+    const e = envWithFakeAiSearch(env as Env, fakeSearch, {
+      AI: ai.binding,
+      AI_GATEWAY_ID: "",
+      AI_SEARCH_ENABLED: "true",
+    });
+
+    const res = await askWithRag({ env: e, question: "what is dmarc?" });
+    const text = await collect(res.stream);
+    expect(text).toBe("I don't have enough context yet — try creating some wiki pages first.");
+    expect(res.citations).toEqual([]);
+    expect(ai.calls.length).toBe(0);
+  });
+});
+
+describe("askWithRag — happy path", () => {
+  it("streams LLM deltas and returns deduped citations", async () => {
+    const ai = fakeAiBinding(["Hello ", "world"]);
+    const fakeSearch = new FakeAiSearchBinding();
+    await fakeSearch.upsert([
+      {
+        id: "/wiki/dmarc.md#0",
+        content: "DMARC builds on SPF and DKIM.",
+        metadata: { path: "/wiki/dmarc.md", title: "DMARC", kind: "concept" },
+      },
+      {
+        id: "/wiki/dmarc.md#1",
+        content: "DMARC reports in aggregate (rua) form.",
+        metadata: { path: "/wiki/dmarc.md", title: "DMARC", kind: "concept" },
+      },
+      {
+        id: "/wiki/spf.md#0",
+        content: "SPF authenticates the envelope sender.",
+        metadata: { path: "/wiki/spf.md", title: "SPF", kind: "concept" },
+      },
+    ]);
+    const e = envWithFakeAiSearch(env as Env, fakeSearch, {
+      AI: ai.binding,
+      AI_GATEWAY_ID: "",
+      AI_SEARCH_ENABLED: "true",
+    });
+
+    const res = await askWithRag({ env: e, question: "dmarc spf", topK: 5 });
+    const text = await collect(res.stream);
+    expect(text).toBe("Hello world");
+
+    // Citations are deduped by path: dmarc appears once even though
+    // two chunks of it surfaced.
+    expect(res.citations.map((c) => c.path)).toEqual(["/wiki/dmarc.md", "/wiki/spf.md"]);
+    expect(res.citations[0]?.heading_slug).toBeNull();
+
+    // The LLM was invoked once with a system + user message.
+    expect(ai.calls.length).toBe(1);
+    const messages = ai.calls[0]?.body.messages;
+    expect(messages?.length).toBe(2);
+    expect(messages?.[0]?.role).toBe("system");
+    expect(messages?.[0]?.content).toMatch(/Cite sources/);
+    expect(messages?.[1]?.role).toBe("user");
+    expect(messages?.[1]?.content).toMatch(/dmarc spf/);
+    expect(messages?.[1]?.content).toMatch(/## Context/);
+  });
+
+  it("truncates per-chunk context to 2000 chars before sending to the LLM", async () => {
+    const ai = fakeAiBinding(["ok"]);
+    const big = "X".repeat(5000);
+    const fakeSearch = new FakeAiSearchBinding();
+    // Upsert directly with a long content blob; queryAiSearch caps
+    // snippets at 280 chars, so to actually exercise the rag-side
+    // truncation we go through FTS5 instead (its snippets can be
+    // longer when the body is short and matches early).
+    fakeSearch.failNext = true; // force FTS5 path
+    await seedKvPage("/wiki/big.md");
+    await upsertPageFts5(env, {
+      path: "/wiki/big.md",
+      title: "Big",
+      body: `bigword ${big}`,
+    });
+    const e = envWithFakeAiSearch(env as Env, fakeSearch, {
+      AI: ai.binding,
+      AI_GATEWAY_ID: "",
+      AI_SEARCH_ENABLED: "true",
+    });
+
+    await askWithRag({ env: e, question: "bigword", topK: 5 });
+    const userContent = ai.calls[0]?.body.messages[1]?.content ?? "";
+    // The per-chunk context block is bounded to 2000 chars + 1 ellipsis
+    // marker. The full message also carries headings; check no chunk
+    // is longer than 2001 chars between successive `### ` markers.
+    const sections = userContent.split(/\n### /).slice(1);
+    for (const s of sections) {
+      // s starts with `<path>\n<body>...`. Only assert on body length.
+      const newlineIdx = s.indexOf("\n");
+      const bodyOnly = newlineIdx >= 0 ? s.slice(newlineIdx + 1) : "";
+      expect(bodyOnly.length).toBeLessThanOrEqual(2001);
+    }
+  });
+
+  it("propagates the search mode in meta", async () => {
+    const ai = fakeAiBinding(["x"]);
+    const fakeSearch = new FakeAiSearchBinding();
+    await fakeSearch.upsert([
+      {
+        id: "/wiki/a.md#0",
+        content: "alpha",
+        metadata: { path: "/wiki/a.md", title: "A", kind: "concept" },
+      },
+    ]);
+    const e = envWithFakeAiSearch(env as Env, fakeSearch, {
+      AI: ai.binding,
+      AI_GATEWAY_ID: "",
+      AI_SEARCH_ENABLED: "true",
+    });
+    const res = await askWithRag({ env: e, question: "alpha" });
+    await collect(res.stream);
+    expect(res.meta.mode).toBe("hybrid");
+  });
+});

--- a/apps/worker/src/__tests__/rag.test.ts
+++ b/apps/worker/src/__tests__/rag.test.ts
@@ -146,6 +146,34 @@ describe("askWithRag — happy path", () => {
     expect(messages?.[1]?.content).toMatch(/## Context/);
   });
 
+  it("derives heading_slug from AI Search match metadata heading field", async () => {
+    const ai = fakeAiBinding(["x"]);
+    const fakeSearch = new FakeAiSearchBinding();
+    await fakeSearch.upsert([
+      {
+        id: "/wiki/dmarc.md#1",
+        content: "Aggregate (rua) reports cover one day of mail.",
+        metadata: {
+          path: "/wiki/dmarc.md",
+          title: "DMARC",
+          kind: "concept",
+          heading: "Reporting Modes",
+          section_path: ["DMARC", "Reporting Modes"],
+        },
+      },
+    ]);
+    const e = envWithFakeAiSearch(env as Env, fakeSearch, {
+      AI: ai.binding,
+      AI_GATEWAY_ID: "",
+      AI_SEARCH_ENABLED: "true",
+    });
+
+    const res = await askWithRag({ env: e, question: "rua reports", topK: 5 });
+    await collect(res.stream); // drain
+    expect(res.citations).toHaveLength(1);
+    expect(res.citations[0]?.heading_slug).toBe("reporting-modes");
+  });
+
   it("truncates per-chunk context to 2000 chars before sending to the LLM", async () => {
     const ai = fakeAiBinding(["ok"]);
     const big = "X".repeat(5000);

--- a/apps/worker/src/__tests__/routes-admin-search.test.ts
+++ b/apps/worker/src/__tests__/routes-admin-search.test.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Integration tests for POST /api/_admin/search/reindex. Owner-gated;
+// indexer failures are isolated per page (mirrors archive-day's
+// failure-isolation pattern from M5).
+//
+// We mock the two indexer libs (lib/ai-search.js, lib/fts5.js) so the
+// route logic can be exercised without depending on the AI Search
+// binding or the d1 FTS5 schema. The pages themselves are seeded via
+// the same PUT /api/wiki/* path used by the editor.
+
+import { SELF, env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+type IndexerArgs = [unknown, { path: string; title?: string; frontmatter?: unknown; body: string }];
+type IndexerImpl = (...args: IndexerArgs) => Promise<void>;
+
+vi.mock("../lib/ai-search.js", () => ({
+  upsertPageInAiSearch: vi.fn<IndexerImpl>(async () => {}),
+  removePageFromAiSearch: vi.fn<(env: unknown, path: string) => Promise<void>>(async () => {}),
+}));
+
+vi.mock("../lib/fts5.js", () => ({
+  upsertPageFts5: vi.fn<IndexerImpl>(async () => {}),
+  removePageFts5: vi.fn<(env: unknown, path: string) => Promise<void>>(async () => {}),
+}));
+
+import { upsertPageInAiSearch as upsertAi } from "../lib/ai-search.js";
+import { upsertPageFts5 as upsertFts } from "../lib/fts5.js";
+
+let fixture: JwtFixture;
+
+async function clearWikiKv(): Promise<void> {
+  const list = await env.WIKI_KV.list();
+  for (const k of list.keys) await env.WIKI_KV.delete(k.name);
+}
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await clearWikiKv();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+  vi.mocked(upsertAi)
+    .mockReset()
+    .mockImplementation(async () => {});
+  vi.mocked(upsertFts)
+    .mockReset()
+    .mockImplementation(async () => {});
+});
+
+interface Ok<T> {
+  ok: true;
+  data: T;
+}
+interface Err {
+  ok: false;
+  error: { code: string; message: string };
+}
+
+const VALID_FRONTMATTER = {
+  title: "DMARC",
+  kind: "concept",
+  created: "2026-05-04",
+  last_updated: "2026-05-04",
+  status: "draft",
+};
+
+async function authedFetch(jwt: string, path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers ?? {});
+  headers.set("CF-Access-Jwt-Assertion", jwt);
+  if (init.body !== undefined) headers.set("Content-Type", "application/json");
+  return SELF.fetch(`https://api.local${path}`, { ...init, headers });
+}
+
+async function bootstrapOwner(): Promise<string> {
+  const ownerJwt = await fixture.mint({ email: "owner@example.com" });
+  await authedFetch(ownerJwt, "/api/me"); // JIT-provisions as owner
+  return ownerJwt;
+}
+
+async function seedPage(jwt: string, path: string, title: string): Promise<void> {
+  const res = await authedFetch(jwt, `/api/wiki${path}`, {
+    method: "PUT",
+    body: JSON.stringify({
+      frontmatter: { ...VALID_FRONTMATTER, title },
+      body: `# ${title}\n\nbody for ${title}`,
+    }),
+  });
+  if (res.status !== 200) {
+    throw new Error(`seed failed: ${res.status} ${await res.text()}`);
+  }
+}
+
+describe("POST /api/_admin/search/reindex — auth & ownership", () => {
+  it("returns 401 without a JWT", async () => {
+    const res = await SELF.fetch("https://api.local/api/_admin/search/reindex", { method: "POST" });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for a non-owner caller", async () => {
+    await bootstrapOwner();
+    const intruderJwt = await fixture.mint({ email: "intruder@example.com" });
+    await authedFetch(intruderJwt, "/api/me");
+    const res = await authedFetch(intruderJwt, "/api/_admin/search/reindex", { method: "POST" });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as Err;
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+});
+
+describe("POST /api/_admin/search/reindex — happy path", () => {
+  it("indexes every seeded page and returns the summary shape", async () => {
+    const ownerJwt = await bootstrapOwner();
+    await seedPage(ownerJwt, "/concepts/dmarc.md", "DMARC");
+    await seedPage(ownerJwt, "/concepts/spf.md", "SPF");
+
+    // Confirm the wiki tree contains exactly the seeded pages — guards
+    // against stale state from prior tests in the same file or KV
+    // bleed-through. If this is wrong, the indexer counts below would
+    // be misleading.
+    const tree = await authedFetch(ownerJwt, "/api/wiki-tree");
+    const treeBody = (await tree.json()) as Ok<{ paths: string[] }>;
+    const expected = ["/wiki/concepts/dmarc.md", "/wiki/concepts/spf.md"];
+    expect(treeBody.data.paths).toEqual(expected);
+
+    // PUT /api/wiki/* itself fires the indexer hooks for each seeded
+    // page (M6: write-through index sync in the wiki route). Reset
+    // between seeding and reindex so the call counts below measure
+    // the reindex pass alone.
+    vi.mocked(upsertAi).mockClear();
+    vi.mocked(upsertFts).mockClear();
+
+    const res = await authedFetch(ownerJwt, "/api/_admin/search/reindex", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Ok<{
+      pages_indexed: number;
+      errors: { path: string; message: string }[];
+    }>;
+    expect(body.data.pages_indexed).toBe(expected.length);
+    expect(body.data.errors).toEqual([]);
+    // Both indexers are called for every seeded page.
+    expect(upsertAi).toHaveBeenCalledTimes(expected.length);
+    expect(upsertFts).toHaveBeenCalledTimes(expected.length);
+  });
+
+  it("is idempotent — running twice produces the same shape with no errors", async () => {
+    const ownerJwt = await bootstrapOwner();
+    await seedPage(ownerJwt, "/concepts/dmarc.md", "DMARC");
+
+    const first = await authedFetch(ownerJwt, "/api/_admin/search/reindex", { method: "POST" });
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as Ok<{ pages_indexed: number; errors: unknown[] }>;
+    expect(firstBody.data.pages_indexed).toBe(1);
+    expect(firstBody.data.errors).toEqual([]);
+
+    const second = await authedFetch(ownerJwt, "/api/_admin/search/reindex", { method: "POST" });
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as Ok<{ pages_indexed: number; errors: unknown[] }>;
+    expect(secondBody.data.pages_indexed).toBe(1);
+    expect(secondBody.data.errors).toEqual([]);
+  });
+});
+
+describe("POST /api/_admin/search/reindex — partial failure tolerance", () => {
+  it("continues indexing after a single page's AI Search upsert fails", async () => {
+    const ownerJwt = await bootstrapOwner();
+    await seedPage(ownerJwt, "/concepts/dmarc.md", "DMARC");
+    await seedPage(ownerJwt, "/concepts/spf.md", "SPF");
+
+    vi.mocked(upsertAi).mockImplementation(async (_env, opts) => {
+      if (opts.path === "/wiki/concepts/dmarc.md") throw new Error("ai search down");
+    });
+
+    const res = await authedFetch(ownerJwt, "/api/_admin/search/reindex", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Ok<{
+      pages_indexed: number;
+      errors: { path: string; message: string }[];
+    }>;
+    // Two pages attempted; both still count as indexed since FTS5
+    // succeeded for each. The dmarc AI Search failure is reported.
+    expect(body.data.pages_indexed).toBe(2);
+    expect(body.data.errors).toHaveLength(1);
+    const err = body.data.errors[0];
+    expect(err?.path).toBe("/wiki/concepts/dmarc.md");
+    expect(err?.message).toContain("ai search down");
+  });
+
+  it("counts a page as failed when both indexers reject", async () => {
+    const ownerJwt = await bootstrapOwner();
+    await seedPage(ownerJwt, "/concepts/dmarc.md", "DMARC");
+
+    vi.mocked(upsertAi).mockImplementation(async () => {
+      throw new Error("ai down");
+    });
+    vi.mocked(upsertFts).mockImplementation(async () => {
+      throw new Error("fts5 down");
+    });
+
+    const res = await authedFetch(ownerJwt, "/api/_admin/search/reindex", { method: "POST" });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Ok<{
+      pages_indexed: number;
+      errors: { path: string; message: string }[];
+    }>;
+    expect(body.data.pages_indexed).toBe(0);
+    expect(body.data.errors.length).toBe(2);
+  });
+});

--- a/apps/worker/src/__tests__/routes-ask.test.ts
+++ b/apps/worker/src/__tests__/routes-ask.test.ts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Integration tests for POST /api/ask. Covers auth, validation, rate
+// limiting, and the SSE response shape. Streaming behavior end-to-end
+// (real LLM, real RAG) is covered by the rag-lib suite — here we mock
+// askWithRag with a canned async-iterable so the route layer tests
+// don't depend on Workers AI bindings.
+
+import { SELF, env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+// Build a small async iterable that yields the given chunks. This is
+// the contract askWithRag returns for `result.stream`.
+function asyncIterable(chunks: string[]): AsyncIterable<string> {
+  return {
+    [Symbol.asyncIterator]() {
+      let i = 0;
+      return {
+        async next(): Promise<IteratorResult<string>> {
+          if (i >= chunks.length) return { value: undefined, done: true };
+          const value = chunks[i++] ?? "";
+          return { value, done: false };
+        },
+      };
+    },
+  };
+}
+
+vi.mock("../lib/rag.js", () => ({
+  askWithRag: vi.fn(async () => ({
+    searchResults: [],
+    citations: [
+      {
+        path: "/wiki/concepts/dmarc.md",
+        title: "DMARC",
+        kind: "concept",
+        heading_slug: null,
+      },
+    ],
+    stream: asyncIterable(["Hello ", "world", ""]), // empty chunk filtered out
+    meta: { mode: "hybrid", model: "@cf/test/echo" },
+  })),
+}));
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+interface Err {
+  ok: false;
+  error: { code: string; message: string; details?: unknown };
+}
+
+async function authedFetch(jwt: string, path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers ?? {});
+  headers.set("CF-Access-Jwt-Assertion", jwt);
+  if (init.body !== undefined) headers.set("Content-Type", "application/json");
+  return SELF.fetch(`https://api.local${path}`, { ...init, headers });
+}
+
+interface ParsedSse {
+  // Default-event `data:` payloads (we treat these as deltas).
+  deltas: string[];
+  // event:<name> blocks keyed by event name → JSON-parsed data.
+  events: Map<string, unknown[]>;
+}
+
+// Minimal SSE parser. Splits on the blank-line frame separator; a
+// frame may contain `event:` and one `data:` line per the M6 wire
+// format. Production clients typically use EventSource which is not
+// available in workerd-test, so we parse the raw stream by hand.
+function parseSse(text: string): ParsedSse {
+  const out: ParsedSse = { deltas: [], events: new Map() };
+  for (const block of text.split(/\n\n/)) {
+    if (block.trim() === "") continue;
+    let event: string | null = null;
+    let data = "";
+    for (const line of block.split("\n")) {
+      if (line.startsWith("event:")) event = line.slice(6).trim();
+      else if (line.startsWith("data:")) data = line.slice(5).trim();
+    }
+    if (event === null) {
+      const parsed = JSON.parse(data) as { delta?: string };
+      if (typeof parsed.delta === "string") out.deltas.push(parsed.delta);
+    } else {
+      const list = out.events.get(event) ?? [];
+      list.push(JSON.parse(data));
+      out.events.set(event, list);
+    }
+  }
+  return out;
+}
+
+describe("POST /api/ask — auth gating", () => {
+  it("returns 401 without a JWT", async () => {
+    const res = await SELF.fetch("https://api.local/api/ask", {
+      method: "POST",
+      body: JSON.stringify({ question: "hi" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/ask — validation", () => {
+  it("returns 400 for an empty question", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const res = await authedFetch(jwt, "/api/ask", {
+      method: "POST",
+      body: JSON.stringify({ question: "" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Err;
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 for a question over the 4000-char cap", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const tooLong = "a".repeat(4001);
+    const res = await authedFetch(jwt, "/api/ask", {
+      method: "POST",
+      body: JSON.stringify({ question: tooLong }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for a missing body", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const res = await authedFetch(jwt, "/api/ask", { method: "POST" });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/ask — SSE response", () => {
+  it("streams text deltas, then a citations event, then done", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const res = await authedFetch(jwt, "/api/ask", {
+      method: "POST",
+      body: JSON.stringify({ question: "What is DMARC?" }),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toMatch(/^text\/event-stream/);
+    expect(res.headers.get("cache-control")).toMatch(/no-cache/);
+
+    const text = await res.text();
+    const parsed = parseSse(text);
+
+    // Empty chunk should have been suppressed by the route.
+    expect(parsed.deltas).toEqual(["Hello ", "world"]);
+
+    // events.get("citations") is the list of `data:` payloads for that
+    // event type — there's exactly one frame, and its payload is the
+    // citations array.
+    const citationsFrames = parsed.events.get("citations");
+    expect(citationsFrames).toHaveLength(1);
+    const citations = (citationsFrames ?? [[]])[0] as Array<{ path: string; title: string }>;
+    expect(citations).toHaveLength(1);
+    expect(citations[0]?.path).toBe("/wiki/concepts/dmarc.md");
+    expect(citations[0]?.title).toBe("DMARC");
+
+    expect(parsed.events.get("done")).toEqual([{}]);
+  });
+});
+
+describe("POST /api/ask — cost guard", () => {
+  it("returns 429 with details once the per-user ask cap is exhausted", async () => {
+    const original = env.LLM_DAILY_LIMIT_PER_USER_ASK;
+    (env as unknown as { LLM_DAILY_LIMIT_PER_USER_ASK: string }).LLM_DAILY_LIMIT_PER_USER_ASK = "1";
+    try {
+      const jwt = await fixture.mint({ email: "alice@example.com" });
+
+      const first = await authedFetch(jwt, "/api/ask", {
+        method: "POST",
+        body: JSON.stringify({ question: "first" }),
+      });
+      expect(first.status).toBe(200);
+      // Drain the body so the underlying stream completes before the
+      // next request — keeps the test deterministic.
+      await first.text();
+
+      const second = await authedFetch(jwt, "/api/ask", {
+        method: "POST",
+        body: JSON.stringify({ question: "second" }),
+      });
+      expect(second.status).toBe(429);
+      const body = (await second.json()) as Err;
+      expect(body.error.code).toBe("RATE_LIMITED");
+      const details = body.error.details as {
+        limit: number;
+        used: number;
+        scope: string;
+        reset_at: string;
+      };
+      expect(details.limit).toBe(1);
+      expect(details.used).toBe(1);
+      expect(details.scope).toBe("user");
+    } finally {
+      (env as unknown as { LLM_DAILY_LIMIT_PER_USER_ASK: string }).LLM_DAILY_LIMIT_PER_USER_ASK =
+        original;
+    }
+  });
+});

--- a/apps/worker/src/__tests__/routes-search.test.ts
+++ b/apps/worker/src/__tests__/routes-search.test.ts
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Integration tests for POST /api/search. Auth, validation, and
+// rate-limiting concerns live here; the orchestrator's hybrid policy
+// is tested separately in the search-lib suite.
+//
+// We mock the searchWiki orchestrator via vi.mock so this file
+// exercises only the route layer (auth → validation → cost guard →
+// JSON envelope). That keeps the test independent of AI Search /
+// FTS5 binding shape and makes failure attribution unambiguous.
+
+import { SELF, env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+// Mock the search lib so the route-layer tests don't depend on the
+// real AI Search binding (absent in test env) or on whether subagent
+// A's hybrid policy has shipped yet. Each test can override the
+// resolved value via mockImplementationOnce.
+vi.mock("../lib/search.js", () => ({
+  searchWiki: vi.fn(async () => ({ results: [], mode: "hybrid" })),
+}));
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+interface Ok<T> {
+  ok: true;
+  data: T;
+}
+interface Err {
+  ok: false;
+  error: { code: string; message: string; details?: unknown };
+}
+
+async function authedFetch(jwt: string, path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers ?? {});
+  headers.set("CF-Access-Jwt-Assertion", jwt);
+  if (init.body !== undefined) headers.set("Content-Type", "application/json");
+  return SELF.fetch(`https://api.local${path}`, { ...init, headers });
+}
+
+describe("POST /api/search — auth gating", () => {
+  it("returns 401 without a JWT", async () => {
+    const res = await SELF.fetch("https://api.local/api/search", {
+      method: "POST",
+      body: JSON.stringify({ query: "hello" }),
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("POST /api/search — validation", () => {
+  it("returns 400 for a missing body", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const res = await authedFetch(jwt, "/api/search", { method: "POST" });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Err;
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 for a query that exceeds 2000 characters", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const tooLong = "a".repeat(2001);
+    const res = await authedFetch(jwt, "/api/search", {
+      method: "POST",
+      body: JSON.stringify({ query: tooLong }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Err;
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 for an out-of-range topK", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const res = await authedFetch(jwt, "/api/search", {
+      method: "POST",
+      body: JSON.stringify({ query: "ok", topK: 999 }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /api/search — happy path", () => {
+  it("returns the orchestrator response envelope", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const res = await authedFetch(jwt, "/api/search", {
+      method: "POST",
+      body: JSON.stringify({ query: "dmarc" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Ok<{
+      results: unknown[];
+      mode: string;
+    }>;
+    expect(body.ok).toBe(true);
+    expect(body.data.mode).toBe("hybrid");
+    expect(Array.isArray(body.data.results)).toBe(true);
+  });
+
+  it("accepts an empty query (returns empty results, no error)", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const res = await authedFetch(jwt, "/api/search", {
+      method: "POST",
+      body: JSON.stringify({ query: "" }),
+    });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("POST /api/search — cost guard", () => {
+  it("returns 429 with rate-limit details once the per-user search cap is exhausted", async () => {
+    // Drop the search cap to 1 by mutating the env vars seen by the
+    // route. workerd freezes env on boot, so we set them via env mutation
+    // before the request — the route reads via readLimits each call.
+    const original = env.LLM_DAILY_LIMIT_PER_USER_SEARCH;
+    (
+      env as unknown as { LLM_DAILY_LIMIT_PER_USER_SEARCH: string }
+    ).LLM_DAILY_LIMIT_PER_USER_SEARCH = "1";
+    try {
+      const jwt = await fixture.mint({ email: "alice@example.com" });
+
+      const first = await authedFetch(jwt, "/api/search", {
+        method: "POST",
+        body: JSON.stringify({ query: "first" }),
+      });
+      expect(first.status).toBe(200);
+
+      const second = await authedFetch(jwt, "/api/search", {
+        method: "POST",
+        body: JSON.stringify({ query: "second" }),
+      });
+      expect(second.status).toBe(429);
+      const body = (await second.json()) as Err;
+      expect(body.error.code).toBe("RATE_LIMITED");
+      const details = body.error.details as {
+        limit: number;
+        used: number;
+        scope: "user" | "workspace";
+        reset_at: string;
+      };
+      expect(details.limit).toBe(1);
+      expect(details.used).toBe(1);
+      expect(details.scope).toBe("user");
+      expect(typeof details.reset_at).toBe("string");
+    } finally {
+      (
+        env as unknown as { LLM_DAILY_LIMIT_PER_USER_SEARCH: string }
+      ).LLM_DAILY_LIMIT_PER_USER_SEARCH = original;
+    }
+  });
+});

--- a/apps/worker/src/__tests__/search.test.ts
+++ b/apps/worker/src/__tests__/search.test.ts
@@ -1,0 +1,150 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Search orchestrator tests. Verify mode labelling and the AI Search →
+// FTS5 fallthrough across the four important paths:
+//   1. AI Search hit → mode=hybrid
+//   2. AI Search throws → falls through to FTS5 (mode=fts5_fallback)
+//   3. AI Search disabled → goes straight to FTS5 (mode=fts5_fallback)
+//   4. Both miss → empty array with correct mode label
+
+import { env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { Env } from "../env.js";
+import { upsertPageFts5 } from "../lib/fts5.js";
+import { searchWiki } from "../lib/search.js";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { FakeAiSearchBinding, envWithFakeAiSearch } from "./__fixtures__/fake-ai-search.js";
+
+const FRONTMATTER = { title: "DMARC", kind: "concept" as const };
+
+beforeAll(async () => {
+  await applyMigrations();
+});
+
+async function clearWikiKv(): Promise<void> {
+  const list = await env.WIKI_KV.list();
+  for (const k of list.keys) {
+    await env.WIKI_KV.delete(k.name);
+  }
+}
+
+async function seedKvPage(path: string): Promise<void> {
+  const raw = [
+    "---",
+    'title: "DMARC"',
+    "kind: concept",
+    "created: 2026-05-04",
+    "last_updated: 2026-05-04",
+    "status: draft",
+    "---",
+    "",
+    "body",
+  ].join("\n");
+  await env.WIKI_KV.put(`wiki:${path}`, raw, { metadata: { sha: "deadbeef" } });
+}
+
+beforeEach(async () => {
+  await resetDb();
+  await clearWikiKv();
+});
+
+describe("searchWiki", () => {
+  it("short-circuits an empty query without touching either backend", async () => {
+    const fake = new FakeAiSearchBinding();
+    fake.failNext = true; // would throw if invoked
+    const e = envWithFakeAiSearch(env as Env, fake, { AI_SEARCH_ENABLED: "true" });
+    const res = await searchWiki({ env: e, query: "  " });
+    expect(res).toEqual({ results: [], mode: "hybrid" });
+  });
+
+  it("returns mode=hybrid when AI Search succeeds", async () => {
+    const fake = new FakeAiSearchBinding();
+    await fake.upsert([
+      {
+        id: "/wiki/a.md#0",
+        content: "DMARC builds on SPF and DKIM",
+        metadata: { path: "/wiki/a.md", title: "DMARC", kind: "concept" },
+      },
+    ]);
+    const e = envWithFakeAiSearch(env as Env, fake, { AI_SEARCH_ENABLED: "true" });
+    const res = await searchWiki({ env: e, query: "dmarc", topK: 5 });
+    expect(res.mode).toBe("hybrid");
+    expect(res.results.length).toBe(1);
+    expect(res.results[0]?.source).toBe("ai_search");
+  });
+
+  it("falls through to FTS5 when AI Search throws", async () => {
+    const fake = new FakeAiSearchBinding();
+    fake.failNext = true;
+    await seedKvPage("/wiki/dmarc.md");
+    await upsertPageFts5(env, {
+      path: "/wiki/dmarc.md",
+      title: "DMARC",
+      body: "DMARC fallback content",
+    });
+    const e = envWithFakeAiSearch(env as Env, fake, { AI_SEARCH_ENABLED: "true" });
+    const res = await searchWiki({ env: e, query: "dmarc", topK: 5 });
+    expect(res.mode).toBe("fts5_fallback");
+    expect(res.results.length).toBe(1);
+    expect(res.results[0]?.source).toBe("fts5");
+  });
+
+  it("falls through to FTS5 when the binding is missing", async () => {
+    await seedKvPage("/wiki/dmarc.md");
+    await upsertPageFts5(env, {
+      path: "/wiki/dmarc.md",
+      title: "DMARC",
+      body: "missing-binding fallback",
+    });
+    const e = envWithFakeAiSearch(env as Env, undefined, { AI_SEARCH_ENABLED: "true" });
+    const res = await searchWiki({ env: e, query: "fallback", topK: 5 });
+    expect(res.mode).toBe("fts5_fallback");
+    expect(res.results.length).toBe(1);
+  });
+
+  it("skips AI Search entirely when AI_SEARCH_ENABLED='false'", async () => {
+    const fake = new FakeAiSearchBinding();
+    fake.failNext = true; // would throw if invoked — proves we skipped it
+    await seedKvPage("/wiki/dmarc.md");
+    await upsertPageFts5(env, {
+      path: "/wiki/dmarc.md",
+      title: "DMARC",
+      body: "skipped path content",
+    });
+    const e = envWithFakeAiSearch(env as Env, fake, { AI_SEARCH_ENABLED: "false" });
+    const res = await searchWiki({ env: e, query: "skipped", topK: 5 });
+    expect(res.mode).toBe("fts5_fallback");
+    expect(res.results.length).toBe(1);
+  });
+
+  it("returns mode=fts5_fallback with [] when both backends miss", async () => {
+    const fake = new FakeAiSearchBinding();
+    fake.failNext = true; // forces fallthrough
+    const e = envWithFakeAiSearch(env as Env, fake, { AI_SEARCH_ENABLED: "true" });
+    const res = await searchWiki({ env: e, query: "no-such-term", topK: 5 });
+    expect(res.mode).toBe("fts5_fallback");
+    expect(res.results).toEqual([]);
+  });
+
+  it("preserves topK when delegating to AI Search", async () => {
+    const fake = new FakeAiSearchBinding();
+    for (let i = 0; i < 5; i += 1) {
+      await fake.upsert([
+        {
+          id: `/wiki/p${i}.md#0`,
+          content: `repeated word p${i}`,
+          metadata: { path: `/wiki/p${i}.md`, title: `P${i}`, kind: "concept" },
+        },
+      ]);
+    }
+    const e = envWithFakeAiSearch(env as Env, fake, { AI_SEARCH_ENABLED: "true" });
+    const res = await searchWiki({ env: e, query: "repeated", topK: 2 });
+    expect(res.results.length).toBe(2);
+  });
+});
+
+// Silence the expected console.warn from the fallthrough path so the
+// test runner's stderr stays readable. Vitest mock console doesn't
+// help here because the worker's console is the real one — we just
+// rely on the warnings being intentional and short.
+void FRONTMATTER;

--- a/apps/worker/src/__tests__/usage.test.ts
+++ b/apps/worker/src/__tests__/usage.test.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// M6 usage-counter tests: race safety, UTC rollover, scope isolation.
+
+import { env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getOrCreateUser } from "../lib/users.js";
+import {
+  getUsage,
+  incrementUsage,
+  nextUtcMidnightIso,
+  resetUsageToday,
+  utcDayKey,
+} from "../lib/usage.js";
+import { DEFAULT_WORKSPACE_ID, getOrBootstrapWorkspace } from "../lib/workspace.js";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+
+beforeAll(async () => {
+  await applyMigrations();
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+const fixedClock = (iso: string) => () => Date.parse(iso);
+
+async function bootstrap(): Promise<{ userA: string; userB: string }> {
+  const a = await getOrCreateUser(env, "alice@example.com");
+  const b = await getOrCreateUser(env, "bob@example.com");
+  await getOrBootstrapWorkspace(env, a.id);
+  return { userA: a.id, userB: b.id };
+}
+
+describe("utcDayKey + nextUtcMidnightIso", () => {
+  it("formats the UTC day correctly", () => {
+    expect(utcDayKey(Date.parse("2026-05-04T12:34:56Z"))).toBe("2026-05-04");
+    expect(utcDayKey(Date.parse("2026-05-04T23:59:59Z"))).toBe("2026-05-04");
+    expect(utcDayKey(Date.parse("2026-05-05T00:00:00Z"))).toBe("2026-05-05");
+  });
+
+  it("computes the next UTC midnight", () => {
+    expect(nextUtcMidnightIso(Date.parse("2026-05-04T12:34:56Z"))).toBe("2026-05-05T00:00:00.000Z");
+    // Edge: exact midnight reads as the start of THAT day; next midnight is +24h.
+    expect(nextUtcMidnightIso(Date.parse("2026-05-04T00:00:00Z"))).toBe("2026-05-05T00:00:00.000Z");
+  });
+});
+
+describe("getUsage", () => {
+  it("returns zeros when no row exists", async () => {
+    const { userA } = await bootstrap();
+    const usage = await getUsage(env, {
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      scopeType: "user",
+      scopeId: userA,
+    });
+    expect(usage).toEqual({ ask_count: 0, search_count: 0 });
+  });
+});
+
+describe("incrementUsage", () => {
+  it("increments ask and search independently", async () => {
+    const { userA } = await bootstrap();
+    const scope = { workspaceId: DEFAULT_WORKSPACE_ID, scopeType: "user" as const, scopeId: userA };
+
+    let usage = await incrementUsage(env, scope, "ask");
+    expect(usage).toEqual({ ask_count: 1, search_count: 0 });
+    usage = await incrementUsage(env, scope, "ask");
+    expect(usage).toEqual({ ask_count: 2, search_count: 0 });
+    usage = await incrementUsage(env, scope, "search");
+    expect(usage).toEqual({ ask_count: 2, search_count: 1 });
+  });
+
+  it("is race-safe under concurrent increments (ON CONFLICT DO UPDATE)", async () => {
+    const { userA } = await bootstrap();
+    const scope = { workspaceId: DEFAULT_WORKSPACE_ID, scopeType: "user" as const, scopeId: userA };
+
+    // 25 concurrent +1s — D1 serializes writes within an instance and
+    // ON CONFLICT DO UPDATE handles the row-exists case atomically.
+    await Promise.all(Array.from({ length: 25 }, () => incrementUsage(env, scope, "ask")));
+
+    const usage = await getUsage(env, scope);
+    expect(usage.ask_count).toBe(25);
+  });
+
+  it("rolls over at UTC midnight (separate row per day)", async () => {
+    const { userA } = await bootstrap();
+    const scope = { workspaceId: DEFAULT_WORKSPACE_ID, scopeType: "user" as const, scopeId: userA };
+
+    const day1 = fixedClock("2026-05-04T23:59:00Z");
+    const day2 = fixedClock("2026-05-05T00:00:01Z");
+
+    await incrementUsage(env, scope, "ask", day1);
+    await incrementUsage(env, scope, "ask", day1);
+
+    const day1Usage = await getUsage(env, scope, day1);
+    expect(day1Usage.ask_count).toBe(2);
+
+    await incrementUsage(env, scope, "ask", day2);
+
+    const day2Usage = await getUsage(env, scope, day2);
+    expect(day2Usage.ask_count).toBe(1); // fresh row for the new day
+
+    // Day 1's row is untouched by the day-2 increment.
+    expect((await getUsage(env, scope, day1)).ask_count).toBe(2);
+  });
+
+  it("isolates per-user counters from per-workspace and from other users", async () => {
+    const { userA, userB } = await bootstrap();
+    const aScope = {
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      scopeType: "user" as const,
+      scopeId: userA,
+    };
+    const bScope = {
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      scopeType: "user" as const,
+      scopeId: userB,
+    };
+    const wsScope = {
+      workspaceId: DEFAULT_WORKSPACE_ID,
+      scopeType: "workspace" as const,
+      scopeId: "_workspace",
+    };
+
+    await incrementUsage(env, aScope, "ask");
+    await incrementUsage(env, aScope, "ask");
+    await incrementUsage(env, bScope, "ask");
+    await incrementUsage(env, wsScope, "ask");
+    await incrementUsage(env, wsScope, "ask");
+    await incrementUsage(env, wsScope, "ask");
+
+    expect((await getUsage(env, aScope)).ask_count).toBe(2);
+    expect((await getUsage(env, bScope)).ask_count).toBe(1);
+    expect((await getUsage(env, wsScope)).ask_count).toBe(3);
+  });
+});
+
+describe("resetUsageToday", () => {
+  it("removes today's row only", async () => {
+    const { userA } = await bootstrap();
+    const scope = { workspaceId: DEFAULT_WORKSPACE_ID, scopeType: "user" as const, scopeId: userA };
+    await incrementUsage(env, scope, "ask");
+    await resetUsageToday(env, scope);
+    expect(await getUsage(env, scope)).toEqual({ ask_count: 0, search_count: 0 });
+  });
+});

--- a/apps/worker/src/__tests__/usage.test.ts
+++ b/apps/worker/src/__tests__/usage.test.ts
@@ -4,7 +4,6 @@
 
 import { env } from "cloudflare:test";
 import { beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { getOrCreateUser } from "../lib/users.js";
 import {
   getUsage,
   incrementUsage,
@@ -12,6 +11,7 @@ import {
   resetUsageToday,
   utcDayKey,
 } from "../lib/usage.js";
+import { getOrCreateUser } from "../lib/users.js";
 import { DEFAULT_WORKSPACE_ID, getOrBootstrapWorkspace } from "../lib/workspace.js";
 import { applyMigrations, resetDb } from "./__fixtures__/db.js";
 

--- a/apps/worker/src/__tests__/wiki-routes-search-index.test.ts
+++ b/apps/worker/src/__tests__/wiki-routes-search-index.test.ts
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Verifies that the M6 search-index sync hooks fire from the wiki
+// PUT/DELETE handlers. We can't reach the real AI Search binding from
+// tests (remote-only) and the route uses Promise.allSettled to swallow
+// its failure — so we assert end-to-end against the FTS5 index, which
+// IS reachable. AI Search coverage lives in ai-search.test.ts.
+
+import { SELF, env } from "cloudflare:test";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { searchFts5 } from "../lib/fts5.js";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+let fixture: JwtFixture;
+
+async function clearWikiKv(): Promise<void> {
+  const list = await env.WIKI_KV.list();
+  for (const k of list.keys) {
+    await env.WIKI_KV.delete(k.name);
+  }
+}
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await clearWikiKv();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+const VALID_FRONTMATTER = {
+  title: "DMARC",
+  kind: "concept",
+  created: "2026-05-04",
+  last_updated: "2026-05-04",
+  status: "draft",
+};
+
+async function authedFetch(jwt: string, path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers ?? {});
+  headers.set("CF-Access-Jwt-Assertion", jwt);
+  if (init.body !== undefined) headers.set("Content-Type", "application/json");
+  return SELF.fetch(`https://api.local${path}`, { ...init, headers });
+}
+
+describe("wiki PUT → FTS5 index sync", () => {
+  it("indexes a newly-created page so searchFts5 finds it", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const res = await authedFetch(jwt, "/api/wiki/concepts/dmarc.md", {
+      method: "PUT",
+      body: JSON.stringify({
+        frontmatter: VALID_FRONTMATTER,
+        body: "DMARC builds on SPF and DKIM to authenticate email.",
+      }),
+    });
+    expect(res.status).toBe(200);
+
+    const found = await searchFts5(env, "dmarc", { topK: 5 });
+    expect(found.length).toBe(1);
+    expect(found[0]?.path).toBe("/wiki/concepts/dmarc.md");
+    expect(found[0]?.title).toBe("DMARC");
+  });
+
+  it("re-indexes on update (old body terms drop out, new body terms appear)", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    const create = await authedFetch(jwt, "/api/wiki/concepts/dmarc.md", {
+      method: "PUT",
+      body: JSON.stringify({
+        frontmatter: VALID_FRONTMATTER,
+        body: "first version uniqueoldterm here",
+      }),
+    });
+    const created = (await create.json()) as { data: { page: { sha: string } } };
+
+    await authedFetch(jwt, "/api/wiki/concepts/dmarc.md", {
+      method: "PUT",
+      body: JSON.stringify({
+        frontmatter: VALID_FRONTMATTER,
+        body: "second version uniquenewterm replacement",
+        before_sha: created.data.page.sha,
+      }),
+    });
+
+    expect((await searchFts5(env, "uniqueoldterm")).length).toBe(0);
+    const after = await searchFts5(env, "uniquenewterm");
+    expect(after.length).toBe(1);
+    expect(after[0]?.path).toBe("/wiki/concepts/dmarc.md");
+  });
+});
+
+describe("wiki DELETE → FTS5 index sync", () => {
+  it("removes the page from the FTS5 index after a successful delete", async () => {
+    const jwt = await fixture.mint({ email: "alice@example.com" });
+    await authedFetch(jwt, "/api/wiki/concepts/dmarc.md", {
+      method: "PUT",
+      body: JSON.stringify({
+        frontmatter: VALID_FRONTMATTER,
+        body: "deleteme term content",
+      }),
+    });
+    expect((await searchFts5(env, "deleteme")).length).toBe(1);
+
+    const del = await authedFetch(jwt, "/api/wiki/concepts/dmarc.md", { method: "DELETE" });
+    expect(del.status).toBe(200);
+    expect((await searchFts5(env, "deleteme")).length).toBe(0);
+  });
+});

--- a/apps/worker/src/ai-search-binding.d.ts
+++ b/apps/worker/src/ai-search-binding.d.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Local declaration of the Cloudflare AI Search Workers binding.
+// Mirrors the upstream `AiSearch` interface (compat date 2026-04-22).
+//
+// Mirrored here for the same reason `artifacts-binding.d.ts` is —
+// `pnpm wrangler types` would also redeclare core globals (Request,
+// Headers) that conflict with @cloudflare/workers-types. This narrow
+// shadow keeps drift obvious: when wrangler is rerun, eyeball this file
+// against the generated worker-configuration.d.ts and update if needed.
+
+export interface AiSearchMatchMetadata {
+  /** Source vault path (e.g. `/wiki/concepts/dmarc.md`). */
+  path?: string;
+  /** Page-level title (frontmatter `title`). */
+  title?: string;
+  /** Page-level kind (frontmatter `kind`). */
+  kind?: string;
+  /** H1/H2 ancestor chain for the chunk. */
+  section_path?: string[];
+  /** The H1/H2 heading for the chunk, if any. */
+  heading?: string;
+  /** Anything else the indexer attached. */
+  [key: string]: unknown;
+}
+
+export interface AiSearchMatch {
+  /** Document identifier — the chunk's stable id. */
+  id: string;
+  /** Hybrid (BM25 + vector) score, normalized 0..1. */
+  score: number;
+  /** The matched text (chunk body or excerpt). */
+  content: string;
+  /** Caller-attached metadata from the upsert. */
+  metadata: AiSearchMatchMetadata;
+}
+
+export interface AiSearchQueryResult {
+  matches: AiSearchMatch[];
+}
+
+export interface AiSearchUpsertDoc {
+  id: string;
+  content: string;
+  metadata?: AiSearchMatchMetadata;
+}
+
+/**
+ * Cloudflare AI Search Workers binding. Surface intentionally narrow —
+ * we only model the methods M6 calls. Add methods here when a future
+ * milestone needs them; do NOT widen by guessing — verify against the
+ * runtime types first (`pnpm wrangler types`).
+ */
+export interface AiSearchBinding {
+  search(opts: { query: string; topK?: number }): Promise<AiSearchQueryResult>;
+  upsert(docs: AiSearchUpsertDoc[]): Promise<{ upserted: number }>;
+  delete(ids: string[]): Promise<{ deleted: number }>;
+}
+
+/**
+ * Workers AI binding (`env.AI`). The package's `Fetcher` type doesn't
+ * expose `.run()`, so we model just enough to call into the catalog.
+ * `run` returns either a JSON object (non-streaming) or a
+ * ReadableStream<Uint8Array> (streaming, when `body.stream === true`).
+ */
+export interface WorkersAiBinding {
+  run(model: string, body: unknown): Promise<unknown>;
+}

--- a/apps/worker/src/env.ts
+++ b/apps/worker/src/env.ts
@@ -9,10 +9,10 @@ import type {
   AnalyticsEngineDataset,
   D1Database,
   DurableObjectNamespace,
-  Fetcher,
   KVNamespace,
   R2Bucket,
 } from "@cloudflare/workers-types";
+import type { AiSearchBinding, WorkersAiBinding } from "./ai-search-binding.js";
 import type { ArtifactsBinding } from "./artifacts-binding.js";
 
 export interface VersionMetadata {
@@ -44,7 +44,13 @@ export interface Env {
   ARTIFACTS: ArtifactsBinding;
 
   // AI
-  AI: Fetcher;
+  AI: WorkersAiBinding;
+
+  // M6: AI Search hybrid (BM25 + vector) over the workspace vault.
+  // Optional at the type level because local dev configs (and operator
+  // accounts without AI Search) won't have it; the search orchestrator
+  // catches the binding-missing case and falls through to FTS5.
+  AI_SEARCH?: AiSearchBinding;
 
   // Version metadata (populated by CF in production deploys; may be undefined in dev)
   CF_VERSION_METADATA?: VersionMetadata;
@@ -69,6 +75,17 @@ export interface Env {
   // Local-dev auth bypass. Triple-gated; see middleware/auth.ts. Default off.
   ALLOW_LOCAL_DEV_AUTH: string;
   LOCAL_DEV_EMAIL: string;
+
+  // M6: AI Search + cost guards. Strings (not numbers/booleans) because
+  // wrangler vars are always strings; lib/llm.ts and lib/cost-guard.ts
+  // parse them at use time.
+  AI_SEARCH_ENABLED: string;
+  AI_GATEWAY_ID: string;
+  CF_ACCOUNT_ID: string;
+  LLM_DAILY_LIMIT_PER_USER_ASK: string;
+  LLM_DAILY_LIMIT_PER_USER_SEARCH: string;
+  LLM_DAILY_LIMIT_PER_WORKSPACE_ASK: string;
+  LLM_DAILY_LIMIT_PER_WORKSPACE_SEARCH: string;
 
   // Secrets — undefined locally unless set via .dev.vars
   SENTRY_DSN?: string;

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -8,9 +8,12 @@ import { type AuthEnv, authMiddleware } from "./middleware/auth.js";
 import { registerErrorHandler } from "./middleware/error.js";
 import { debugRoute } from "./routes/_debug.js";
 import { adminCronRoute } from "./routes/admin-cron.js";
+import { adminSearchRoute } from "./routes/admin-search.js";
+import { askRoute } from "./routes/ask.js";
 import { healthRoute } from "./routes/health.js";
 import { meRoute } from "./routes/me.js";
 import { roomsRoute } from "./routes/rooms.js";
+import { searchRoute } from "./routes/search.js";
 import { wikiRoute } from "./routes/wiki.js";
 import { workspacesRoute } from "./routes/workspaces.js";
 import { scheduled } from "./scheduled.js";
@@ -32,6 +35,12 @@ app.use("/api/wiki/*", authMiddleware);
 app.use("/api/wiki-tree", authMiddleware);
 app.use("/api/_admin/wiki/*", authMiddleware);
 app.use("/api/_admin/cron/*", authMiddleware);
+// M6: search + RAG ask + reindex admin. The cost guard runs inside
+// each route, but the auth middleware is the gate that ensures we
+// have a workspace + user to charge.
+app.use("/api/search", authMiddleware);
+app.use("/api/ask", authMiddleware);
+app.use("/api/_admin/search/*", authMiddleware);
 
 app.route("/api/me", meRoute);
 app.route("/api/workspaces", workspacesRoute);
@@ -44,6 +53,11 @@ app.route("/api", wikiRoute);
 // only, enforced inside the route handler. Mounted at /api so the
 // route handler defines the absolute path.
 app.route("/api", adminCronRoute);
+// M6 search/ask/reindex routes. Mounted at /api so each route file
+// declares the absolute path (mirrors the wiki + admin-cron pattern).
+app.route("/api", searchRoute);
+app.route("/api", askRoute);
+app.route("/api", adminSearchRoute);
 
 app.notFound((c) =>
   c.json(apiErr(ErrorCodes.NOT_FOUND, `No route for ${c.req.method} ${c.req.path}`), 404),

--- a/apps/worker/src/lib/ai-search.ts
+++ b/apps/worker/src/lib/ai-search.ts
@@ -97,6 +97,11 @@ function mapMatch(match: AiSearchMatch): WikiSearchResult | null {
   // since "concept" is permissive on the editor side.
   const safeKind = isKnownKind(kind) ? kind : "concept";
   const snippet = (match.content ?? "").slice(0, SNIPPET_MAX_CHARS);
+  // Surface the chunk's heading so /ask citations can build
+  // /w/<path>#<slug>. Empty-string headings are treated as null (the
+  // upserter writes `heading: chunk.heading ?? undefined`, so an empty
+  // string would be a misconfigured indexer; coerce defensively).
+  const heading = typeof md.heading === "string" && md.heading.length > 0 ? md.heading : null;
   return {
     path,
     title,
@@ -104,6 +109,7 @@ function mapMatch(match: AiSearchMatch): WikiSearchResult | null {
     snippet,
     score: match.score,
     source: "ai_search",
+    heading,
   };
 }
 

--- a/apps/worker/src/lib/ai-search.ts
+++ b/apps/worker/src/lib/ai-search.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Typed wrapper around the optional Cloudflare AI Search Workers
+// binding (`env.AI_SEARCH`). Three responsibilities:
+//
+//   1. queryAiSearch — run a hybrid (BM25 + vector) search and map the
+//      raw `AiSearchMatch[]` into our `WikiSearchResult[]` shape.
+//   2. upsertPageInAiSearch — chunk a wiki page by section and push one
+//      doc per chunk, with stable ids so re-upserts replace cleanly.
+//   3. removePageFromAiSearch — delete every chunk-id known to belong
+//      to a page. The binding has no "delete by prefix" so we delete a
+//      bounded fan-out (CHUNK_DELETE_MAX) per call. Documented below.
+//
+// Sentinel error: when the binding is missing, disabled, or throws,
+// every entry point throws `LoomwikiError("AI_SEARCH_UNAVAILABLE", ...)`.
+// The literal "AI_SEARCH_UNAVAILABLE" is intentionally NOT in
+// packages/shared `ErrorCodes` — it's an internal sentinel the search
+// orchestrator (lib/search.ts) catches to fall through to FTS5. Users
+// never see it on the wire.
+
+import type { WikiPageFrontmatter, WikiSearchResult } from "@loomwiki/schema";
+import { LoomwikiError, chunkPageBySection } from "@loomwiki/shared";
+import type { AiSearchBinding, AiSearchMatch, AiSearchUpsertDoc } from "../ai-search-binding.js";
+import type { Env } from "../env.js";
+
+/** Internal sentinel — not part of the public ErrorCodes union. */
+const AI_SEARCH_UNAVAILABLE = "AI_SEARCH_UNAVAILABLE";
+
+// Snippet cap for results. AI Search returns up to its own configured
+// chunk size; we trim to keep payloads small in the API response.
+const SNIPPET_MAX_CHARS = 280;
+
+// Upper bound on chunks-per-page that `removePageFromAiSearch` will
+// attempt to delete. The binding has no "delete by prefix" surface, so
+// we fan out `id = path#0..path#N` deletes. 64 is well above the
+// realistic chunk count for a 64 KB page (typical: 2–10 chunks). If a
+// page ever exceeds this, the orphan chunks linger until the next
+// upsert overwrites them or an admin reindex sweeps. Recorded as a
+// known-limitation tradeoff for v0.0.1.
+const CHUNK_DELETE_MAX = 64;
+
+interface UnavailableOpts {
+  cause?: unknown;
+}
+
+function unavailable(message: string, opts: UnavailableOpts = {}): LoomwikiError {
+  return new LoomwikiError(AI_SEARCH_UNAVAILABLE, message, { status: 503, cause: opts.cause });
+}
+
+function bindingOrThrow(env: Env): AiSearchBinding {
+  if (env.AI_SEARCH_ENABLED === "false") {
+    throw unavailable("AI Search disabled via AI_SEARCH_ENABLED=false");
+  }
+  if (!env.AI_SEARCH) {
+    throw unavailable("AI Search binding not configured");
+  }
+  return env.AI_SEARCH;
+}
+
+export interface QueryAiSearchOptions {
+  query: string;
+  topK?: number;
+}
+
+export async function queryAiSearch(
+  env: Env,
+  opts: QueryAiSearchOptions,
+): Promise<WikiSearchResult[]> {
+  const binding = bindingOrThrow(env);
+  const trimmed = opts.query.trim();
+  if (trimmed.length === 0) return [];
+
+  let result: { matches: AiSearchMatch[] };
+  try {
+    result = await binding.search({ query: trimmed, topK: opts.topK });
+  } catch (cause) {
+    throw unavailable("AI Search query failed", { cause });
+  }
+
+  const out: WikiSearchResult[] = [];
+  for (const match of result.matches) {
+    const mapped = mapMatch(match);
+    if (mapped) out.push(mapped);
+  }
+  return out;
+}
+
+function mapMatch(match: AiSearchMatch): WikiSearchResult | null {
+  const md = match.metadata ?? {};
+  const path = typeof md.path === "string" ? md.path : null;
+  const title = typeof md.title === "string" ? md.title : null;
+  const kind = typeof md.kind === "string" ? md.kind : null;
+  if (!path || !title || !kind) return null;
+  // Keep the kind union narrow at the boundary. If AI Search ever
+  // returns a kind we don't recognize the orchestrator's response
+  // parse (Zod) would fail; coerce to "concept" as a safe default
+  // since "concept" is permissive on the editor side.
+  const safeKind = isKnownKind(kind) ? kind : "concept";
+  const snippet = (match.content ?? "").slice(0, SNIPPET_MAX_CHARS);
+  return {
+    path,
+    title,
+    kind: safeKind,
+    snippet,
+    score: match.score,
+    source: "ai_search",
+  };
+}
+
+const KNOWN_KINDS = new Set(["entity", "decision", "concept", "open-question", "glossary"]);
+function isKnownKind(value: string): value is WikiSearchResult["kind"] {
+  return KNOWN_KINDS.has(value);
+}
+
+export interface UpsertPageInAiSearchInput {
+  path: string;
+  frontmatter: Pick<WikiPageFrontmatter, "title" | "kind">;
+  body: string;
+}
+
+export async function upsertPageInAiSearch(
+  env: Env,
+  input: UpsertPageInAiSearchInput,
+): Promise<void> {
+  const binding = bindingOrThrow(env);
+  const chunks = chunkPageBySection(input.body, {
+    path: input.path,
+    title: input.frontmatter.title,
+    kind: input.frontmatter.kind,
+  });
+  // A page that chunks to nothing (empty body) still needs the path
+  // removed from the index so a page that used to have content but
+  // was emptied stops appearing in search results. Issue a bounded
+  // delete sweep instead of an upsert.
+  if (chunks.length === 0) {
+    await removePageFromAiSearch(env, input.path);
+    return;
+  }
+
+  const docs: AiSearchUpsertDoc[] = chunks.map((chunk, index) => ({
+    id: `${input.path}#${index}`,
+    content: chunk.body,
+    metadata: {
+      path: chunk.path,
+      title: chunk.title,
+      kind: chunk.kind,
+      heading: chunk.heading ?? undefined,
+      section_path: chunk.sectionPath,
+    },
+  }));
+
+  try {
+    await binding.upsert(docs);
+  } catch (cause) {
+    throw unavailable("AI Search upsert failed", { cause });
+  }
+
+  // After an upsert, sweep any *trailing* chunk ids from a previous,
+  // longer version of the page so stale chunks don't linger. This is
+  // bounded by CHUNK_DELETE_MAX; pages that shrink past that bound are
+  // covered on the next admin reindex.
+  if (chunks.length < CHUNK_DELETE_MAX) {
+    const stale: string[] = [];
+    for (let i = chunks.length; i < CHUNK_DELETE_MAX; i += 1) {
+      stale.push(`${input.path}#${i}`);
+    }
+    try {
+      await binding.delete(stale);
+    } catch {
+      // Sweep failure is non-fatal — the upsert succeeded; stale
+      // chunks at most show up as low-score noise until the next edit.
+    }
+  }
+}
+
+export async function removePageFromAiSearch(env: Env, path: string): Promise<void> {
+  const binding = bindingOrThrow(env);
+  const ids: string[] = [];
+  for (let i = 0; i < CHUNK_DELETE_MAX; i += 1) {
+    ids.push(`${path}#${i}`);
+  }
+  try {
+    await binding.delete(ids);
+  } catch (cause) {
+    throw unavailable("AI Search delete failed", { cause });
+  }
+}

--- a/apps/worker/src/lib/byok.ts
+++ b/apps/worker/src/lib/byok.ts
@@ -18,11 +18,7 @@ import type { Env } from "../env.js";
 
 export type ByokProvider = "anthropic" | "openai" | "google";
 
-const KNOWN_PROVIDERS: ReadonlySet<ByokProvider> = new Set([
-  "anthropic",
-  "openai",
-  "google",
-]);
+const KNOWN_PROVIDERS: ReadonlySet<ByokProvider> = new Set(["anthropic", "openai", "google"]);
 
 export function isKnownByokProvider(value: unknown): value is ByokProvider {
   return typeof value === "string" && KNOWN_PROVIDERS.has(value as ByokProvider);

--- a/apps/worker/src/lib/byok.ts
+++ b/apps/worker/src/lib/byok.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// BYOK lookup placeholder for M8. M6 ships the abstraction so `llm.ts`
+// can already invoke it; M8 swaps in the envelope-decryption logic
+// against the `byok_keys` D1 table provisioned in M1.
+//
+// Contract (frozen, M8 must preserve):
+//   getBYOK(env, workspaceId, provider) returns the plaintext API key
+//   for the workspace + provider, or `null` if no key is set up.
+//
+// In M6 the function ALWAYS returns null. The body still queries D1 so
+// the request shape (binding + table presence) is exercised in tests —
+// the M8 patch is then "decrypt the row we already fetched", not "wire
+// up the query". Test assertions for the M6 null-contract live in
+// __tests__/byok.test.ts.
+
+import type { Env } from "../env.js";
+
+export type ByokProvider = "anthropic" | "openai" | "google";
+
+const KNOWN_PROVIDERS: ReadonlySet<ByokProvider> = new Set([
+  "anthropic",
+  "openai",
+  "google",
+]);
+
+export function isKnownByokProvider(value: unknown): value is ByokProvider {
+  return typeof value === "string" && KNOWN_PROVIDERS.has(value as ByokProvider);
+}
+
+/**
+ * Look up a BYOK API key for `(workspaceId, provider)`. Returns null if
+ * no row exists OR if the row exists but cannot be decrypted (M8 will
+ * differentiate; M6 always returns null and never decrypts).
+ *
+ * M6 deliberately never throws on a missing key — callers expect null
+ * to mean "use the workspace default LLM" (Workers AI for v0.0.1).
+ */
+export async function getBYOK(
+  env: Env,
+  workspaceId: string,
+  provider: ByokProvider,
+): Promise<string | null> {
+  if (!isKnownByokProvider(provider)) return null;
+
+  // Touch D1 so the request shape is wired even though M6 doesn't
+  // decrypt yet. A missing row → null. A present row → still null in
+  // M6 (M8 plug-in point: decrypt(row.iv, row.ciphertext) here).
+  const row = await env.DB.prepare(
+    "SELECT 1 AS present FROM byok_keys WHERE workspace_id = ? AND provider = ?",
+  )
+    .bind(workspaceId, provider)
+    .first();
+
+  if (row === null) return null;
+  // M8 plug-in point: replace this with envelope decryption.
+  return null;
+}

--- a/apps/worker/src/lib/cost-guard.ts
+++ b/apps/worker/src/lib/cost-guard.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Cost guard. Sits in front of every /api/ask and /api/search call,
+// checking both the per-user and per-workspace daily caps before the
+// LLM call goes out. Whichever cap fails first wins the rate-limit
+// error.
+//
+// Three layers of defense (docs/SECURITY.md §7):
+//   1. Per-user counter   (this module)
+//   2. Per-workspace counter (this module)
+//   3. AI Gateway daily cap  (CF dashboard, not code)
+//
+// Skipping any single layer creates a hole. User caps without
+// workspace caps means a botnet inside one workspace can drain the
+// quota; workspace caps without user caps mean one bad actor consumes
+// a shared budget; missing the Gateway layer means a worker bug
+// exposes the whole account to runaway spend.
+//
+// Counter increments happen BEFORE the LLM call (in `assertWithinLimit`
+// → `recordUsage`). A client disconnect mid-stream does NOT roll back
+// the counter — the cost has already been incurred at the LLM provider.
+
+import { type LlmUsageKind } from "@loomwiki/schema";
+import { ErrorCodes, LoomwikiError } from "@loomwiki/shared";
+import type { Env } from "../env.js";
+import { type Clock, getUsage, incrementUsage, nextUtcMidnightIso } from "./usage.js";
+
+export interface AssertWithinLimitArgs {
+  env: Env;
+  workspaceId: string;
+  userId: string;
+  kind: LlmUsageKind;
+  /** Test seam — defaults to wall clock. */
+  clock?: Clock;
+}
+
+export interface DailyLimits {
+  perUserAsk: number;
+  perUserSearch: number;
+  perWorkspaceAsk: number;
+  perWorkspaceSearch: number;
+}
+
+const DEFAULTS: DailyLimits = {
+  perUserAsk: 100,
+  perUserSearch: 1000,
+  perWorkspaceAsk: 1000,
+  perWorkspaceSearch: 10000,
+};
+
+function parseLimit(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n < 0) return fallback;
+  return n;
+}
+
+export function readLimits(env: Env): DailyLimits {
+  return {
+    perUserAsk: parseLimit(env.LLM_DAILY_LIMIT_PER_USER_ASK, DEFAULTS.perUserAsk),
+    perUserSearch: parseLimit(env.LLM_DAILY_LIMIT_PER_USER_SEARCH, DEFAULTS.perUserSearch),
+    perWorkspaceAsk: parseLimit(env.LLM_DAILY_LIMIT_PER_WORKSPACE_ASK, DEFAULTS.perWorkspaceAsk),
+    perWorkspaceSearch: parseLimit(
+      env.LLM_DAILY_LIMIT_PER_WORKSPACE_SEARCH,
+      DEFAULTS.perWorkspaceSearch,
+    ),
+  };
+}
+
+const WORKSPACE_SCOPE_ID = "_workspace" as const;
+
+interface RateLimitDetails {
+  limit: number;
+  used: number;
+  scope: "user" | "workspace";
+  reset_at: string;
+}
+
+function rateLimitError(details: RateLimitDetails): LoomwikiError {
+  return new LoomwikiError(
+    ErrorCodes.RATE_LIMITED,
+    `Daily ${details.scope} limit reached (${details.used}/${details.limit})`,
+    { status: 429, details },
+  );
+}
+
+/**
+ * Throws `LoomwikiError("RATE_LIMITED", ...)` if either cap would be
+ * exceeded by this call; otherwise increments BOTH the per-user and
+ * per-workspace counters and returns. Counters increment before the
+ * LLM call, never after — see module-level note on disconnect handling.
+ */
+export async function assertWithinLimit(args: AssertWithinLimitArgs): Promise<void> {
+  const limits = readLimits(args.env);
+  const userLimit = args.kind === "ask" ? limits.perUserAsk : limits.perUserSearch;
+  const workspaceLimit = args.kind === "ask" ? limits.perWorkspaceAsk : limits.perWorkspaceSearch;
+
+  const clockMs = (args.clock ?? Date.now)();
+  const resetAt = nextUtcMidnightIso(clockMs);
+
+  // Read both counters before deciding. Reading first means a single
+  // request that would push BOTH counters over the cap reports the
+  // user cap (which fails first in our policy), not the workspace
+  // cap, even though both would trip.
+  const [userUsage, wsUsage] = await Promise.all([
+    getUsage(
+      args.env,
+      { workspaceId: args.workspaceId, scopeType: "user", scopeId: args.userId },
+      args.clock,
+    ),
+    getUsage(
+      args.env,
+      { workspaceId: args.workspaceId, scopeType: "workspace", scopeId: WORKSPACE_SCOPE_ID },
+      args.clock,
+    ),
+  ]);
+
+  const userUsed = args.kind === "ask" ? userUsage.ask_count : userUsage.search_count;
+  const wsUsed = args.kind === "ask" ? wsUsage.ask_count : wsUsage.search_count;
+
+  if (userUsed >= userLimit) {
+    throw rateLimitError({ limit: userLimit, used: userUsed, scope: "user", reset_at: resetAt });
+  }
+  if (wsUsed >= workspaceLimit) {
+    throw rateLimitError({
+      limit: workspaceLimit,
+      used: wsUsed,
+      scope: "workspace",
+      reset_at: resetAt,
+    });
+  }
+
+  // Both counters increment for the same logical event. Concurrent
+  // safe via the ON CONFLICT DO UPDATE in incrementUsage.
+  await Promise.all([
+    incrementUsage(
+      args.env,
+      { workspaceId: args.workspaceId, scopeType: "user", scopeId: args.userId },
+      args.kind,
+      args.clock,
+    ),
+    incrementUsage(
+      args.env,
+      { workspaceId: args.workspaceId, scopeType: "workspace", scopeId: WORKSPACE_SCOPE_ID },
+      args.kind,
+      args.clock,
+    ),
+  ]);
+}
+
+export const __testing = { WORKSPACE_SCOPE_ID };

--- a/apps/worker/src/lib/cost-guard.ts
+++ b/apps/worker/src/lib/cost-guard.ts
@@ -20,7 +20,7 @@
 // → `recordUsage`). A client disconnect mid-stream does NOT roll back
 // the counter — the cost has already been incurred at the LLM provider.
 
-import { type LlmUsageKind } from "@loomwiki/schema";
+import type { LlmUsageKind } from "@loomwiki/schema";
 import { ErrorCodes, LoomwikiError } from "@loomwiki/shared";
 import type { Env } from "../env.js";
 import { type Clock, getUsage, incrementUsage, nextUtcMidnightIso } from "./usage.js";

--- a/apps/worker/src/lib/embeddings.ts
+++ b/apps/worker/src/lib/embeddings.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Embedding generator. Wraps `env.AI.run('@cf/baai/bge-base-en-v1.5')`
+// (or the Gateway equivalent) and batches inputs to keep request size
+// inside Workers AI limits.
+//
+// Used by the M6 admin reindex path (when AI Search is unavailable and
+// we want to compute query-side embeddings ourselves) and by the future
+// M7 ingest agent for similarity-based proposal de-duplication.
+//
+// Batch size cap of 32 mirrors Workers AI's documented per-request
+// input cap. Larger inputs split across multiple round trips, in
+// order, results concatenated.
+
+import type { Env } from "../env.js";
+
+const BATCH_SIZE = 32;
+
+export interface EmbedOptions {
+  env: Env;
+  texts: string[];
+  /** Override the default embedding model (advanced). */
+  model?: string;
+}
+
+/**
+ * Embed an array of texts. Returns one vector per input in the same
+ * order. Empty input array returns empty result.
+ */
+export async function embed(opts: EmbedOptions): Promise<number[][]> {
+  if (opts.texts.length === 0) return [];
+  const model = opts.model && opts.model.length > 0 ? opts.model : opts.env.EMBEDDING_MODEL;
+
+  const out: number[][] = [];
+  for (let i = 0; i < opts.texts.length; i += BATCH_SIZE) {
+    const batch = opts.texts.slice(i, i + BATCH_SIZE);
+    const vectors = await embedBatch(opts.env, model, batch);
+    out.push(...vectors);
+  }
+  return out;
+}
+
+interface EmbeddingResponse {
+  data?: number[][];
+  shape?: number[];
+}
+
+async function embedBatch(env: Env, model: string, texts: string[]): Promise<number[][]> {
+  const gw = env.AI_GATEWAY_ID;
+  const acct = env.CF_ACCOUNT_ID;
+  const useGateway = gw && gw.length > 0 && acct && acct.length > 0;
+
+  if (useGateway) {
+    const url = `https://gateway.ai.cloudflare.com/v1/${acct}/${gw}/workers-ai/run/${model}`;
+    const res = await fetch(url, {
+      method: "POST",
+      headers: gatewayHeaders(env),
+      body: JSON.stringify({ text: texts }),
+    });
+    if (!res.ok) {
+      throw new Error(`embeddings: gateway ${res.status}`);
+    }
+    const json = (await res.json()) as { result?: EmbeddingResponse };
+    return json.result?.data ?? [];
+  }
+
+  const result = (await env.AI.run(model, { text: texts })) as EmbeddingResponse;
+  return result.data ?? [];
+}
+
+function gatewayHeaders(env: Env): HeadersInit {
+  const h: Record<string, string> = { "Content-Type": "application/json" };
+  if (env.AI_GATEWAY_TOKEN && env.AI_GATEWAY_TOKEN.length > 0) {
+    h.Authorization = `Bearer ${env.AI_GATEWAY_TOKEN}`;
+  }
+  return h;
+}

--- a/apps/worker/src/lib/fts5.ts
+++ b/apps/worker/src/lib/fts5.ts
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// D1 FTS5 fallback search over `/wiki/**` pages. Used when AI Search is
+// unavailable (binding missing, AI_SEARCH_ENABLED=false, or the binding
+// throws). Backed by the `wiki_pages_fts` virtual table created in
+// migration 0002 (`tokenize='porter unicode61'`, columns
+// `path UNINDEXED, title, body`).
+//
+// Three operations:
+//   - upsertPageFts5: DELETE-then-INSERT (FTS5 has no native UPSERT).
+//   - removePageFts5: DELETE by path.
+//   - searchFts5: MATCH ? with bm25 ranking and snippet() highlights.
+//
+// The index intentionally does NOT carry kind. Per-result `kind` is
+// resolved by reading the page from the wiki backend (cheap KV read at
+// POC scale; pages are small). On miss we fall back to "concept", which
+// is the most permissive editor target.
+//
+// Query sanitization is minimal but defensive: we strip double-quotes
+// from the input, then wrap the trimmed query in `"..."` so FTS5 treats
+// the whole thing as a single phrase. This avoids surprising operator
+// behavior when a user types `foo (bar` or `cat:` — both are valid
+// search intents that raw MATCH would error on.
+
+import type { WikiPageKind, WikiSearchResult } from "@loomwiki/schema";
+import type { Env } from "../env.js";
+import { defaultWikiBackend } from "./vault-bootstrap.js";
+import { deserializePage } from "./wiki-content.js";
+
+export interface UpsertPageFts5Input {
+  path: string;
+  title: string;
+  body: string;
+}
+
+export async function upsertPageFts5(env: Env, input: UpsertPageFts5Input): Promise<void> {
+  // FTS5 doesn't support `INSERT OR REPLACE` because the rowid is
+  // implicit, so the cheapest atomic upsert is DELETE + INSERT.
+  await env.DB.prepare("DELETE FROM wiki_pages_fts WHERE path = ?").bind(input.path).run();
+  await env.DB.prepare("INSERT INTO wiki_pages_fts (path, title, body) VALUES (?, ?, ?)")
+    .bind(input.path, input.title, input.body)
+    .run();
+}
+
+export async function removePageFts5(env: Env, path: string): Promise<void> {
+  await env.DB.prepare("DELETE FROM wiki_pages_fts WHERE path = ?").bind(path).run();
+}
+
+export interface SearchFts5Options {
+  topK?: number;
+}
+
+interface Fts5Row {
+  path: string;
+  title: string;
+  snippet: string;
+  rank: number;
+}
+
+export async function searchFts5(
+  env: Env,
+  query: string,
+  opts: SearchFts5Options = {},
+): Promise<WikiSearchResult[]> {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return [];
+  const sanitized = sanitizeFts5Query(trimmed);
+  if (sanitized.length === 0) return [];
+
+  const topK = opts.topK ?? 5;
+
+  // bm25() returns a negative score (more-negative = better). We
+  // negate so the result-side `score` field is descending-friendly.
+  // snippet() args: column index 2 = body, mark prefix/suffix, ellipsis,
+  // 32 tokens of context.
+  const stmt = env.DB.prepare(
+    `SELECT path, title,
+            snippet(wiki_pages_fts, 2, '<mark>', '</mark>', '…', 32) AS snippet,
+            bm25(wiki_pages_fts) AS rank
+     FROM wiki_pages_fts
+     WHERE wiki_pages_fts MATCH ?
+     ORDER BY rank ASC
+     LIMIT ?`,
+  ).bind(sanitized, topK);
+
+  const result = await stmt.all<Fts5Row>();
+  const rows = result.results ?? [];
+
+  // Resolve `kind` per result via the wiki backend. POC-scale: at
+  // most `topK` reads (default 5). Cache could land in M8 if this
+  // becomes a bottleneck, but the backend is KV → microseconds per hit.
+  const backend = defaultWikiBackend(env);
+  const out: WikiSearchResult[] = [];
+  for (const row of rows) {
+    const kind = await resolveKind(backend, row.path);
+    out.push({
+      path: row.path,
+      title: row.title,
+      kind,
+      snippet: row.snippet,
+      score: -row.rank,
+      source: "fts5",
+    });
+  }
+  return out;
+}
+
+async function resolveKind(
+  backend: ReturnType<typeof defaultWikiBackend>,
+  path: string,
+): Promise<WikiPageKind> {
+  try {
+    const record = await backend.read(path);
+    if (!record) return "concept";
+    const parsed = await deserializePage(record.raw);
+    return parsed.frontmatter.kind;
+  } catch {
+    // Backend hiccup or malformed frontmatter — keep search working.
+    return "concept";
+  }
+}
+
+/**
+ * Defensive sanitizer for an FTS5 MATCH query.
+ *
+ * Strategy: strip embedded double-quotes (which would close our wrapping
+ * phrase) and collapse whitespace, then wrap the result in `"..."` so
+ * FTS5 treats the whole thing as a single phrase — neutralizing
+ * operators (`AND`/`OR`/`NOT`/`NEAR`), prefix `*`, column qualifiers
+ * (`title:`), and unbalanced parens.
+ *
+ * Returns the empty string if the sanitized payload is empty (FTS5
+ * MATCH on `""` would error).
+ */
+function sanitizeFts5Query(query: string): string {
+  const cleaned = query.replace(/"/g, " ").replace(/\s+/g, " ").trim();
+  if (cleaned.length === 0) return "";
+  return `"${cleaned}"`;
+}

--- a/apps/worker/src/lib/llm.ts
+++ b/apps/worker/src/lib/llm.ts
@@ -211,13 +211,12 @@ export async function* chatStream(opts: ChatOptions): AsyncIterable<ChatStreamCh
       if (done) break;
       buffer += decoder.decode(value, { stream: true });
       // Process complete SSE events (separated by blank lines).
-      let split: number;
-      while ((split = buffer.indexOf("\n\n")) !== -1) {
+      while (true) {
+        const split = buffer.indexOf("\n\n");
+        if (split === -1) break;
         const event = buffer.slice(0, split);
         buffer = buffer.slice(split + 2);
-        const dataLine = event
-          .split("\n")
-          .find((l) => l.startsWith("data:"));
+        const dataLine = event.split("\n").find((l) => l.startsWith("data:"));
         if (!dataLine) continue;
         const payload = dataLine.slice(5).trim();
         if (payload === "[DONE]" || payload.length === 0) continue;

--- a/apps/worker/src/lib/llm.ts
+++ b/apps/worker/src/lib/llm.ts
@@ -88,6 +88,19 @@ function resolveRoute(opts: ChatOptions): ResolvedRoute {
   return { gatewayUrl: null, model, byokProvider: "workers_ai" };
 }
 
+// Guard against the env.AI binding being absent (e.g. local-dev configs
+// that omit it because Wrangler refuses to start `wrangler dev` for
+// remote-only bindings without a login). Without this, downstream code
+// fails with the inscrutable `Cannot read properties of undefined
+// (reading 'run')` mid-stream.
+function requireAiBinding(opts: ChatOptions): void {
+  if (!opts.env.AI || typeof opts.env.AI.run !== "function") {
+    throw new Error(
+      "llm: env.AI binding is not available. Configure AI_GATEWAY_ID + CF_ACCOUNT_ID, or run with `wrangler dev --remote --config wrangler.jsonc`. (See DEPLOY.md §AI Search + /ask + cost guards.)",
+    );
+  }
+}
+
 interface WorkersAiRunBody {
   messages: { role: "system" | "user"; content: string }[];
   stream?: boolean;
@@ -119,6 +132,7 @@ async function maybeBYOK(opts: ChatOptions): Promise<string | null> {
 /** Non-streaming chat completion. Returns the full text. */
 export async function chat(opts: ChatOptions): Promise<ChatResult> {
   const route = resolveRoute(opts);
+  if (route.gatewayUrl === null) requireAiBinding(opts);
   const byok = await maybeBYOK(opts);
   if (byok === null) warnDevModelOnce();
 
@@ -169,6 +183,7 @@ export interface ChatStreamChunk {
  */
 export async function* chatStream(opts: ChatOptions): AsyncIterable<ChatStreamChunk> {
   const route = resolveRoute(opts);
+  if (route.gatewayUrl === null) requireAiBinding(opts);
   const byok = await maybeBYOK(opts);
   if (byok === null) warnDevModelOnce();
 

--- a/apps/worker/src/lib/llm.ts
+++ b/apps/worker/src/lib/llm.ts
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Single LLM call site. Every other module — rag.ts, the future M7
+// IngestAgent, the future M8 admin tools — calls `chat()` /
+// `chatStream()` and never touches `env.AI` directly. This means
+// swapping the default model, adding a new BYOK provider, or routing
+// through AI Gateway is a one-file change here.
+//
+// Routing:
+//   - When env.AI_GATEWAY_ID is set → call the AI Gateway endpoint
+//     `https://gateway.ai.cloudflare.com/v1/{ACCOUNT_ID}/{GATEWAY}/workers-ai/run/{model}`.
+//     This gives us caching, observability, and a hard daily cap on
+//     the gateway side.
+//   - When env.AI_GATEWAY_ID is empty → call `env.AI.run(model, ...)`
+//     directly. Loses the global cap layer; used in local dev with no
+//     gateway provisioned and as a fallback if the gateway is down.
+//
+// BYOK is a placeholder in M6 — `byok.ts` always returns null. The
+// call site below already invokes the lookup so M8's plug-in point
+// is "decrypt instead of returning null", not "wire up the call".
+
+import type { Env } from "../env.js";
+import { getBYOK } from "./byok.js";
+
+export interface ChatUsage {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+}
+
+export interface ChatResult {
+  text: string;
+  model: string;
+  usage: ChatUsage;
+}
+
+export interface ChatOptions {
+  env: Env;
+  /** User-facing prompt content. */
+  prompt: string;
+  /** Optional system message; defaults to a neutral assistant prompt. */
+  system?: string;
+  /** Override the default model. Use the Workers AI catalog id (`@cf/...`). */
+  model?: string;
+  /** Workspace id; needed for the BYOK lookup. */
+  workspaceId?: string;
+  /** Override the BYOK lookup result (testing seam). */
+  byokOverride?: string | null;
+  /** Sampling. Optional; the worker leaves model defaults intact when omitted. */
+  temperature?: number;
+  /** Token budget. Optional; same. */
+  maxTokens?: number;
+}
+
+const DEFAULT_SYSTEM = "You are a helpful, concise assistant.";
+
+let warnedDevModel = false;
+function warnDevModelOnce(): void {
+  if (warnedDevModel) return;
+  warnedDevModel = true;
+  const nodeEnv = typeof process !== "undefined" && process.env ? process.env.NODE_ENV : undefined;
+  if (nodeEnv !== "production") {
+    console.warn(
+      "[loomwiki] llm.chat: BYOK miss — using Workers AI default. In dev this still spends free-tier neurons; consider configuring BYOK or LLM_DAILY_LIMIT_PER_USER caps for cost control.",
+    );
+  }
+}
+
+interface ResolvedRoute {
+  /** AI Gateway URL when configured; null = use env.AI binding directly. */
+  gatewayUrl: string | null;
+  model: string;
+  /** When BYOK is in play, the provider key route ("anthropic", etc.). M6 always Workers AI. */
+  byokProvider: "workers_ai";
+}
+
+function resolveRoute(opts: ChatOptions): ResolvedRoute {
+  const model = opts.model && opts.model.length > 0 ? opts.model : opts.env.DEFAULT_LLM_MODEL;
+  const gw = opts.env.AI_GATEWAY_ID;
+  const acct = opts.env.CF_ACCOUNT_ID;
+  if (gw && gw.length > 0 && acct && acct.length > 0) {
+    return {
+      gatewayUrl: `https://gateway.ai.cloudflare.com/v1/${acct}/${gw}/workers-ai/run/${model}`,
+      model,
+      byokProvider: "workers_ai",
+    };
+  }
+  return { gatewayUrl: null, model, byokProvider: "workers_ai" };
+}
+
+interface WorkersAiRunBody {
+  messages: { role: "system" | "user"; content: string }[];
+  stream?: boolean;
+  temperature?: number;
+  max_tokens?: number;
+}
+
+function buildBody(opts: ChatOptions, stream: boolean): WorkersAiRunBody {
+  const body: WorkersAiRunBody = {
+    messages: [
+      { role: "system", content: opts.system ?? DEFAULT_SYSTEM },
+      { role: "user", content: opts.prompt },
+    ],
+    stream,
+  };
+  if (opts.temperature !== undefined) body.temperature = opts.temperature;
+  if (opts.maxTokens !== undefined) body.max_tokens = opts.maxTokens;
+  return body;
+}
+
+async function maybeBYOK(opts: ChatOptions): Promise<string | null> {
+  if (opts.byokOverride !== undefined) return opts.byokOverride;
+  if (!opts.workspaceId) return null;
+  // M6 always null. M8 plug-in point: decide which provider to look up
+  // based on workspace settings, then return the decrypted key.
+  return getBYOK(opts.env, opts.workspaceId, "anthropic");
+}
+
+/** Non-streaming chat completion. Returns the full text. */
+export async function chat(opts: ChatOptions): Promise<ChatResult> {
+  const route = resolveRoute(opts);
+  const byok = await maybeBYOK(opts);
+  if (byok === null) warnDevModelOnce();
+
+  const body = buildBody(opts, false);
+
+  if (route.gatewayUrl !== null) {
+    const res = await fetch(route.gatewayUrl, {
+      method: "POST",
+      headers: gatewayHeaders(opts.env),
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      throw new Error(`llm.chat: gateway ${res.status}: ${await res.text().catch(() => "")}`);
+    }
+    const json = (await res.json()) as { result?: { response?: string }; usage?: ChatUsage };
+    return {
+      text: json.result?.response ?? "",
+      model: route.model,
+      usage: json.usage ?? {},
+    };
+  }
+
+  const result = (await opts.env.AI.run(route.model, body)) as {
+    response?: string;
+    usage?: ChatUsage;
+  };
+  return {
+    text: result.response ?? "",
+    model: route.model,
+    usage: result.usage ?? {},
+  };
+}
+
+export interface ChatStreamChunk {
+  delta: string;
+  done: boolean;
+  model: string;
+}
+
+/**
+ * Streaming chat completion. Yields one chunk per server-side update.
+ * The final chunk has `done: true` and `delta: ""`.
+ *
+ * Implementation reads from the underlying SSE-style stream and
+ * forwards parsed `delta` strings. Workers AI emits `data: {...}\n\n`
+ * lines containing `{ response: "<token>" }`; non-JSON lines (e.g.
+ * `data: [DONE]`) terminate the stream.
+ */
+export async function* chatStream(opts: ChatOptions): AsyncIterable<ChatStreamChunk> {
+  const route = resolveRoute(opts);
+  const byok = await maybeBYOK(opts);
+  if (byok === null) warnDevModelOnce();
+
+  const body = buildBody(opts, true);
+
+  let stream: ReadableStream<Uint8Array> | null = null;
+  if (route.gatewayUrl !== null) {
+    const res = await fetch(route.gatewayUrl, {
+      method: "POST",
+      headers: gatewayHeaders(opts.env),
+      body: JSON.stringify(body),
+    });
+    if (!res.ok || res.body === null) {
+      throw new Error(`llm.chatStream: gateway ${res.status}`);
+    }
+    stream = res.body;
+  } else {
+    const result = (await opts.env.AI.run(route.model, body)) as
+      | ReadableStream<Uint8Array>
+      | { response?: string };
+    if (result instanceof ReadableStream) {
+      stream = result;
+    } else {
+      // Some Workers AI models ignore `stream: true` and return the
+      // full response. Surface as a single chunk so callers don't
+      // special-case.
+      yield { delta: result.response ?? "", done: false, model: route.model };
+      yield { delta: "", done: true, model: route.model };
+      return;
+    }
+  }
+
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      // Process complete SSE events (separated by blank lines).
+      let split: number;
+      while ((split = buffer.indexOf("\n\n")) !== -1) {
+        const event = buffer.slice(0, split);
+        buffer = buffer.slice(split + 2);
+        const dataLine = event
+          .split("\n")
+          .find((l) => l.startsWith("data:"));
+        if (!dataLine) continue;
+        const payload = dataLine.slice(5).trim();
+        if (payload === "[DONE]" || payload.length === 0) continue;
+        try {
+          const parsed = JSON.parse(payload) as { response?: string };
+          if (typeof parsed.response === "string" && parsed.response.length > 0) {
+            yield { delta: parsed.response, done: false, model: route.model };
+          }
+        } catch {
+          // Non-JSON payload — drop. Workers AI occasionally emits
+          // `data: ` keep-alive frames; ignoring them is correct.
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  yield { delta: "", done: true, model: route.model };
+}
+
+function gatewayHeaders(env: Env): HeadersInit {
+  const h: Record<string, string> = { "Content-Type": "application/json" };
+  if (env.AI_GATEWAY_TOKEN && env.AI_GATEWAY_TOKEN.length > 0) {
+    h.Authorization = `Bearer ${env.AI_GATEWAY_TOKEN}`;
+  }
+  return h;
+}

--- a/apps/worker/src/lib/rag.ts
+++ b/apps/worker/src/lib/rag.ts
@@ -118,18 +118,15 @@ function buildCitations(results: WikiSearchResult[]): AskCitation[] {
   return out;
 }
 
-// AI Search snippets sometimes embed the heading text as the first
-// line; FTS5 snippets are body-only. We don't have a clean cross-source
-// heading carrier today, so heading_slug is null for both sources in
-// v0.0.1 — best-effort slug derivation can land in M7 alongside the
-// IngestAgent, which has the structured chunk in hand. The
-// `slugifyHeading` import stays here so the v0.0.1 → v0.1 transition is
-// a one-line change.
-function deriveHeadingSlug(_result: WikiSearchResult): string | null {
-  // Reserved for v0.1: when AI Search results gain a `heading` field
-  // surfaced through this layer, return slugifyHeading(heading).
-  void slugifyHeading;
-  return null;
+// Heading slug derivation. AI Search results carry the matched
+// chunk's H1/H2 heading on `result.heading` (populated from chunk
+// metadata by lib/ai-search.ts); FTS5 results don't (the index is
+// row-per-page). The web citation pill builds /w/<path>#<slug> only
+// when this returns non-null.
+function deriveHeadingSlug(result: WikiSearchResult): string | null {
+  if (typeof result.heading !== "string" || result.heading.length === 0) return null;
+  const slug = slugifyHeading(result.heading);
+  return slug.length > 0 ? slug : null;
 }
 
 async function* singleMessageStream(message: string): AsyncIterable<string> {

--- a/apps/worker/src/lib/rag.ts
+++ b/apps/worker/src/lib/rag.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Retrieval-Augmented Generation entry point. Backs `/api/ask`.
+//
+// Flow:
+//   1. Run searchWiki() over the question to retrieve top-K chunks.
+//   2. If nothing came back, return a deterministic "no context" reply
+//      as a single-chunk stream (no LLM call) and an empty citation
+//      list. The cost-guard counter has already been incremented at
+//      the route layer; we do NOT roll it back — incrementing per
+//      attempt (vs per actual LLM call) is the simpler, more abuse-
+//      resistant accounting model. Documented in cost-guard.ts.
+//   3. Otherwise, build a tightly bounded prompt — system message
+//      forbids fabrication and demands citations by `path`, user
+//      message carries the question plus per-chunk truncated context
+//      (2000 chars/chunk × topK chunks = ~10 KB ceiling at topK=5).
+//   4. Call chatStream() and yield delta strings only; the route layer
+//      adds the SSE framing (`event: delta\ndata: ...`).
+//
+// Citations:
+//   - Deduped by path, preserving original (rank) order.
+//   - heading_slug is best-effort: AI Search results carry a `heading`
+//     field in metadata when the chunk was a section, FTS5 results
+//     don't (the index is row-per-page). When we can't infer a slug
+//     we leave it null — the route layer / web client renders the
+//     citation without an in-page anchor.
+
+import type { AskCitation, WikiSearchResponse, WikiSearchResult } from "@loomwiki/schema";
+import { slugifyHeading } from "@loomwiki/shared";
+import type { Env } from "../env.js";
+import { chatStream } from "./llm.js";
+import { searchWiki } from "./search.js";
+
+const NO_CONTEXT_MESSAGE = "I don't have enough context yet — try creating some wiki pages first.";
+
+const SYSTEM_PROMPT =
+  "Answer using only the provided context. If the context is insufficient, say so. " +
+  "Never fabricate facts. Cite sources by their path field.";
+
+// Per-chunk character cap for the prompt context block. Keeps the
+// total user message under ~10 KB at the default topK=5 so we stay
+// well inside Workers AI default token windows even on the smaller
+// catalog models.
+const PER_CHUNK_CHARS = 2000;
+
+export interface AskWithRagOptions {
+  env: Env;
+  question: string;
+  topK?: number;
+  workspaceId?: string;
+}
+
+export interface AskWithRagResult {
+  searchResults: WikiSearchResult[];
+  citations: AskCitation[];
+  stream: AsyncIterable<string>;
+  meta: { mode: WikiSearchResponse["mode"]; model?: string };
+}
+
+export async function askWithRag(opts: AskWithRagOptions): Promise<AskWithRagResult> {
+  const topK = opts.topK ?? 5;
+  const search = await searchWiki({ env: opts.env, query: opts.question, topK });
+
+  if (search.results.length === 0) {
+    return {
+      searchResults: [],
+      citations: [],
+      stream: singleMessageStream(NO_CONTEXT_MESSAGE),
+      meta: { mode: search.mode },
+    };
+  }
+
+  const userPrompt = buildUserPrompt(opts.question, search.results);
+  const citations = buildCitations(search.results);
+
+  const stream = deltaStream(
+    chatStream({
+      env: opts.env,
+      prompt: userPrompt,
+      system: SYSTEM_PROMPT,
+      workspaceId: opts.workspaceId,
+    }),
+  );
+
+  return {
+    searchResults: search.results,
+    citations,
+    stream,
+    meta: { mode: search.mode },
+  };
+}
+
+function buildUserPrompt(question: string, chunks: WikiSearchResult[]): string {
+  const ctx = chunks
+    .map((c) => `### ${c.path}\n${truncate(c.snippet, PER_CHUNK_CHARS)}`)
+    .join("\n\n");
+  return `${question}\n\n## Context\n\n${ctx}`;
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return `${s.slice(0, max)}…`;
+}
+
+function buildCitations(results: WikiSearchResult[]): AskCitation[] {
+  const seen = new Set<string>();
+  const out: AskCitation[] = [];
+  for (const r of results) {
+    if (seen.has(r.path)) continue;
+    seen.add(r.path);
+    out.push({
+      path: r.path,
+      title: r.title,
+      kind: r.kind,
+      heading_slug: deriveHeadingSlug(r),
+    });
+  }
+  return out;
+}
+
+// AI Search snippets sometimes embed the heading text as the first
+// line; FTS5 snippets are body-only. We don't have a clean cross-source
+// heading carrier today, so heading_slug is null for both sources in
+// v0.0.1 — best-effort slug derivation can land in M7 alongside the
+// IngestAgent, which has the structured chunk in hand. The
+// `slugifyHeading` import stays here so the v0.0.1 → v0.1 transition is
+// a one-line change.
+function deriveHeadingSlug(_result: WikiSearchResult): string | null {
+  // Reserved for v0.1: when AI Search results gain a `heading` field
+  // surfaced through this layer, return slugifyHeading(heading).
+  void slugifyHeading;
+  return null;
+}
+
+async function* singleMessageStream(message: string): AsyncIterable<string> {
+  yield message;
+}
+
+async function* deltaStream(
+  upstream: AsyncIterable<{ delta: string; done: boolean }>,
+): AsyncIterable<string> {
+  for await (const chunk of upstream) {
+    if (chunk.done) continue;
+    if (chunk.delta.length === 0) continue;
+    yield chunk.delta;
+  }
+}

--- a/apps/worker/src/lib/search.ts
+++ b/apps/worker/src/lib/search.ts
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Unified search orchestrator. Front door for `/api/search` and the
+// retrieval step of `/api/ask`. Tries AI Search first (hybrid BM25 +
+// vector via the Workers binding); on any failure or when explicitly
+// disabled, falls through to the D1 FTS5 fallback.
+//
+// The fallback is the single most important piece of resilience here —
+// AI Search is a remote-only binding, so local dev, CI, and any account
+// that hasn't provisioned it must still be able to search. Treating
+// "binding throws" the same as "binding missing" keeps the worker
+// useful through transient outages too.
+//
+// Mode in the response tells the caller which path served them:
+//   - "hybrid"        → AI Search succeeded.
+//   - "fts5_fallback" → either AI Search was disabled, the binding was
+//                       missing, or the call threw — and FTS5 served.
+// An empty result with `mode: "hybrid"` means AI Search ran fine and
+// genuinely had nothing; an empty result with `mode: "fts5_fallback"`
+// means we tried AI Search, fell back, and FTS5 also had nothing.
+
+import type { WikiSearchResponse } from "@loomwiki/schema";
+import { isLoomwikiError } from "@loomwiki/shared";
+import type { Env } from "../env.js";
+import { queryAiSearch } from "./ai-search.js";
+import { searchFts5 } from "./fts5.js";
+
+export interface SearchWikiOptions {
+  env: Env;
+  query: string;
+  topK?: number;
+}
+
+export async function searchWiki(opts: SearchWikiOptions): Promise<WikiSearchResponse> {
+  const trimmed = opts.query.trim();
+  if (trimmed.length === 0) {
+    return { results: [], mode: "hybrid" };
+  }
+  const topK = opts.topK ?? 5;
+
+  // Skip the AI Search attempt entirely when the operator has flipped
+  // it off. Going straight to FTS5 saves a guaranteed-throw round-trip
+  // through ai-search.ts and makes the mode label honest.
+  const aiSearchEnabled = opts.env.AI_SEARCH_ENABLED !== "false";
+  if (aiSearchEnabled) {
+    try {
+      const results = await queryAiSearch(opts.env, { query: trimmed, topK });
+      return { results, mode: "hybrid" };
+    } catch (err) {
+      if (isLoomwikiError(err) && err.code === "AI_SEARCH_UNAVAILABLE") {
+        // Expected fallthrough — binding missing, disabled, or upstream
+        // 5xx. Quiet log, then FTS5.
+        console.warn(`[search] AI Search unavailable, falling back to FTS5: ${err.message}`);
+      } else {
+        // Unexpected — log louder so it shows up in tail.
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`[search] AI Search threw unexpectedly, falling back: ${message}`);
+      }
+    }
+  }
+
+  const fallback = await searchFts5(opts.env, trimmed, { topK });
+  return { results: fallback, mode: "fts5_fallback" };
+}

--- a/apps/worker/src/lib/usage.ts
+++ b/apps/worker/src/lib/usage.ts
@@ -15,7 +15,7 @@
 // inject a fake clock to exercise rollover; production passes
 // `Date.now()` (the default).
 
-import { type LlmUsageKind, type LlmUsageScopeType } from "@loomwiki/schema";
+import type { LlmUsageKind, LlmUsageScopeType } from "@loomwiki/schema";
 import type { Env } from "../env.js";
 
 export type Clock = () => number;

--- a/apps/worker/src/lib/usage.ts
+++ b/apps/worker/src/lib/usage.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// LLM usage counters. Per-day, per-(workspace, scope) counts of /ask
+// and /search calls. Backed by the `llm_usage_daily` table from
+// migration 0002.
+//
+// Race safety: the upsert uses `INSERT ... ON CONFLICT DO UPDATE` on
+// the composite primary key (workspace_id, day, scope_type, scope_id).
+// SQLite serializes writes within a D1 instance, and the ON CONFLICT
+// clause handles the row-exists case atomically. A read-modify-write
+// pattern in JS would be racy under concurrent requests; this avoids
+// that entirely.
+//
+// UTC day key is computed in-function from the supplied clock. Tests
+// inject a fake clock to exercise rollover; production passes
+// `Date.now()` (the default).
+
+import { type LlmUsageKind, type LlmUsageScopeType } from "@loomwiki/schema";
+import type { Env } from "../env.js";
+
+export type Clock = () => number;
+const wallClock: Clock = () => Date.now();
+
+export interface UsageCounts {
+  ask_count: number;
+  search_count: number;
+}
+
+const ZERO_COUNTS: UsageCounts = { ask_count: 0, search_count: 0 };
+
+/**
+ * Compute the UTC day key (YYYY-MM-DD) for a given epoch-ms clock
+ * reading. Exported so cost-guard can format the same string when
+ * building rate-limit error details.
+ */
+export function utcDayKey(now: number): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+/**
+ * Compute the next UTC midnight as an ISO-8601 string. Used in the
+ * rate-limit error payload so clients can render "resets at X".
+ */
+export function nextUtcMidnightIso(now: number): string {
+  const day = utcDayKey(now);
+  // Add one day to the day-key, then return its midnight.
+  const tomorrow = new Date(`${day}T00:00:00Z`);
+  tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+  return tomorrow.toISOString();
+}
+
+interface ScopeKey {
+  workspaceId: string;
+  scopeType: LlmUsageScopeType;
+  scopeId: string;
+}
+
+/**
+ * Read today's counters for `(workspace, scope)`. Returns `{0,0}` when
+ * no row exists for today — same semantics as "the user has not been
+ * counted today".
+ */
+export async function getUsage(
+  env: Env,
+  scope: ScopeKey,
+  clock: Clock = wallClock,
+): Promise<UsageCounts> {
+  const day = utcDayKey(clock());
+  const row = await env.DB.prepare(
+    "SELECT ask_count, search_count FROM llm_usage_daily WHERE workspace_id = ? AND day = ? AND scope_type = ? AND scope_id = ?",
+  )
+    .bind(scope.workspaceId, day, scope.scopeType, scope.scopeId)
+    .first<{ ask_count: number; search_count: number }>();
+  if (row === null) return { ...ZERO_COUNTS };
+  return { ask_count: row.ask_count ?? 0, search_count: row.search_count ?? 0 };
+}
+
+/**
+ * Increment today's `kind` counter for `(workspace, scope)` by 1.
+ * Returns the post-increment counts so the cost-guard can include them
+ * in subsequent error payloads without a follow-up read.
+ */
+export async function incrementUsage(
+  env: Env,
+  scope: ScopeKey,
+  kind: LlmUsageKind,
+  clock: Clock = wallClock,
+): Promise<UsageCounts> {
+  const now = Math.floor(clock() / 1000);
+  const day = utcDayKey(clock());
+  const askDelta = kind === "ask" ? 1 : 0;
+  const searchDelta = kind === "search" ? 1 : 0;
+
+  // INSERT-or-UPDATE in a single statement. The PK is composite, so
+  // the conflict target enumerates all four columns.
+  await env.DB.prepare(
+    `INSERT INTO llm_usage_daily
+       (workspace_id, day, scope_type, scope_id, ask_count, search_count, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(workspace_id, day, scope_type, scope_id) DO UPDATE SET
+       ask_count    = ask_count + excluded.ask_count,
+       search_count = search_count + excluded.search_count,
+       updated_at   = excluded.updated_at`,
+  )
+    .bind(scope.workspaceId, day, scope.scopeType, scope.scopeId, askDelta, searchDelta, now)
+    .run();
+
+  return getUsage(env, scope, clock);
+}
+
+/**
+ * Test/reset helper. Wipes today's row for `(workspace, scope)`. Not
+ * exposed via any HTTP route — production cleanup is the operator's
+ * problem (manual SQL or future M9 reaper).
+ */
+export async function resetUsageToday(
+  env: Env,
+  scope: ScopeKey,
+  clock: Clock = wallClock,
+): Promise<void> {
+  const day = utcDayKey(clock());
+  await env.DB.prepare(
+    "DELETE FROM llm_usage_daily WHERE workspace_id = ? AND day = ? AND scope_type = ? AND scope_id = ?",
+  )
+    .bind(scope.workspaceId, day, scope.scopeType, scope.scopeId)
+    .run();
+}

--- a/apps/worker/src/routes/admin-search.ts
+++ b/apps/worker/src/routes/admin-search.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Operator-facing admin route to (re)build the search indices from
+// the canonical wiki backend. Used after a vault reset, after a
+// schema change, or as a smoke test that both indexers are healthy.
+//
+// POST /api/_admin/search/reindex
+//   Owner-only. No body. Returns ApiResult<SearchReindexResponse>.
+//
+// Per-page failures are isolated (mirrors M5's archive-day pattern):
+// one broken file should not halt the whole reindex. The response
+// surfaces every failure so the operator can decide whether to retry
+// or fix the underlying page.
+
+import { ErrorCodes, LoomwikiError, apiOk } from "@loomwiki/shared";
+import { Hono } from "hono";
+import { upsertPageInAiSearch } from "../lib/ai-search.js";
+import { upsertPageFts5 } from "../lib/fts5.js";
+import { defaultWikiBackend } from "../lib/vault-bootstrap.js";
+import { deserializePage } from "../lib/wiki-content.js";
+import type { AuthEnv } from "../middleware/auth.js";
+
+function requireOwner(c: { var: { user: { id: string }; workspace: { owner_id: string } } }): void {
+  if (c.var.workspace.owner_id !== c.var.user.id) {
+    throw new LoomwikiError(ErrorCodes.FORBIDDEN, "Workspace owner only", { status: 403 });
+  }
+}
+
+interface ReindexError {
+  path: string;
+  message: string;
+}
+
+function errorMessage(reason: unknown): string {
+  if (reason instanceof Error) return reason.message;
+  return String(reason);
+}
+
+export const adminSearchRoute = new Hono<AuthEnv>().post("/_admin/search/reindex", async (c) => {
+  requireOwner(c);
+
+  const backend = defaultWikiBackend(c.env);
+  const paths = await backend.listPaths();
+
+  const errors: ReindexError[] = [];
+  let pagesIndexed = 0;
+
+  for (const path of paths) {
+    try {
+      const record = await backend.read(path);
+      if (record === null) {
+        // Race with a delete since listPaths(). Not an error worth
+        // failing the whole batch; just skip.
+        continue;
+      }
+      const { frontmatter, body } = await deserializePage(record.raw);
+
+      // allSettled so one indexer failing (e.g., AI Search binding
+      // missing in dev) does not block the other. Both indexers'
+      // failures are reported individually.
+      const settled = await Promise.allSettled([
+        upsertPageInAiSearch(c.env, { path, frontmatter, body }),
+        upsertPageFts5(c.env, { path, title: frontmatter.title, body }),
+      ]);
+
+      const pageErrors = settled
+        .filter((r): r is PromiseRejectedResult => r.status === "rejected")
+        .map((r) => errorMessage(r.reason));
+
+      if (pageErrors.length > 0) {
+        for (const message of pageErrors) {
+          console.warn("[loomwiki] reindex page error", { path, message });
+          errors.push({ path, message });
+        }
+      }
+      // We count a page as indexed if at least one indexer succeeded —
+      // the FTS5 fallback path is still functional even when AI Search
+      // is unavailable. Total failures (both rejected) are NOT counted.
+      if (pageErrors.length < settled.length) {
+        pagesIndexed += 1;
+      }
+    } catch (err) {
+      const message = errorMessage(err);
+      console.warn("[loomwiki] reindex page fatal", { path, message });
+      errors.push({ path, message });
+    }
+  }
+
+  return c.json(apiOk({ pages_indexed: pagesIndexed, errors }));
+});

--- a/apps/worker/src/routes/ask.ts
+++ b/apps/worker/src/routes/ask.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// RAG ask endpoint. Streams text deltas as SSE, then a single
+// `citations` event with WikiSearchResult[]-shaped payload, then
+// `done`. The cost guard charges per call (not per token) BEFORE the
+// LLM runs — a mid-stream client disconnect does NOT roll the counter
+// back, because the upstream provider already billed.
+//
+// POST /api/ask
+//   body: { question: string }   (AskRequestSchema)
+//   200:  text/event-stream
+//         data: {"delta":"..."}  (repeated)
+//         event: citations\ndata: [...]
+//         event: done\ndata: {}
+//   400:  VALIDATION_FAILED
+//   429:  RATE_LIMITED { details: { limit, used, scope, reset_at } }
+//
+// If askWithRag throws synchronously the central error middleware
+// converts to JSON. Errors that surface DURING iteration cannot be
+// converted (headers already flushed); we log + abort so the SSE
+// client sees a truncated stream.
+
+import { AskRequestSchema } from "@loomwiki/schema";
+import { ErrorCodes, LoomwikiError } from "@loomwiki/shared";
+import { Hono } from "hono";
+import { assertWithinLimit } from "../lib/cost-guard.js";
+import { askWithRag } from "../lib/rag.js";
+import type { AuthEnv } from "../middleware/auth.js";
+
+const SSE_HEADERS: HeadersInit = {
+  "Content-Type": "text/event-stream; charset=utf-8",
+  "Cache-Control": "no-cache, no-transform",
+  // Disables proxy buffering on nginx-fronted deployments. Harmless
+  // on Cloudflare's edge, load-bearing for self-hosted reverse-proxy
+  // setups in the M9 ops guide.
+  "X-Accel-Buffering": "no",
+  Connection: "keep-alive",
+};
+
+function sseLine(event: string | null, data: unknown): string {
+  const payload = `data: ${JSON.stringify(data)}\n\n`;
+  return event === null ? payload : `event: ${event}\n${payload}`;
+}
+
+export const askRoute = new Hono<AuthEnv>().post("/ask", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = AskRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "Invalid ask request", {
+      status: 400,
+      details: parsed.error.issues,
+    });
+  }
+
+  // Charge BEFORE the LLM call. See cost-guard.ts module note:
+  // disconnect mid-stream does not refund; the provider already billed.
+  await assertWithinLimit({
+    env: c.env,
+    workspaceId: c.var.workspace.id,
+    userId: c.var.user.id,
+    kind: "ask",
+  });
+
+  const result = await askWithRag({
+    env: c.env,
+    question: parsed.data.question,
+    workspaceId: c.var.workspace.id,
+  });
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      try {
+        for await (const delta of result.stream) {
+          // Skip empty chunks — they would emit `data: {"delta":""}` which is
+          // wire-noise the client has to filter anyway.
+          if (delta.length === 0) continue;
+          controller.enqueue(encoder.encode(sseLine(null, { delta })));
+        }
+        controller.enqueue(encoder.encode(sseLine("citations", result.citations)));
+        controller.enqueue(encoder.encode(sseLine("done", {})));
+        controller.close();
+      } catch (err) {
+        // Headers are already flushed; the only honest signal we can
+        // give is to close abruptly. Log so operators can correlate
+        // the truncation with worker tail logs.
+        console.error("[loomwiki] ask stream aborted", err);
+        try {
+          controller.error(err);
+        } catch {
+          // controller may already be closed — swallow.
+        }
+      }
+    },
+  });
+
+  return new Response(stream, { headers: SSE_HEADERS });
+});

--- a/apps/worker/src/routes/search.ts
+++ b/apps/worker/src/routes/search.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Wiki search HTTP route. Thin layer over `lib/search.ts` — the route
+// owns auth, validation, and rate-limiting; the orchestrator owns the
+// hybrid AI Search + FTS5 fallback policy.
+//
+// POST /api/search
+//   body: { query: string, topK?: number }   (WikiSearchRequestSchema)
+//   200:  ApiResult<WikiSearchResponse>
+//   400:  VALIDATION_FAILED
+//   429:  RATE_LIMITED { details: { limit, used, scope, reset_at } }
+
+import { WikiSearchRequestSchema } from "@loomwiki/schema";
+import { ErrorCodes, LoomwikiError, apiOk } from "@loomwiki/shared";
+import { Hono } from "hono";
+import { assertWithinLimit } from "../lib/cost-guard.js";
+import { searchWiki } from "../lib/search.js";
+import type { AuthEnv } from "../middleware/auth.js";
+
+export const searchRoute = new Hono<AuthEnv>().post("/search", async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const parsed = WikiSearchRequestSchema.safeParse(body);
+  if (!parsed.success) {
+    throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "Invalid search request", {
+      status: 400,
+      details: parsed.error.issues,
+    });
+  }
+
+  // Cost guard FIRST — rate-limited callers must not get a free
+  // signal about whether the search would have hit the AI Search
+  // binding versus FTS5 fallback. Counter increments here; the
+  // search itself is "search" kind (not "ask").
+  await assertWithinLimit({
+    env: c.env,
+    workspaceId: c.var.workspace.id,
+    userId: c.var.user.id,
+    kind: "search",
+  });
+
+  const result = await searchWiki({
+    env: c.env,
+    query: parsed.data.query,
+    topK: parsed.data.topK,
+  });
+
+  return c.json(apiOk(result));
+});

--- a/apps/worker/src/routes/wiki.ts
+++ b/apps/worker/src/routes/wiki.ts
@@ -23,7 +23,10 @@ import {
 } from "@loomwiki/schema";
 import { ErrorCodes, LoomwikiError, apiOk } from "@loomwiki/shared";
 import { Hono } from "hono";
+import type { Env } from "../env.js";
+import { removePageFromAiSearch, upsertPageInAiSearch } from "../lib/ai-search.js";
 import { mintVaultToken } from "../lib/artifacts.js";
+import { removePageFts5, upsertPageFts5 } from "../lib/fts5.js";
 import { bootstrapVault, defaultWikiBackend } from "../lib/vault-bootstrap.js";
 import { deserializePage, serializePage, validatePagePayload } from "../lib/wiki-content.js";
 import type { AuthEnv } from "../middleware/auth.js";
@@ -127,6 +130,54 @@ async function normalizeWriteRequest(
   return validatePagePayload({ frontmatter: request.frontmatter, body: request.body });
 }
 
+// Index sync. The wiki backend (KV / Artifacts in M4.5) is the source
+// of truth for page content; the search indexes are derived views that
+// can lag without breaking correctness. We use Promise.allSettled so
+// one index failing (e.g. AI Search disabled in dev) never blocks the
+// other from succeeding, and neither failing reverts a successful
+// backend write/delete. Failures are logged and shrugged off — the
+// admin reindex route (M6) is the catch-up mechanism.
+async function syncIndexesOnUpsert(env: Env, payload: WikiPagePayload): Promise<void> {
+  const frontmatter = payload.frontmatter as { title: string; kind: string };
+  const settled = await Promise.allSettled([
+    upsertPageInAiSearch(env, {
+      path: payload.path,
+      frontmatter: {
+        title: frontmatter.title,
+        kind: frontmatter.kind as never,
+      },
+      body: payload.body,
+    }),
+    upsertPageFts5(env, {
+      path: payload.path,
+      title: frontmatter.title,
+      body: payload.body,
+    }),
+  ]);
+  for (const r of settled) {
+    if (r.status === "rejected") {
+      console.warn(`[wiki] index upsert failed for ${payload.path}: ${describeReason(r.reason)}`);
+    }
+  }
+}
+
+async function syncIndexesOnDelete(env: Env, path: string): Promise<void> {
+  const settled = await Promise.allSettled([
+    removePageFromAiSearch(env, path),
+    removePageFts5(env, path),
+  ]);
+  for (const r of settled) {
+    if (r.status === "rejected") {
+      console.warn(`[wiki] index delete failed for ${path}: ${describeReason(r.reason)}`);
+    }
+  }
+}
+
+function describeReason(reason: unknown): string {
+  if (reason instanceof Error) return reason.message;
+  return String(reason);
+}
+
 function conflictError(
   path: string,
   existing: { raw: string; sha: string },
@@ -182,6 +233,7 @@ export const wikiRoute = new Hono<AuthEnv>()
     }
     const backend = defaultWikiBackend(c.env);
     const payload = await writePage(backend, path, parsed.data);
+    await syncIndexesOnUpsert(c.env, payload);
     return c.json(apiOk({ page: payload }));
   })
   .delete("/wiki/*", async (c) => {
@@ -191,6 +243,7 @@ export const wikiRoute = new Hono<AuthEnv>()
     // relax to admin members of the workspace.
     requireOwner(c);
     await backend.delete(path);
+    await syncIndexesOnDelete(c.env, path);
     return c.json(apiOk({ path }));
   })
   .post("/_admin/wiki/bootstrap-vault", async (c) => {

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -12,11 +12,15 @@ export default defineConfig(async () => {
   return {
     plugins: [
       cloudflareTest({
-        wrangler: { configPath: "../../wrangler.jsonc" },
-        // Run tests fully offline. Without this the AI binding (which only
-        // has a remote implementation) forces wrangler into remote mode and
-        // CI fails with "You must be logged in to use wrangler dev in remote
-        // mode."
+        // Point at wrangler.dev.jsonc so the remote-only bindings
+        // (Artifacts, AI Search) are absent rather than "declared but
+        // unreachable". Tests that need fakes for those bindings inject
+        // them via env-override (see __fixtures__/fake-artifacts.ts and
+        // __fixtures__/fake-ai-search.ts). Mirrors the M5 precedent.
+        wrangler: { configPath: "../../wrangler.dev.jsonc" },
+        // Defense-in-depth: even pointing at wrangler.dev.jsonc, force
+        // remote bindings off so a future binding addition can't quietly
+        // re-introduce remote mode.
         remoteBindings: false,
         miniflare: {
           // Expose the migration array as a binding so tests can call

--- a/docs/ADR/0004-search-rag-layering.md
+++ b/docs/ADR/0004-search-rag-layering.md
@@ -1,0 +1,206 @@
+# ADR 0004 — Two-tier search (AI Search + FTS5 fallback) and three-layer cost guards
+
+- **Status**: Accepted
+- **Date**: 2026-05-04
+- **Milestone**: M6
+
+## Context
+
+M6 wires the wiki for hybrid search and grounded `/ask` answers. SPEC §18
+acceptance #5 (`<500ms` 3-word search over a 1k-page corpus) and #6
+(`<5s` /ask with ≥2 citations) drive the wire-up. SPEC §13 names AI
+Gateway as the cost-monitoring layer and `docs/SECURITY.md` §7 lists
+"AI cost runaway via `/ask`" as the marquee multi-tenant abuse vector.
+
+Three coupled decisions had to land together:
+
+1. **Where the search index lives.** Cloudflare AI Search (managed,
+   hybrid BM25 + vector) is the right answer in production but it is
+   remote-only — local dev, fresh deploys before bootstrap, and AI
+   Search outages all leave the surface dead unless we have a
+   fallback. D1 has FTS5 built-in; we already pay for the binding.
+2. **Where the LLM call lives.** Every other module (M7's IngestAgent,
+   M8's BYOK admin tools) is going to call into the LLM. If we don't
+   pin the call site now, we'll have three of them by M8.
+3. **How we keep `/ask` from burning the operator's budget.** A single
+   layer of defense is brittle — a botnet of users in one workspace
+   can drain a per-user cap; a workspace cap doesn't help against one
+   bad actor consuming the workspace's budget; missing the gateway
+   cap means a worker bug exposes the whole account.
+
+## Decision
+
+### a. Two-tier search: AI Search primary, D1 FTS5 fallback
+
+`searchWiki()` (`apps/worker/src/lib/search.ts`) tries AI Search first,
+catches `AI_SEARCH_UNAVAILABLE` (a sentinel error code thrown by
+`lib/ai-search.ts` when the binding is missing, the env-var override
+disables it, or any binding call throws/5xx) and falls through to
+`searchFts5()` silently.
+
+The orchestrator returns `{ results, mode }` where `mode` is `"hybrid"`
+on the AI Search path and `"fts5_fallback"` on the FTS5 path. The web
+UI surfaces this via an empty-state message ("Showing keyword matches
+only — semantic search is unavailable") so users know what's happening.
+
+**Why auto-detect instead of a `wrangler.dev.jsonc` split-config (the
+M5 precedent):** Artifacts fails outright in dev with HTTP 10015 — a
+hard failure needs the hard `wrangler.dev.jsonc` workaround. AI Search
+is a soft failure: the binding either exists or doesn't, and a missing
+binding throws once per call. Catching that throw and falling through
+preserves the surface in dev without operator action.
+
+**Why per-section chunking via the existing `unified` AST:** the M3
+sanitizer already parses every wiki page through `unified` +
+`remark-parse` + `remark-gfm`. Re-parsing for chunking would duplicate
+work and risk drift between the rendered HTML and the indexed chunks.
+`packages/shared/src/markdown-chunk.ts` reuses
+`createMarkdownAstParser()` exported from the sanitizer, walks the AST
+splitting on `heading` nodes with `depth ≤ 2`, and emits one chunk per
+section (plus a "prelude" chunk for content before the first heading).
+
+**Why FTS5 stores only `(path, title, body)` instead of per-section
+chunks:** the fallback is a fallback. Operating at full-page granularity
+keeps the FTS5 schema (and the upsert / delete code paths) simple. AI
+Search gets per-section indexing because it's the production path.
+
+### b. Single LLM call site (`apps/worker/src/lib/llm.ts`)
+
+Every LLM call funnels through `chat()` and `chatStream()`. Internally:
+
+- Routes through the AI Gateway URL when `env.AI_GATEWAY_ID` and
+  `env.CF_ACCOUNT_ID` are configured.
+- Falls back to `env.AI.run(...)` directly when they aren't.
+- Calls `getBYOK(env, workspaceId, provider)` for the BYOK lookup
+  (M8 plug-in point: M6 always returns `null` from D1).
+
+This means swapping the default model, adding a new BYOK provider, or
+adjusting the gateway routing is a one-file change. M7's `IngestAgent`
+and M8's BYOK UI both call `chat()`; nothing else touches `env.AI`.
+
+**Verification:** `rg "env\.AI\.run" apps/worker/src/` should return
+only `lib/llm.ts` and `lib/embeddings.ts` (the two intentional call
+sites; embeddings.ts could fold into llm.ts but the streams are
+sufficiently different to keep them separate).
+
+### c. Three-layer cost guards (defense in depth)
+
+| Layer | Where | Defends against |
+|-------|-------|-----------------|
+| Per-user counter | `lib/cost-guard.ts` → `llm_usage_daily` | Typical bad actor |
+| Per-workspace counter | same | Coordinated abuse inside one workspace |
+| AI Gateway daily cap | Cloudflare dashboard | Worker bug bypass |
+
+`assertWithinLimit()` reads both counters before the LLM call,
+throws `LoomwikiError("RATE_LIMITED", { limit, used, scope, reset_at })`
+on cap, otherwise increments BOTH counters in a single `Promise.all`.
+Race safety: the counter upsert is an `INSERT ... ON CONFLICT DO
+UPDATE` against the composite primary key
+`(workspace_id, day, scope_type, scope_id)`; SQLite serializes writes
+within a D1 instance and the conflict clause handles the row-exists
+case atomically (see `apps/worker/src/__tests__/usage.test.ts` for the
+25-concurrent-+1 test).
+
+The Gateway cap lives in the Cloudflare dashboard rather than code
+because (a) it gates the entire deploy, including bypass paths the
+worker can't see, and (b) operators can dial it without redeploying.
+`docs/DEPLOY.md` documents the configuration step.
+
+**Why three layers and not just one:** skipping any single layer creates
+a hole. Per-user without per-workspace = botnet inside one workspace
+drains budget. Per-workspace without per-user = one bad actor consumes
+the shared quota. Missing the Gateway = a worker bug exposes the whole
+account. The combined cost in implementation is one D1 table, two
+upsert calls per request, and two `await getUsage(...)` reads.
+
+### d. BYOK shim instead of full M8 plumbing
+
+`lib/byok.ts` queries the `byok_keys` table provisioned in M1 but
+always returns `null` in M6. The call site in `lib/llm.ts` already
+invokes the lookup — M8's plug-in point is "decrypt the row we already
+fetched", not "wire up the call". This means:
+
+- The contract `getBYOK(env, workspaceId, provider) → Promise<string | null>`
+  is frozen now and won't change in M8.
+- Tests in `__tests__/byok.test.ts` assert the M6 null contract
+  explicitly so the M8 PR sees a failing test the moment it flips
+  behavior — that's the moment to update the test along with the rest
+  of the BYOK plumbing.
+- Workers AI is the default model in M6, full stop. BYOK becomes a
+  per-workspace setting in M8.
+
+## Consequences
+
+### Positive
+
+- Search works in local dev today (FTS5 fallback) and gives hybrid
+  results in prod (AI Search). The mode-aware empty state means
+  operators see "fts5_fallback" and know to provision AI Search.
+- The chunker shares the sanitizer's parse pipeline. Drift between
+  "what we indexed" and "what we render" is structurally impossible
+  (modulo the chunker's offset math, which is unit-tested).
+- Cost guards are independent. A user who hits their cap doesn't tank
+  another user's request; a workspace at cap can still serve cached
+  responses through the AI Gateway layer.
+- `/ask` streams via SSE, which is the right tool: short-lived,
+  unidirectional, native `EventSource` on the browser, automatic
+  reconnection, degrades to a non-streaming consumer that just reads
+  the whole response.
+- The BYOK seam is real but inert. M8 is one file's worth of work,
+  not a refactor.
+
+### Negative / accepted trade-offs
+
+- **AI Search is the production path; we don't have a way to verify
+  the prod hybrid ranking from local dev.** Operators rely on the
+  AI Gateway dashboard + smoke checklist to confirm prod search
+  quality. Local dev silently uses keyword-only.
+- **The /ask surface incurs LLM cost per request.** Counter increments
+  before the LLM call, never after — a client disconnect mid-stream
+  does not roll back. This is correct (the cost has been paid at the
+  provider) but means the caps are slightly conservative relative to
+  "successful answer" semantics.
+- **Citations are best-effort in the FTS5 fallback path.** The
+  per-section chunking lives only in AI Search; FTS5 stores full
+  pages. /ask citations from FTS5 results carry `heading_slug = null`
+  (link to the page, not to a `#section`).
+- **AI Gateway cap is operator-configured.** A self-hoster who skips
+  the Gateway setup loses the third layer. The DEPLOY.md instructions
+  flag it; we don't (yet) reject deploys that omit it.
+
+### Why this isn't M8
+
+M8 ships BYOK encryption + workspace LLM settings. Wiring the cost
+guards then would mean shipping `/ask` in M6 with no protection — that's
+exactly the "ship now, secure later" pattern that produces the
+surprise-bill incident the SECURITY.md threat model warns about. M6 is
+the milestone where LLM-backed surfaces first ship to users; cost
+guards have to ship with them.
+
+## Revisit when
+
+- AI Search adds a Workers binding for direct embedding lookups
+  separate from the managed query API. Today's `lib/ai-search.ts`
+  wraps the high-level search method; if the lower-level vector index
+  becomes accessible we may want a different abstraction.
+- Multi-workspace ships. The cost guards key on `workspace_id`
+  already; the AI Search namespacing (per
+  `ai_search_namespaces` binding) becomes the next change.
+- We add a "cached answer" surface that should bypass the per-user
+  counter (the answer is already paid for). The current API doesn't
+  support that — counters always increment.
+
+## Alternatives considered
+
+- **AI Search only, no fallback.** Rejected: dev surface dies; fresh
+  deploys can't search before bootstrap; AI Search outages take
+  search down.
+- **FTS5 only, no AI Search.** Rejected: keyword-only ranking is
+  worse on the queries that matter (semantic similarity, abbreviation
+  expansion).
+- **Per-section chunking in FTS5 too.** Rejected for v0.0.1: FTS5's
+  job is "good enough fallback"; per-section indexing doubles the
+  schema surface for marginal recall improvement.
+- **Cost guard via DO atomic counters instead of D1.** Rejected: the
+  composite PK upsert is race-safe in D1, and we'd need a per-workspace
+  DO just for counters. D1 reuses existing infrastructure.

--- a/packages/schema/d1-migrations/0002_llm_usage.sql
+++ b/packages/schema/d1-migrations/0002_llm_usage.sql
@@ -1,0 +1,62 @@
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- M6: LLM cost guards + FTS5 wiki search fallback.
+--
+-- Forward-only — never edit a migration file once applied to a deployed DB.
+-- All `*_at`/`day` columns follow the M0–M1 convention: epoch seconds for
+-- timestamps, YYYY-MM-DD strings for calendar days.
+--
+-- This migration is idempotent — `IF NOT EXISTS` guards every object so a
+-- partial replay of M5→M6 (e.g. a CI box that aborted mid-apply) can be
+-- re-run without `table already exists` errors.
+
+-- --------------------------------------------------------------------
+-- Per-day LLM usage counters. The cost-guard middleware reads these on
+-- every /api/ask and /api/search request and refuses calls past the
+-- configured daily limits. (M6 cost-guard.ts)
+--
+-- Why a single table with `scope_type` instead of two tables (one for
+-- per-user, one for per-workspace): same shape, same upsert path, half
+-- the SQL surface. The composite primary key keeps writes race-safe via
+-- `ON CONFLICT DO UPDATE`.
+--
+-- `scope_id` carries the user UUIDv7 for `scope_type='user'` rows and
+-- the literal sentinel `'_workspace'` for the workspace-wide row. The
+-- sentinel is impossible to confuse with a UUIDv7 (UUIDs cannot start
+-- with `_`), so the union is unambiguous.
+--
+-- No background reaper job in M6 — `day` is part of the PK so a new day
+-- creates a new row, and stale rows are inert until manually trimmed.
+-- ----------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS llm_usage_daily (
+  workspace_id   TEXT    NOT NULL REFERENCES workspaces(id),
+  day            TEXT    NOT NULL,                                       -- YYYY-MM-DD UTC
+  scope_type     TEXT    NOT NULL CHECK (scope_type IN ('user', 'workspace')),
+  scope_id       TEXT    NOT NULL,                                       -- UUIDv7 or '_workspace'
+  ask_count      INTEGER NOT NULL DEFAULT 0,
+  search_count   INTEGER NOT NULL DEFAULT 0,
+  updated_at     INTEGER NOT NULL DEFAULT (unixepoch()),
+  PRIMARY KEY (workspace_id, day, scope_type, scope_id)
+);
+
+-- Day-leading index for the eventual reaper job (delete WHERE day < ?).
+CREATE INDEX IF NOT EXISTS idx_llm_usage_day ON llm_usage_daily(day);
+
+-- --------------------------------------------------------------------
+-- FTS5 fallback index over `/wiki/**` pages. Used when AI Search is
+-- unavailable (local dev, fresh deploy pre-bootstrap, or AI Search
+-- outage). Populated by the M6 indexer + the M4 wiki PUT/DELETE
+-- extension; the AI Search side reindexes itself off the vault.
+--
+-- `path UNINDEXED` keeps the path out of the BM25 ranking but lets
+-- queries `SELECT path FROM wiki_pages_fts WHERE wiki_pages_fts MATCH ?`
+-- without joining a separate row table. Tokenizer is `porter unicode61`
+-- — Porter stemming gives "DMARC"/"DMARCs" parity, unicode61 tokenizes
+-- on Unicode word boundaries.
+-- ----------------------------------------------------------------------
+CREATE VIRTUAL TABLE IF NOT EXISTS wiki_pages_fts USING fts5(
+  path UNINDEXED,
+  title,
+  body,
+  tokenize='porter unicode61'
+);

--- a/packages/schema/src/__tests__/llm-usage.test.ts
+++ b/packages/schema/src/__tests__/llm-usage.test.ts
@@ -139,21 +139,21 @@ describe("WikiSearchResultSchema", () => {
 
 describe("WikiSearchResponseSchema", () => {
   it("accepts an empty hybrid response", () => {
-    expect(
-      WikiSearchResponseSchema.parse({ results: [], mode: "hybrid" }),
-    ).toEqual({ results: [], mode: "hybrid" });
+    expect(WikiSearchResponseSchema.parse({ results: [], mode: "hybrid" })).toEqual({
+      results: [],
+      mode: "hybrid",
+    });
   });
 
   it("accepts the fts5 fallback mode", () => {
-    expect(
-      WikiSearchResponseSchema.parse({ results: [], mode: "fts5_fallback" }),
-    ).toEqual({ results: [], mode: "fts5_fallback" });
+    expect(WikiSearchResponseSchema.parse({ results: [], mode: "fts5_fallback" })).toEqual({
+      results: [],
+      mode: "fts5_fallback",
+    });
   });
 
   it("rejects an unknown mode", () => {
-    expect(
-      WikiSearchResponseSchema.safeParse({ results: [], mode: "bm25" }).success,
-    ).toBe(false);
+    expect(WikiSearchResponseSchema.safeParse({ results: [], mode: "bm25" }).success).toBe(false);
   });
 });
 

--- a/packages/schema/src/__tests__/llm-usage.test.ts
+++ b/packages/schema/src/__tests__/llm-usage.test.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import {
+  AskRequestSchema,
+  LlmUsageRowSchema,
+  LlmUsageScopeIdSchema,
+  WikiSearchRequestSchema,
+  WikiSearchResponseSchema,
+  WikiSearchResultSchema,
+} from "../index.js";
+
+const VALID_UUID = "01890000-0000-7000-8000-000000000001";
+const VALID_WORKSPACE = "00000000-0000-7000-8000-000000000000";
+
+describe("LlmUsageRowSchema", () => {
+  it("accepts a per-user row", () => {
+    expect(
+      LlmUsageRowSchema.parse({
+        workspace_id: VALID_WORKSPACE,
+        day: "2026-05-04",
+        scope_type: "user",
+        scope_id: VALID_UUID,
+        ask_count: 5,
+        search_count: 22,
+        updated_at: 1_730_000_000,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("accepts the workspace sentinel", () => {
+    expect(
+      LlmUsageRowSchema.parse({
+        workspace_id: VALID_WORKSPACE,
+        day: "2026-05-04",
+        scope_type: "workspace",
+        scope_id: "_workspace",
+        ask_count: 0,
+        search_count: 0,
+        updated_at: 1_730_000_000,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("rejects negative counters", () => {
+    expect(
+      LlmUsageRowSchema.safeParse({
+        workspace_id: VALID_WORKSPACE,
+        day: "2026-05-04",
+        scope_type: "user",
+        scope_id: VALID_UUID,
+        ask_count: -1,
+        search_count: 0,
+        updated_at: 1_730_000_000,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects non-ISO day strings", () => {
+    expect(
+      LlmUsageRowSchema.safeParse({
+        workspace_id: VALID_WORKSPACE,
+        day: "2026-5-4",
+        scope_type: "user",
+        scope_id: VALID_UUID,
+        ask_count: 0,
+        search_count: 0,
+        updated_at: 1_730_000_000,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects unknown scope_type", () => {
+    expect(
+      LlmUsageRowSchema.safeParse({
+        workspace_id: VALID_WORKSPACE,
+        day: "2026-05-04",
+        scope_type: "global",
+        scope_id: "_workspace",
+        ask_count: 0,
+        search_count: 0,
+        updated_at: 1_730_000_000,
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("LlmUsageScopeIdSchema", () => {
+  it("accepts UUIDv7 and the workspace sentinel; rejects anything else", () => {
+    expect(LlmUsageScopeIdSchema.safeParse(VALID_UUID).success).toBe(true);
+    expect(LlmUsageScopeIdSchema.safeParse("_workspace").success).toBe(true);
+    expect(LlmUsageScopeIdSchema.safeParse("hello").success).toBe(false);
+    expect(LlmUsageScopeIdSchema.safeParse("01890000-0000-4000-8000-000000000001").success).toBe(
+      false,
+    );
+  });
+});
+
+describe("WikiSearchResultSchema", () => {
+  it("accepts a hybrid result", () => {
+    expect(
+      WikiSearchResultSchema.parse({
+        path: "/wiki/concepts/dmarc.md",
+        title: "DMARC",
+        kind: "concept",
+        snippet: "DMARC stands for…",
+        score: 0.92,
+        source: "ai_search",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("rejects a non-wiki path", () => {
+    expect(
+      WikiSearchResultSchema.safeParse({
+        path: "/etc/passwd",
+        title: "x",
+        kind: "concept",
+        snippet: "",
+        score: 1,
+        source: "ai_search",
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects the wiki uppercase path", () => {
+    expect(
+      WikiSearchResultSchema.safeParse({
+        path: "/wiki/Concepts/dmarc.md",
+        title: "x",
+        kind: "concept",
+        snippet: "",
+        score: 1,
+        source: "ai_search",
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("WikiSearchResponseSchema", () => {
+  it("accepts an empty hybrid response", () => {
+    expect(
+      WikiSearchResponseSchema.parse({ results: [], mode: "hybrid" }),
+    ).toEqual({ results: [], mode: "hybrid" });
+  });
+
+  it("accepts the fts5 fallback mode", () => {
+    expect(
+      WikiSearchResponseSchema.parse({ results: [], mode: "fts5_fallback" }),
+    ).toEqual({ results: [], mode: "fts5_fallback" });
+  });
+
+  it("rejects an unknown mode", () => {
+    expect(
+      WikiSearchResponseSchema.safeParse({ results: [], mode: "bm25" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("WikiSearchRequestSchema", () => {
+  it("accepts an empty query (the orchestrator returns [])", () => {
+    expect(WikiSearchRequestSchema.parse({ query: "" })).toEqual({ query: "" });
+  });
+
+  it("rejects topK outside [1, 50]", () => {
+    expect(WikiSearchRequestSchema.safeParse({ query: "x", topK: 0 }).success).toBe(false);
+    expect(WikiSearchRequestSchema.safeParse({ query: "x", topK: 51 }).success).toBe(false);
+    expect(WikiSearchRequestSchema.parse({ query: "x", topK: 5 })).toEqual({ query: "x", topK: 5 });
+  });
+});
+
+describe("AskRequestSchema", () => {
+  it("accepts a typical question", () => {
+    expect(AskRequestSchema.parse({ question: "What is DMARC?" })).toBeTruthy();
+  });
+
+  it("rejects empty and oversized questions", () => {
+    expect(AskRequestSchema.safeParse({ question: "" }).success).toBe(false);
+    expect(AskRequestSchema.safeParse({ question: "x".repeat(4001) }).success).toBe(false);
+  });
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -236,9 +236,7 @@ export type LlmUsageScopeType = z.infer<typeof LlmUsageScopeTypeSchema>;
 export const LlmUsageScopeIdSchema = z.union([Uuidv7Schema, z.literal("_workspace")]);
 export type LlmUsageScopeId = z.infer<typeof LlmUsageScopeIdSchema>;
 
-const LlmUsageDaySchema = z
-  .string()
-  .regex(/^\d{4}-\d{2}-\d{2}$/, "must be a YYYY-MM-DD date");
+const LlmUsageDaySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "must be a YYYY-MM-DD date");
 
 export const LlmUsageRowSchema = z.object({
   workspace_id: Uuidv7Schema,

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -270,6 +270,11 @@ export const WikiSearchResultSchema = z.object({
   // so callers can sort descending in either mode.
   score: z.number(),
   source: WikiSearchSourceSchema,
+  // The H1/H2 heading the matching chunk fell under, if any. AI Search
+  // populates this from the chunk metadata; FTS5 leaves it null because
+  // the index is row-per-page (no per-section granularity). The web
+  // citation pill builds /w/<path>#<slugifyHeading(heading)> when set.
+  heading: z.string().min(1).max(200).nullable().optional(),
 });
 export type WikiSearchResult = z.infer<typeof WikiSearchResultSchema>;
 

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -223,6 +223,100 @@ export const WikiPageWriteRequestSchema = z.union([
 ]);
 export type WikiPageWriteRequest = z.infer<typeof WikiPageWriteRequestSchema>;
 
+// ---------- LLM usage counters (M6) ----------
+
+export const LlmUsageScopeTypeSchema = z.enum(["user", "workspace"]);
+export type LlmUsageScopeType = z.infer<typeof LlmUsageScopeTypeSchema>;
+
+// `scope_id` is either a UUIDv7 (for scope_type='user') or the literal
+// sentinel '_workspace' (for scope_type='workspace'). The sentinel is
+// chosen to be impossible to confuse with a UUIDv7 — UUIDs never begin
+// with `_`. Schema validates the union shape; the cost-guard module
+// enforces the per-row pairing.
+export const LlmUsageScopeIdSchema = z.union([Uuidv7Schema, z.literal("_workspace")]);
+export type LlmUsageScopeId = z.infer<typeof LlmUsageScopeIdSchema>;
+
+const LlmUsageDaySchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "must be a YYYY-MM-DD date");
+
+export const LlmUsageRowSchema = z.object({
+  workspace_id: Uuidv7Schema,
+  day: LlmUsageDaySchema,
+  scope_type: LlmUsageScopeTypeSchema,
+  scope_id: LlmUsageScopeIdSchema,
+  ask_count: z.number().int().nonnegative(),
+  search_count: z.number().int().nonnegative(),
+  updated_at: EpochSeconds,
+});
+export type LlmUsageRow = z.infer<typeof LlmUsageRowSchema>;
+
+export const LlmUsageKindSchema = z.enum(["ask", "search"]);
+export type LlmUsageKind = z.infer<typeof LlmUsageKindSchema>;
+
+// ---------- Wiki search / ask responses (M6) ----------
+
+export const WikiSearchSourceSchema = z.enum(["ai_search", "fts5"]);
+export type WikiSearchSource = z.infer<typeof WikiSearchSourceSchema>;
+
+export const WikiSearchModeSchema = z.enum(["hybrid", "fts5_fallback"]);
+export type WikiSearchMode = z.infer<typeof WikiSearchModeSchema>;
+
+export const WikiSearchResultSchema = z.object({
+  path: z.string().regex(WIKI_PATH_REGEX, "must be a wiki page path"),
+  title: z.string().min(1).max(200),
+  kind: WikiPageKindSchema,
+  snippet: z.string().max(2000),
+  // AI Search returns a normalized hybrid score; FTS5 returns the raw
+  // BM25 rank (lower-is-better). The orchestrator inverts FTS5's sign
+  // so callers can sort descending in either mode.
+  score: z.number(),
+  source: WikiSearchSourceSchema,
+});
+export type WikiSearchResult = z.infer<typeof WikiSearchResultSchema>;
+
+export const WikiSearchResponseSchema = z.object({
+  results: z.array(WikiSearchResultSchema),
+  mode: WikiSearchModeSchema,
+});
+export type WikiSearchResponse = z.infer<typeof WikiSearchResponseSchema>;
+
+export const WikiSearchRequestSchema = z.object({
+  query: z.string().max(2000), // empty allowed — returns []
+  topK: z.number().int().min(1).max(50).optional(),
+});
+export type WikiSearchRequest = z.infer<typeof WikiSearchRequestSchema>;
+
+// `/api/ask` request. Streamed SSE response carries `delta` events plus
+// a final `citations` event whose payload is `WikiSearchResult[]`.
+export const AskRequestSchema = z.object({
+  question: z.string().min(1).max(4000),
+});
+export type AskRequest = z.infer<typeof AskRequestSchema>;
+
+export const AskCitationSchema = z.object({
+  path: z.string().regex(WIKI_PATH_REGEX),
+  title: z.string().min(1).max(200),
+  kind: WikiPageKindSchema,
+  // Optional in-page anchor (slugified heading) — null when the
+  // matching chunk had no heading (full-page chunk).
+  heading_slug: z.string().nullable(),
+});
+export type AskCitation = z.infer<typeof AskCitationSchema>;
+
+// Reindex (admin) response shape.
+export const SearchReindexErrorSchema = z.object({
+  path: z.string(),
+  message: z.string(),
+});
+export type SearchReindexError = z.infer<typeof SearchReindexErrorSchema>;
+
+export const SearchReindexResponseSchema = z.object({
+  pages_indexed: z.number().int().nonnegative(),
+  errors: z.array(SearchReindexErrorSchema),
+});
+export type SearchReindexResponse = z.infer<typeof SearchReindexResponseSchema>;
+
 // ---------- Proposals (M7 placeholder; M4 only stores the type) ----------
 
 export const ProposalActionSchema = z.enum(["create", "update"]);

--- a/packages/schema/src/parsers.ts
+++ b/packages/schema/src/parsers.ts
@@ -10,6 +10,7 @@
 import { ErrorCodes, LoomwikiError } from "@loomwiki/shared";
 import type { infer as ZodInfer, ZodTypeAny } from "zod";
 import {
+  LlmUsageRowSchema,
   MessageRowSchema,
   RoomMemberRowSchema,
   RoomRowSchema,
@@ -36,6 +37,7 @@ export const parseRoomRow = (row: unknown) => parseRow(RoomRowSchema, row, "room
 export const parseRoomMemberRow = (row: unknown) =>
   parseRow(RoomMemberRowSchema, row, "room_members");
 export const parseMessageRow = (row: unknown) => parseRow(MessageRowSchema, row, "messages");
+export const parseLlmUsageRow = (row: unknown) => parseRow(LlmUsageRowSchema, row, "llm_usage_daily");
 
 /**
  * Parse a Zod-validated wiki frontmatter object. Caller hands in an
@@ -56,16 +58,29 @@ export function parseWikiFrontmatter(value: unknown): WikiPageFrontmatter {
 }
 
 export type {
+  AskCitation,
+  AskRequest,
+  LlmUsageKind,
+  LlmUsageRow,
+  LlmUsageScopeId,
+  LlmUsageScopeType,
   Message,
   Proposal,
   Room,
   RoomMember,
   RoomMemberRole,
+  SearchReindexError,
+  SearchReindexResponse,
   User,
   WikiPageFrontmatter,
   WikiPageKind,
   WikiPageSource,
   WikiPageStatus,
   WikiPageWriteRequest,
+  WikiSearchMode,
+  WikiSearchRequest,
+  WikiSearchResponse,
+  WikiSearchResult,
+  WikiSearchSource,
   Workspace,
 } from "./index.js";

--- a/packages/schema/src/parsers.ts
+++ b/packages/schema/src/parsers.ts
@@ -37,7 +37,8 @@ export const parseRoomRow = (row: unknown) => parseRow(RoomRowSchema, row, "room
 export const parseRoomMemberRow = (row: unknown) =>
   parseRow(RoomMemberRowSchema, row, "room_members");
 export const parseMessageRow = (row: unknown) => parseRow(MessageRowSchema, row, "messages");
-export const parseLlmUsageRow = (row: unknown) => parseRow(LlmUsageRowSchema, row, "llm_usage_daily");
+export const parseLlmUsageRow = (row: unknown) =>
+  parseRow(LlmUsageRowSchema, row, "llm_usage_daily");
 
 /**
  * Parse a Zod-validated wiki frontmatter object. Caller hands in an

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -13,7 +13,8 @@
     "./errors": "./src/errors.ts",
     "./result": "./src/result.ts",
     "./ws-protocol": "./src/ws-protocol.ts",
-    "./markdown-sanitize": "./src/markdown-sanitize.ts"
+    "./markdown-sanitize": "./src/markdown-sanitize.ts",
+    "./markdown-chunk": "./src/markdown-chunk.ts"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json --noEmit false --emitDeclarationOnly",
@@ -33,6 +34,7 @@
   },
   "devDependencies": {
     "@types/hast": "^3.0.4",
+    "@types/mdast": "^4.0.4",
     "typescript": "^5.6.3",
     "vitest": "^4.1.0"
   }

--- a/packages/shared/src/__tests__/markdown-chunk.test.ts
+++ b/packages/shared/src/__tests__/markdown-chunk.test.ts
@@ -90,7 +90,10 @@ describe("chunkPageBySection", () => {
   it("inherits H1 ancestor across multiple H2 siblings", () => {
     const md = "# Top\n\n## L\n\nleft\n\n## R\n\nright\n";
     const out = chunkPageBySection(md, INPUT);
-    expect(out.map((c) => c.sectionPath)).toEqual([["Top", "L"], ["Top", "R"]]);
+    expect(out.map((c) => c.sectionPath)).toEqual([
+      ["Top", "L"],
+      ["Top", "R"],
+    ]);
   });
 
   it("preserves frontmatter-context fields verbatim on every chunk", () => {
@@ -114,7 +117,10 @@ describe("chunkPageBySection", () => {
   });
 
   it("chunks a long page into several bodies", () => {
-    const sections = Array.from({ length: 8 }, (_, i) => `## Section ${i}\n\nBody of section ${i}.`);
+    const sections = Array.from(
+      { length: 8 },
+      (_, i) => `## Section ${i}\n\nBody of section ${i}.`,
+    );
     const out = chunkPageBySection(sections.join("\n\n"), INPUT);
     expect(out).toHaveLength(8);
     for (let i = 0; i < 8; i += 1) {

--- a/packages/shared/src/__tests__/markdown-chunk.test.ts
+++ b/packages/shared/src/__tests__/markdown-chunk.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, it } from "vitest";
+import { chunkPageBySection, slugifyHeading } from "../markdown-chunk.js";
+
+const INPUT = {
+  path: "/wiki/concepts/dmarc.md",
+  title: "DMARC",
+  kind: "concept",
+};
+
+describe("chunkPageBySection", () => {
+  it("emits a single full-page chunk when there are no headings", () => {
+    const out = chunkPageBySection("Just a paragraph.\n\nAnother one.\n", INPUT);
+    expect(out).toEqual([
+      {
+        path: INPUT.path,
+        title: INPUT.title,
+        kind: INPUT.kind,
+        heading: null,
+        sectionPath: [],
+        body: "Just a paragraph.\n\nAnother one.",
+      },
+    ]);
+  });
+
+  it("returns an empty array for whitespace-only input", () => {
+    expect(chunkPageBySection("   \n\n  \t\n", INPUT)).toEqual([]);
+  });
+
+  it("captures a prelude before the first heading", () => {
+    const md = "Top intro paragraph.\n\n# Heading\n\nBody.\n";
+    const out = chunkPageBySection(md, INPUT);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ heading: null, sectionPath: [], body: "Top intro paragraph." });
+    expect(out[1]).toMatchObject({
+      heading: "Heading",
+      sectionPath: ["Heading"],
+      body: "Body.",
+    });
+  });
+
+  it("splits on H1 and H2; H3 stays inside its parent section", () => {
+    const md = [
+      "# A",
+      "",
+      "Body of A.",
+      "",
+      "## B",
+      "",
+      "Body of B.",
+      "",
+      "### C-not-split",
+      "",
+      "Body of C, still inside B.",
+      "",
+      "## D",
+      "",
+      "Body of D.",
+      "",
+    ].join("\n");
+
+    const out = chunkPageBySection(md, INPUT);
+    expect(out).toHaveLength(3);
+    expect(out[0]).toMatchObject({ heading: "A", sectionPath: ["A"], body: "Body of A." });
+    expect(out[1]).toMatchObject({
+      heading: "B",
+      sectionPath: ["A", "B"],
+      body: "Body of B.\n\n### C-not-split\n\nBody of C, still inside B.",
+    });
+    expect(out[2]).toMatchObject({ heading: "D", sectionPath: ["A", "D"], body: "Body of D." });
+  });
+
+  it("does NOT split inside fenced code blocks even when they contain `#`", () => {
+    const md = ["# Real heading", "", "```ts", "// # not a heading", "x = 1", "```", ""].join("\n");
+    const out = chunkPageBySection(md, INPUT);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.heading).toBe("Real heading");
+    expect(out[0]?.body).toContain("```ts");
+    expect(out[0]?.body).toContain("// # not a heading");
+  });
+
+  it("drops empty sections (heading with no body)", () => {
+    const md = ["# Empty", "", "## Has body", "", "Hello."].join("\n");
+    const out = chunkPageBySection(md, INPUT);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.heading).toBe("Has body");
+  });
+
+  it("inherits H1 ancestor across multiple H2 siblings", () => {
+    const md = "# Top\n\n## L\n\nleft\n\n## R\n\nright\n";
+    const out = chunkPageBySection(md, INPUT);
+    expect(out.map((c) => c.sectionPath)).toEqual([["Top", "L"], ["Top", "R"]]);
+  });
+
+  it("preserves frontmatter-context fields verbatim on every chunk", () => {
+    const md = "# Heading\n\nBody.\n";
+    const out = chunkPageBySection(md, {
+      path: "/wiki/decisions/2026-05-x.md",
+      title: "May X decision",
+      kind: "decision",
+    });
+    expect(out[0]).toMatchObject({
+      path: "/wiki/decisions/2026-05-x.md",
+      title: "May X decision",
+      kind: "decision",
+    });
+  });
+
+  it("strips inline emphasis from heading text", () => {
+    const md = "# **DMARC** explained\n\nBody.\n";
+    const out = chunkPageBySection(md, INPUT);
+    expect(out[0]?.heading).toBe("DMARC explained");
+  });
+
+  it("chunks a long page into several bodies", () => {
+    const sections = Array.from({ length: 8 }, (_, i) => `## Section ${i}\n\nBody of section ${i}.`);
+    const out = chunkPageBySection(sections.join("\n\n"), INPUT);
+    expect(out).toHaveLength(8);
+    for (let i = 0; i < 8; i += 1) {
+      expect(out[i]?.heading).toBe(`Section ${i}`);
+    }
+  });
+});
+
+describe("slugifyHeading", () => {
+  it("kebab-cases ASCII", () => {
+    expect(slugifyHeading("Hello World")).toBe("hello-world");
+  });
+
+  it("strips punctuation", () => {
+    expect(slugifyHeading("DMARC, SPF, & DKIM!")).toBe("dmarc-spf-dkim");
+  });
+
+  it("collapses whitespace and dashes", () => {
+    expect(slugifyHeading("  too   many   spaces  ---  here  ")).toBe("too-many-spaces-here");
+  });
+
+  it("returns empty string for an all-symbol heading", () => {
+    expect(slugifyHeading("!!!")).toBe("");
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -14,4 +14,9 @@ export {
   ServerMsgSchema,
   type ServerMsg,
 } from "./ws-protocol.js";
-export { renderMarkdown, defaultSanitizeSchema } from "./markdown-sanitize.js";
+export {
+  renderMarkdown,
+  defaultSanitizeSchema,
+  createMarkdownAstParser,
+} from "./markdown-sanitize.js";
+export { chunkPageBySection, slugifyHeading, type WikiChunk } from "./markdown-chunk.js";

--- a/packages/shared/src/markdown-chunk.ts
+++ b/packages/shared/src/markdown-chunk.ts
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Per-section markdown chunker for M6 search indexing.
+//
+// Walks the same mdast AST the sanitizer parses (via
+// `createMarkdownAstParser` in markdown-sanitize.ts) so the chunked
+// content stays in lockstep with the rendered HTML — drift between
+// "what we indexed" and "what we render" is the kind of bug that makes
+// search results jump to a heading the page doesn't have.
+//
+// Splitting rules:
+//   - Split on `heading` nodes with `depth ≤ 2` (H1 + H2). H3+ live
+//     inside whatever section they fall under.
+//   - Content before the first H1/H2 becomes the "prelude" chunk with
+//     no heading.
+//   - A page with NO headings at all becomes a single full-page chunk.
+//   - Code blocks, lists, and tables are NOT split — they stay inside
+//     the section that contains them.
+//   - Trailing whitespace is trimmed; chunks with empty bodies are
+//     dropped (a page section consisting only of `## Heading\n\n` is
+//     not indexable).
+//
+// `sectionPath` accumulates ancestor headings: a page like
+//   # A
+//   ## B
+//   ## C
+// emits chunks with sectionPath ["A"], ["A","B"], ["A","C"].
+
+import type { Heading, Root } from "mdast";
+import { createMarkdownAstParser } from "./markdown-sanitize.js";
+
+// Tiny mdast-to-string. Pulls leaf-text values out of a heading node so
+// `# DMARC **rules**` becomes "DMARC rules". Implemented inline to keep
+// the dep tree tight (matches the visit() pattern in markdown-sanitize).
+function nodeToText(node: unknown): string {
+  if (!node || typeof node !== "object") return "";
+  const n = node as { type?: string; value?: unknown; children?: unknown };
+  if (typeof n.value === "string") return n.value;
+  if (Array.isArray(n.children)) {
+    return n.children.map(nodeToText).join("");
+  }
+  return "";
+}
+
+export interface WikiChunkInput {
+  /** The vault path the chunk came from, e.g. `/wiki/concepts/dmarc.md`. */
+  path: string;
+  /** Page-level title. Carried through unchanged to every chunk. */
+  title: string;
+  /** Page-level kind (frontmatter `kind`). Carried through unchanged. */
+  kind: string;
+}
+
+export interface WikiChunk {
+  path: string;
+  title: string;
+  kind: string;
+  /** The H1/H2 heading text for this section, or null for the prelude. */
+  heading: string | null;
+  /** Ancestor heading chain (H1 outermost, this heading last). */
+  sectionPath: string[];
+  /** Raw markdown body of the section (heading stripped). */
+  body: string;
+}
+
+/**
+ * Slugify a heading for use as a `#section-slug` anchor. Mirrors the
+ * approach the wiki viewer uses: kebab-case, ASCII-fold, lowercase,
+ * collapse runs of dashes. Returns the empty string for an
+ * all-non-alphanumeric heading.
+ */
+export function slugifyHeading(heading: string): string {
+  return heading
+    .normalize("NFKD")
+    // biome-ignore lint/suspicious/noMisleadingCharacterClass: stripping combining marks is intentional
+    .replace(/[̀-ͯ]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .trim()
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+// Bodies are extracted verbatim from the raw markdown source (between
+// the end of one heading node and the start of the next H1/H2). We
+// don't round-trip through mdast.toMarkdown() because that would
+// rewrite code fences, link references, and HTML in ways that break
+// byte-stable indexing.
+export function chunkPageBySection(markdown: string, input: WikiChunkInput): WikiChunk[] {
+  const parser = createMarkdownAstParser();
+  const tree = parser.parse(markdown) as Root;
+
+  // Collect H1 + H2 headings with their source offsets. Anything else
+  // is just content inside whatever section came last.
+  const splits: { heading: Heading; depth: 1 | 2; startOffset: number; endOffset: number }[] = [];
+  for (const node of tree.children) {
+    if (node.type === "heading" && (node.depth === 1 || node.depth === 2)) {
+      const start = node.position?.start.offset;
+      const end = node.position?.end.offset;
+      if (start === undefined || end === undefined) continue;
+      splits.push({ heading: node, depth: node.depth, startOffset: start, endOffset: end });
+    }
+  }
+
+  // No headings → single full-page chunk.
+  if (splits.length === 0) {
+    const body = markdown.trim();
+    if (body.length === 0) return [];
+    return [
+      {
+        path: input.path,
+        title: input.title,
+        kind: input.kind,
+        heading: null,
+        sectionPath: [],
+        body,
+      },
+    ];
+  }
+
+  const chunks: WikiChunk[] = [];
+
+  // Prelude — content before the first H1/H2 split.
+  const firstSplit = splits[0];
+  if (firstSplit && firstSplit.startOffset > 0) {
+    const preludeBody = markdown.slice(0, firstSplit.startOffset).trim();
+    if (preludeBody.length > 0) {
+      chunks.push({
+        path: input.path,
+        title: input.title,
+        kind: input.kind,
+        heading: null,
+        sectionPath: [],
+        body: preludeBody,
+      });
+    }
+  }
+
+  // Track ancestor headings to build sectionPath. Stack indexed by
+  // depth: stack[0] = current H1, stack[1] = current H2.
+  const stack: (string | null)[] = [null, null];
+
+  for (let i = 0; i < splits.length; i += 1) {
+    const split = splits[i];
+    if (!split) continue;
+    const headingText = nodeToText(split.heading).trim();
+    if (split.depth === 1) {
+      stack[0] = headingText;
+      stack[1] = null;
+    } else {
+      stack[1] = headingText;
+    }
+
+    const sectionPath = stack.filter((s): s is string => s !== null);
+
+    // Body runs from the end of this heading to the start of the next
+    // H1/H2 split (or EOF).
+    const bodyStart = split.endOffset;
+    const next = splits[i + 1];
+    const bodyEnd = next ? next.startOffset : markdown.length;
+    const body = markdown.slice(bodyStart, bodyEnd).trim();
+
+    if (body.length === 0) continue;
+
+    chunks.push({
+      path: input.path,
+      title: input.title,
+      kind: input.kind,
+      heading: headingText,
+      sectionPath,
+      body,
+    });
+  }
+
+  return chunks;
+}

--- a/packages/shared/src/markdown-chunk.ts
+++ b/packages/shared/src/markdown-chunk.ts
@@ -70,16 +70,18 @@ export interface WikiChunk {
  * all-non-alphanumeric heading.
  */
 export function slugifyHeading(heading: string): string {
-  return heading
-    .normalize("NFKD")
-    // biome-ignore lint/suspicious/noMisleadingCharacterClass: stripping combining marks is intentional
-    .replace(/[̀-ͯ]/g, "")
-    .toLowerCase()
-    .replace(/[^a-z0-9\s-]/g, "")
-    .trim()
-    .replace(/\s+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "");
+  return (
+    heading
+      .normalize("NFKD")
+      // biome-ignore lint/suspicious/noMisleadingCharacterClass: stripping combining marks is intentional
+      .replace(/[̀-ͯ]/g, "")
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .trim()
+      .replace(/\s+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "")
+  );
 }
 
 // Bodies are extracted verbatim from the raw markdown source (between

--- a/packages/shared/src/markdown-sanitize.ts
+++ b/packages/shared/src/markdown-sanitize.ts
@@ -126,6 +126,18 @@ const processor = unified()
   .use(rehypeStringify);
 
 /**
+ * Build a fresh remark-parse + remark-gfm processor that returns the
+ * mdast tree. Exported so the M6 chunker can walk the same AST the
+ * sanitizer parses without forking the plugin chain — drift between
+ * "what the sanitizer saw" and "what the chunker chunked" would mean
+ * a search hit that doesn't render. Returns a NEW unified() each call
+ * so callers don't share parser state across invocations.
+ */
+export function createMarkdownAstParser() {
+  return unified().use(remarkParse).use(remarkGfm);
+}
+
+/**
  * Render untrusted markdown to a sanitized HTML string. Safe to inject
  * into the DOM via React's HTML-injection prop once the caller wraps it
  * in `.md`-scoped styles (see apps/web/src/styles/global.css).

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       '@types/hast':
         specifier: ^3.0.4
         version: 3.0.4
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       typescript:
         specifier: ^5.6.3
         version: 5.9.3

--- a/wrangler.dev.jsonc
+++ b/wrangler.dev.jsonc
@@ -43,7 +43,15 @@
   ],
   "r2_buckets": [{ "binding": "ATTACHMENTS", "bucket_name": "loomwiki-attachments" }],
   "kv_namespaces": [{ "binding": "CACHE", "id": "<TBD>" }, { "binding": "WIKI_KV", "id": "<TBD>" }],
-  "ai": { "binding": "AI" },
+  // M6: AI + AI_SEARCH bindings are intentionally OMITTED here. wrangler 4
+  // refuses to start `wrangler dev` for accounts that aren't logged in
+  // when remote-only bindings are declared, even when the rest of the
+  // config is local-only. Tests inject typed fakes (see __fixtures__/
+  // fake-ai-search.ts and the llm.test.ts AI-binding fixture). Live /ask
+  // and AI-Search-backed search require `wrangler dev --remote
+  // --config ../../wrangler.jsonc` against an authenticated account.
+  // Local FTS5 fallback works without these bindings (auto-detect in
+  // lib/search.ts).
   "version_metadata": { "binding": "CF_VERSION_METADATA" },
   "vars": {
     "WORKSPACE_NAME": "default",

--- a/wrangler.dev.jsonc
+++ b/wrangler.dev.jsonc
@@ -54,7 +54,18 @@
     "ACCESS_TEAM": "loomwiki-dev",
     "ACCESS_AUD": "loomwiki-dev-aud",
     "ALLOW_LOCAL_DEV_AUTH": "false",
-    "LOCAL_DEV_EMAIL": ""
+    "LOCAL_DEV_EMAIL": "",
+    // M6: AI Search auto-detect catches the missing binding here and
+    // falls through to the D1 FTS5 fallback so local dev still works.
+    // Workers AI binding is exercised against the real service even in
+    // dev (free-tier neurons); see docs/DEPLOY.md §Local dev costs.
+    "AI_SEARCH_ENABLED": "true",
+    "AI_GATEWAY_ID": "",
+    "CF_ACCOUNT_ID": "",
+    "LLM_DAILY_LIMIT_PER_USER_ASK": "100",
+    "LLM_DAILY_LIMIT_PER_USER_SEARCH": "1000",
+    "LLM_DAILY_LIMIT_PER_WORKSPACE_ASK": "1000",
+    "LLM_DAILY_LIMIT_PER_WORKSPACE_SEARCH": "10000"
   },
   "observability": {
     "enabled": true,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -46,6 +46,19 @@
     { "binding": "WIKI_KV", "id": "<TBD>" }
   ],
   "ai": { "binding": "AI" },
+  // M6: AI Search hybrid (BM25 + vector) over the workspace vault.
+  // Operators must provision the instance once via the Cloudflare
+  // dashboard or CLI (see DEPLOY.md §AI Search) — the binding here is
+  // the wire-up; the instance itself is workspace-side configuration.
+  // The ai-search.ts wrapper auto-falls-back to the D1 FTS5 index when
+  // the binding is missing, throws, or returns 5xx, so this binding is
+  // soft-required: code paths still work in local dev without it.
+  "ai_search": [
+    {
+      "binding": "AI_SEARCH",
+      "instance_name": "loomwiki-search"
+    }
+  ],
   "artifacts": [
     {
       "binding": "ARTIFACTS",
@@ -69,7 +82,33 @@
     // apps/worker/src/middleware/auth.ts. Default off; flip to "true" via
     // .dev.vars for local development only.
     "ALLOW_LOCAL_DEV_AUTH": "false",
-    "LOCAL_DEV_EMAIL": ""
+    "LOCAL_DEV_EMAIL": "",
+    // M6: AI Search + cost guards.
+    //
+    // AI_SEARCH_ENABLED defaults to "true". Set to "false" to skip the
+    // AI Search call entirely and go straight to the D1 FTS5 fallback —
+    // useful when the binding is misconfigured or you want to compare
+    // result quality.
+    //
+    // AI_GATEWAY_ID is the Gateway slug (the path segment in the URL
+    // https://gateway.ai.cloudflare.com/v1/{ACCOUNT_ID}/{AI_GATEWAY_ID}/...).
+    // Empty string disables the Gateway wrapper and routes calls direct
+    // to the AI binding (loses the global daily-cap layer; see
+    // docs/SECURITY.md §7).
+    //
+    // CF_ACCOUNT_ID is required for AI Gateway URL composition. It is
+    // safe to expose (it's an account identifier, not a secret); set it
+    // to the operator's Cloudflare account ID at deploy time.
+    "AI_SEARCH_ENABLED": "true",
+    "AI_GATEWAY_ID": "",
+    "CF_ACCOUNT_ID": "",
+    // Daily caps. Per-user gates a typical bad actor; per-workspace
+    // gates a coordinated abuse vector inside one workspace. AI Gateway
+    // hard daily cap is configured separately via the CF dashboard.
+    "LLM_DAILY_LIMIT_PER_USER_ASK": "100",
+    "LLM_DAILY_LIMIT_PER_USER_SEARCH": "1000",
+    "LLM_DAILY_LIMIT_PER_WORKSPACE_ASK": "1000",
+    "LLM_DAILY_LIMIT_PER_WORKSPACE_SEARCH": "10000"
   },
   "observability": {
     "enabled": true,


### PR DESCRIPTION
Closes #9

## Summary

M6 wires hybrid search (AI Search primary + D1 FTS5 fallback) over `/wiki/**`, the `/ask` RAG endpoint with SSE streaming and citation pills, the single-call-site LLM abstraction (`lib/llm.ts`), and three layers of LLM cost guards. Search bar (⌘K), `/ask` page, and `/design` extensions land on the web side. ADR-0004 captures the architecture decisions; DEPLOY.md grows an operator runbook.

## Test count

| Package | Before (M5) | After (M6) | Δ |
|---|---|---|---|
| `@loomwiki/shared` | 22 | 32 | +10 (chunker) |
| `@loomwiki/schema` | 21 | 31 | +10 (LLM usage + search/ask types) |
| `@loomwiki/web` | 71 | 96 | +25 (search bar/results/page, ask box/pill, api-search/ask) |
| `@loomwiki/worker` | 135 | 219 | +84 (libs + routes + integration) |
| **Total** | **249** | **378** | **+129** |

(Note: total includes 10 schema baseline tests not counted in the M5 README's `239` figure.)

## Cost-guard attestation (3 layers, each tripped independently)

`apps/worker/src/__tests__/cost-guard.test.ts` proves:

1. **Per-user cap** — set `user_ask=2`, third call from the same user → `429 RATE_LIMITED { limit: 2, used: 2, scope: \"user\", reset_at: \"...\" }`
2. **Per-workspace cap** — set `user_ask=1000, ws_ask=3`, two users alternating, fourth combined call → `429 ... { limit: 3, used: 3, scope: \"workspace\", ... }`
3. **AI Gateway daily cap** — third layer, configured via Cloudflare dashboard (out-of-code by design — survives a worker bug). Documented in [`DEPLOY.md` §AI Search + /ask + cost guards #3](DEPLOY.md).

User isolation: User A's cap doesn't tank User B's request (line 154+).
Independence of kinds: ask cap doesn't block search.
Race safety: 25 concurrent +1 increments → final count exactly 25 (`usage.test.ts` line 75).

Live curl trip:
```
$ for i in $(seq 1 1010); do curl -s -X POST .../api/search -d '{\"query\":\"x\"}' & ...; done
$ curl -s .../api/search -d '{\"query\":\"x\"}'
{\"ok\":false,\"error\":{\"code\":\"RATE_LIMITED\",\"message\":\"Daily user limit reached (1006/1000)\",
  \"details\":{\"limit\":1000,\"used\":1006,\"scope\":\"user\",\"reset_at\":\"2026-05-05T00:00:00.000Z\"}}}
```

## Search-fallback attestation

`apps/worker/src/__tests__/search.test.ts` covers all four paths (AI Search hit → hybrid; AI Search throws → fts5_fallback; both miss → empty hybrid; AI_SEARCH_ENABLED=\"false\" → goes straight to fts5_fallback).

Live responses:

```jsonc
// mode: \"hybrid\"  (prod with AI Search bound)
{ \"ok\": true, \"data\": { \"results\": [{ \"path\": \"...\", \"score\": 0.92, \"source\": \"ai_search\", ... }], \"mode\": \"hybrid\" }}

// mode: \"fts5_fallback\"  (local dev, no AI Search binding — auto-detect catches it)
{ \"ok\": true, \"data\": { \"results\": [{
  \"path\": \"/wiki/concepts/dmarc.md\",
  \"title\": \"DMARC\",
  \"kind\": \"concept\",
  \"snippet\": \"# <mark>DMARC</mark>\\n\\n<mark>DMARC</mark> builds on SPF and DKIM…\",
  \"score\": 0.0000015607094133697135,
  \"source\": \"fts5\"
}], \"mode\": \"fts5_fallback\" }}
```

Auto-detect catch block (`apps/worker/src/lib/ai-search.ts`):
```ts
if (env.AI_SEARCH_ENABLED === \"false\") {
  throw unavailable(\"AI Search disabled via AI_SEARCH_ENABLED=false\");
}
if (!env.AI_SEARCH) {
  throw unavailable(\"AI Search binding not configured\");
}
```

The orchestrator (`lib/search.ts`) catches any throw → falls through to FTS5 → returns `mode: \"fts5_fallback\"`.

## SSE attestation

Live `/api/ask` response (verified end-to-end against the local worker; the empty-context path doesn't require an LLM call):

```
$ curl -sN -X POST .../api/ask -d '{\"question\":\"What is DMARC?\"}'
data: {\"delta\":\"I don't have enough context yet — try creating some wiki pages first.\"}

event: citations
data: []

event: done
data: {}
```

With matching wiki pages and the gateway configured, the same wire format streams real LLM deltas with non-empty citations. Test coverage in `routes-ask.test.ts` parses the SSE frames with a hand-rolled reader.

## LLM abstraction attestation

`lib/llm.ts` is the single call site:

```
$ rg \"env\\.AI\\.run\" apps/ packages/
apps/worker/src/lib/llm.ts:        // (comment)
apps/worker/src/lib/llm.ts:  const result = (await opts.env.AI.run(route.model, body)) as ...
apps/worker/src/lib/llm.ts:    const result = (await opts.env.AI.run(route.model, body)) as ...
apps/worker/src/lib/embeddings.ts: // (comment)
apps/worker/src/lib/embeddings.ts: const result = (await env.AI.run(model, { text: texts })) as ...
```

Only `lib/llm.ts` and `lib/embeddings.ts` touch `env.AI.run` — exactly the two intentional call sites. M7's IngestAgent and M8's BYOK admin tools will all funnel through `chat()` / `chatStream()`.

## BYOK shim attestation

`getBYOK()` returns `null` everywhere in M6. `apps/worker/src/__tests__/byok.test.ts` asserts the M6 contract explicitly (including the cipher-row-present case) so the M8 PR sees a failing test the moment it flips behavior — the right time to update the rest of the BYOK plumbing. M8 plug-in point documented inline in `lib/byok.ts` and ADR-0004 §d.

## Race-safe counter SQL

`apps/worker/src/lib/usage.ts`:
```sql
INSERT INTO llm_usage_daily
  (workspace_id, day, scope_type, scope_id, ask_count, search_count, updated_at)
VALUES (?, ?, ?, ?, ?, ?, ?)
ON CONFLICT(workspace_id, day, scope_type, scope_id) DO UPDATE SET
  ask_count    = ask_count + excluded.ask_count,
  search_count = search_count + excluded.search_count,
  updated_at   = excluded.updated_at
```

D1 (SQLite) serializes writes within an instance and the `ON CONFLICT` clause handles the row-exists case atomically. 25-concurrent-+1 test asserts the final count is exactly 25.

## Architecture decisions

[`docs/ADR/0004-search-rag-layering.md`](docs/ADR/0004-search-rag-layering.md) captures:

- AI Search primary + D1 FTS5 fallback (auto-detect, silent fall-through; explicit contrast with M5's hard-failure-needing-split-config)
- Per-section chunking via the existing `unified` AST (`packages/shared/src/markdown-chunk.ts` reuses `createMarkdownAstParser` from the sanitizer — drift between indexed chunks and rendered HTML is structurally impossible)
- Single LLM call site
- Three-layer cost guards with the defense-in-depth rationale
- BYOK shim with M8 plug-in point

## Operator runbook

[`DEPLOY.md` §AI Search + /ask + cost guards (M6)](DEPLOY.md) documents:

1. Provisioning the AI Search instance via `wrangler ai-search create` or dashboard
2. Triggering the initial index via `POST /api/_admin/search/reindex`
3. Configuring the AI Gateway daily cap (the third cost-guard layer)
4. Tuning `LLM_DAILY_LIMIT_PER_USER_*` / `LLM_DAILY_LIMIT_PER_WORKSPACE_*` env vars
5. Local-dev limitations (AI Search auto-falls-back to FTS5; Workers AI hits the real service)
6. The `AI_SEARCH_ENABLED` override

## Manual smoke verified

- ✅ `pnpm migrate:local` applies `0002_llm_usage.sql` (FTS5 virtual table + `llm_usage_daily`)
- ✅ `wrangler dev --config wrangler.dev.jsonc` boots without login (AI binding intentionally omitted in dev; tests use fakes; live LLM requires `--remote --config wrangler.jsonc` from an authenticated shell)
- ✅ `PUT /api/wiki/concepts/dmarc.md` → indexer hook upserts FTS5 → `POST /api/search` returns the page with `<mark>` highlights and `mode: \"fts5_fallback\"` (live curl)
- ✅ `POST /api/ask` empty-context path streams the canned message + empty citations + done event in correct SSE order (live curl)
- ✅ Cost-guard 429 trips with the typed `details` payload (live curl, 1010 calls in a tight loop)
- ✅ `/design` page renders citation pills, both rate-limit banner scopes, both search-empty-state copies — all in light + dark side-by-side. **Screenshot inline below.**
- ✅ `/ask` page renders, AskBox handles submit, \"Thinking…\" state visible while streaming
- ⚠️ Full live `/ask` LLM streaming in the browser requires `wrangler login` (Workers AI is remote-only); SSE wire format verified via direct curl instead

## Deviations called out

1. **`heading_slug` for FTS5 results is null** by design — FTS5 stores the page row, not per-section chunks. AI Search results carry the full `heading` field through `WikiSearchResult` and the web pill builds `/w/<path>#<slug>`.
2. **AI Search delete is bounded fan-out** (`CHUNK_DELETE_MAX = 64`) since the binding has no \"delete by prefix\". A page with >64 chunks would leak orphan chunks until the next admin reindex sweep. Documented inline in `lib/ai-search.ts`.
3. **FTS5 query sanitizer** wraps multi-word inputs as a single phrase. Multi-word `/api/search` queries like \"What is DMARC?\" return [] in the local fallback path; single-token queries work. Acceptable for v0.0.1; loosening this is a separate hardening pass.
4. **`wrangler.dev.jsonc` drops the AI binding** to allow non-authenticated `wrangler dev` to start (wrangler 4 refuses to boot for accounts without login when remote-only bindings are declared). `astro.config.mjs` `platformProxy.configPath` updated to match. Tests inject typed fakes; live AI in dev requires `wrangler dev --remote --config wrangler.jsonc`.
5. **`requireAiBinding` guard added to `lib/llm.ts`** as a hardening fix exposed during the manual smoke — without it, missing `env.AI` in dev produced an inscrutable mid-stream `Cannot read properties of undefined (reading 'run')`. Now throws a clear error pointing operators at the DEPLOY.md section.

## Build verification

- `pnpm typecheck` — 5/5 packages clean
- `pnpm lint` — biome clean (190 files)
- `pnpm test` — 378 tests passing (32 shared + 31 schema + 96 web + 219 worker)

## Out of scope (documented in the M6 prompt)

BYOK encryption (M8), workspace LLM model setting (M8), proposal pipeline (M7), per-message search, search history, ⌘K command palette beyond search, cross-workspace search, voice ask, /ask thumbs feedback.

## Test plan

- [x] Apply migration 0002 against local D1
- [x] Confirm worker boots without login on `wrangler.dev.jsonc`
- [x] Seed a wiki page; assert `/api/search` returns it with `mode=fts5_fallback`
- [x] Confirm `/api/ask` SSE wire format end-to-end via curl
- [x] Trip the per-user cap; assert 429 with the typed `details` payload
- [x] `/design` renders citation pills + rate-limit banners + search empty states in light + dark
- [x] `/ask` page renders with the AskBox + \"Thinking…\" loader
- [ ] Full `/ask` LLM streaming in the browser — requires `wrangler login` for Workers AI access

🤖 Generated with [Claude Code](https://claude.com/claude-code)