### PR TITLE
feat(m7): add Run ingest button to room header

### DIFF
--- a/apps/web/src/components/chat/RoomView.test.tsx
+++ b/apps/web/src/components/chat/RoomView.test.tsx
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// RoomView pins the wiring of the "Run ingest" button:
+//   - clicking calls triggerIngest(roomId)
+//   - 200 running   → toast.success
+//   - 202 lock_held → toast.info
+//   - ApiError      → toast.error("<code>: <message>") + button re-enabled
+//   - button is disabled while the request is in flight
+//
+// useChat is mocked because the real hook opens a WebSocket on mount;
+// happy-dom has no WebSocket, and the chat plumbing is already covered
+// by useChat.test.tsx. We're testing the ingest path here.
+
+import { ApiError } from "@/lib/api";
+import * as apiInbox from "@/lib/api-inbox";
+import type { SerializedRoom, SerializedUser } from "@/lib/types";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { toast } from "sonner";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { RoomView } from "./RoomView";
+
+vi.mock("./useChat", () => ({
+  useChat: () => ({
+    status: "connected" as const,
+    messages: [],
+    hasOlderHistory: false,
+    lastError: null,
+    loadOlder: vi.fn(),
+    send: vi.fn(),
+    edit: vi.fn(),
+    remove: vi.fn(),
+    retry: vi.fn(),
+  }),
+}));
+
+const ROOM_ID = "01900000-0000-7000-8000-000000000001";
+const USER_ID = "01900000-0000-7000-8000-0000000000aa";
+
+const ROOM: SerializedRoom = {
+  id: ROOM_ID,
+  workspace_id: "01900000-0000-7000-8000-000000000000",
+  slug: "test",
+  name: "test",
+  topic: null,
+  created_by: USER_ID,
+  created_at: "2026-01-01T00:00:00.000Z",
+};
+
+const USER: SerializedUser = {
+  id: USER_ID,
+  email: "cory@example.com",
+  display_name: "Cory",
+  avatar_url: null,
+  created_at: "2026-01-01T00:00:00.000Z",
+};
+
+describe("RoomView — Run ingest button", () => {
+  let triggerIngestSpy: ReturnType<typeof vi.spyOn>;
+  let toastSuccess: ReturnType<typeof vi.spyOn>;
+  let toastInfo: ReturnType<typeof vi.spyOn>;
+  let toastError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    triggerIngestSpy = vi.spyOn(apiInbox, "triggerIngest");
+    toastSuccess = vi.spyOn(toast, "success").mockImplementation(() => "id");
+    toastInfo = vi.spyOn(toast, "info").mockImplementation(() => "id");
+    toastError = vi.spyOn(toast, "error").mockImplementation(() => "id");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders the button in the room header", () => {
+    render(<RoomView room={ROOM} currentUser={USER} />);
+    expect(screen.getByRole("button", { name: /run ingest/i })).toBeInTheDocument();
+  });
+
+  it("calls triggerIngest with the room id and shows a success toast on running", async () => {
+    triggerIngestSpy.mockResolvedValue({ run_id: "run-1", status: "running" });
+    render(<RoomView room={ROOM} currentUser={USER} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /run ingest/i }));
+
+    await waitFor(() => expect(triggerIngestSpy).toHaveBeenCalledWith(ROOM_ID));
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
+    expect(toastSuccess.mock.calls[0]?.[0]).toMatch(/ingest started/i);
+    expect(toastInfo).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("shows an info toast when the lock is already held", async () => {
+    triggerIngestSpy.mockResolvedValue({ run_id: "run-1", status: "lock_held" });
+    render(<RoomView room={ROOM} currentUser={USER} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /run ingest/i }));
+
+    await waitFor(() => expect(toastInfo).toHaveBeenCalledTimes(1));
+    expect(toastInfo.mock.calls[0]?.[0]).toMatch(/already in progress/i);
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("shows an error toast with code:message on ApiError and re-enables the button", async () => {
+    triggerIngestSpy.mockRejectedValue(
+      new ApiError("RATE_LIMITED", "Daily ingest cap reached", 429),
+    );
+    render(<RoomView room={ROOM} currentUser={USER} />);
+
+    const button = screen.getByRole("button", { name: /run ingest/i });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+    expect(toastError.mock.calls[0]?.[0]).toBe("RATE_LIMITED: Daily ingest cap reached");
+    // Button should not be stuck in the "Starting…" state.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /run ingest/i })).not.toBeDisabled(),
+    );
+  });
+
+  it("disables the button while the request is in flight", async () => {
+    let resolve: ((v: { run_id: string; status: "running" }) => void) | undefined;
+    triggerIngestSpy.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    render(<RoomView room={ROOM} currentUser={USER} />);
+
+    const button = screen.getByRole("button", { name: /run ingest/i });
+    fireEvent.click(button);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /starting/i })).toBeDisabled());
+
+    resolve?.({ run_id: "run-1", status: "running" });
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /run ingest/i })).not.toBeDisabled(),
+    );
+  });
+});

--- a/apps/web/src/components/chat/RoomView.tsx
+++ b/apps/web/src/components/chat/RoomView.tsx
@@ -4,9 +4,12 @@
 // as the page is interactive. Owns the chat plumbing (useChat) and
 // composes MessageList + MessageComposer + ConnectionBadge.
 
+import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
+import { ApiError } from "@/lib/api";
+import { triggerIngest } from "@/lib/api-inbox";
 import type { SerializedRoom, SerializedUser } from "@/lib/types";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ConnectionBadge } from "./ConnectionBadge";
 import { MessageComposer } from "./MessageComposer";
@@ -22,6 +25,7 @@ export interface RoomViewProps {
 
 export function RoomView({ room, currentUser, members }: RoomViewProps) {
   const chat = useChat({ roomId: room.id, currentUserId: currentUser.id });
+  const [ingestPending, setIngestPending] = useState(false);
 
   // Author display-name lookup. Includes the current user as a baseline
   // so own messages render without a network round-trip. Workspace
@@ -41,6 +45,28 @@ export function RoomView({ room, currentUser, members }: RoomViewProps) {
     if (chat.lastError) toast.error(chat.lastError.message);
   }, [chat.lastError]);
 
+  async function handleRunIngest(): Promise<void> {
+    setIngestPending(true);
+    try {
+      const res = await triggerIngest(room.id);
+      if (res.status === "lock_held") {
+        toast.info("An ingest run is already in progress for this room.");
+      } else {
+        toast.success("Ingest started — check Inbox for proposals shortly.");
+      }
+    } catch (err) {
+      const msg =
+        err instanceof ApiError
+          ? `${err.code}: ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : "Failed to start ingest";
+      toast.error(msg);
+    } finally {
+      setIngestPending(false);
+    }
+  }
+
   return (
     <section className="flex h-full min-h-0 flex-col">
       <header className="flex items-center justify-between border-b border-border bg-background px-4 py-3">
@@ -48,7 +74,18 @@ export function RoomView({ room, currentUser, members }: RoomViewProps) {
           <h1 className="truncate text-base font-semibold">#{room.slug}</h1>
           {room.topic && <p className="truncate text-xs text-muted-foreground">{room.topic}</p>}
         </div>
-        <ConnectionBadge status={chat.status} />
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRunIngest}
+            disabled={ingestPending}
+            title="Run the ingest agent on this room's recent chat"
+          >
+            {ingestPending ? "Starting…" : "Run ingest"}
+          </Button>
+          <ConnectionBadge status={chat.status} />
+        </div>
       </header>
 
       <div className="min-h-0 flex-1">


### PR DESCRIPTION
## Summary

- Adds a **Run ingest** button to `RoomView` header (next to the connection badge) that hits the existing `POST /api/rooms/:rid/ingest` route via the already-tested `triggerIngest` API client.
- Closes the UX gap surfaced in dogfood: [`ProposalsList.tsx:27`](apps/web/src/components/inbox/ProposalsList.tsx#L27) tells members to "Trigger an ingest run from a chat room" but no such button existed. The 03:00 UTC cron remained the only path on live.
- No new API surface, no schema change. The route, per-room run lock, audit log entry, and workspace daily rate limit are all already in place from M7 (#22).

## Toast behavior

| Server response | Toast |
|---|---|
| `200 { status: "running" }` | `success` — "Ingest started — check Inbox for proposals shortly." |
| `202 { status: "lock_held" }` | `info` — "An ingest run is already in progress for this room." |
| `429 RATE_LIMITED` / other `ApiError` | `error` — `${code}: ${message}` |

Button disables while the request is in flight.

## Test plan

- [x] `pnpm --filter @loomwiki/web typecheck` — 0 errors, 0 warnings
- [x] `pnpm --filter @loomwiki/web test --run` — 133 passed
- [x] `biome check` on touched file — clean
- [ ] Live smoke on `loomwiki.cortech.online`: open a room, click **Run ingest**, confirm a toast appears and a new pending proposal lands in `/inbox` within ~30s.
- [ ] Click again immediately while the first run is in flight → expect the `lock_held` info toast.

## Out of scope / follow-ups

- No new component-level test for the click handler. The API client (`triggerIngest`) already has a unit test in `api-inbox.test.ts`; the button is a thin wrapper. Worth adding a `RoomView.test.tsx` later, but not blocking this fix.
- During this work I also confirmed `cory@coryrank.in` is correctly set as `workspaces.owner_id` for the `default` workspace and `/api/me` returns `user.id === workspace.owner_id`. If **Settings** still isn't visible in the top nav on live, the bug is a page that doesn't compute and pass `isOwner` to `<AppShell>` — worth a separate audit.

Refs M7 (#22).

🤖 Generated with [Claude Code](https://claude.com/claude-code)