### PR TITLE
fix: pass isOwner to AppShell on all non-settings pages

### DIFF
--- a/apps/web/src/pages/ask.astro
+++ b/apps/web/src/pages/ask.astro
@@ -18,10 +18,12 @@ try {
   if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
   throw err;
 }
+
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Ask — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <div slot="sidebar" class="p-4 text-xs text-muted-foreground">
       <p class="font-medium text-foreground">Ask</p>
       <p class="mt-1">Answers grounded in your wiki, with citations.</p>

--- a/apps/web/src/pages/inbox/index.astro
+++ b/apps/web/src/pages/inbox/index.astro
@@ -26,10 +26,11 @@ try {
 
 const today = new Date().toISOString().slice(0, 10);
 const digestHref = `/w/_inbox/${today}.md`;
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Inbox — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/inbox/proposals/[id].astro
+++ b/apps/web/src/pages/inbox/proposals/[id].astro
@@ -55,10 +55,12 @@ if (detail.proposal.action === "update") {
     if (!(err instanceof SsrApiError && err.status === 404)) throw err;
   }
 }
+
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Proposal — ${detail.proposal.page_path}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -20,10 +20,12 @@ try {
   }
   throw err;
 }
+
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Loomwiki — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/r/[slug].astro
+++ b/apps/web/src/pages/r/[slug].astro
@@ -26,10 +26,11 @@ try {
 }
 
 const room = me.rooms.find((r) => r.slug === slug);
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={room ? `#${room.slug} — ${me.workspace.name}` : "Room not found"}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/search.astro
+++ b/apps/web/src/pages/search.astro
@@ -17,10 +17,12 @@ try {
   if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
   throw err;
 }
+
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Search — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <div slot="sidebar" class="p-4 text-xs text-muted-foreground">
       Search across the wiki. Use the sidebar nav to switch surfaces.
     </div>

--- a/apps/web/src/pages/w/[...path].astro
+++ b/apps/web/src/pages/w/[...path].astro
@@ -88,7 +88,7 @@ const draft: WikiPagePayload | null =
 ---
 
 <Layout title={page ? `${page.frontmatter.title} — ${me.workspace.name}` : "Wiki page not found"}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <WikiTree
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/w/index.astro
+++ b/apps/web/src/pages/w/index.astro
@@ -43,7 +43,7 @@ const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Wiki — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <WikiTree
       slot="sidebar"
       client:idle


### PR DESCRIPTION
## Summary

- All 8 pages rendering `<AppShell>` outside `/settings/*` were omitting the `isOwner` prop, so the Settings tab was always hidden even for workspace owners.
- Added `const isOwner = me.workspace.owner_id === me.user.id;` in the frontmatter of each page and passed `isOwner={isOwner}` to `<AppShell>` — the same pattern already used by `settings/workspace.astro`, `settings/byok.astro`, and `settings/agentsmd.astro`.
- Two pages (`w/index.astro`, `w/[...path].astro`) already computed `isOwner` locally for in-page rendering logic but forgot to forward it to the shell; fixed those too.
- `AppShell.astro` prop signature and default (`isOwner = false`) are unchanged.

## Affected pages

| Page | Change |
|------|--------|
| `apps/web/src/pages/index.astro` | added `isOwner` computation + prop |
| `apps/web/src/pages/ask.astro` | added `isOwner` computation + prop |
| `apps/web/src/pages/search.astro` | added `isOwner` computation + prop |
| `apps/web/src/pages/r/[slug].astro` | added `isOwner` computation + prop |
| `apps/web/src/pages/inbox/index.astro` | added `isOwner` computation + prop |
| `apps/web/src/pages/inbox/proposals/[id].astro` | added `isOwner` computation + prop |
| `apps/web/src/pages/w/index.astro` | already computed; now passed to shell |
| `apps/web/src/pages/w/[...path].astro` | already computed; now passed to shell |

Closes #28

## Test plan

- [ ] `pnpm --filter @loomwiki/web typecheck` passes — **0 errors, 0 warnings** (20 hints, pre-existing).
- [ ] `pnpm --filter @loomwiki/web test --run` passes — **138 tests across 26 files**.
- [ ] `pnpm typecheck` (root) passes — all packages clean.
- [ ] `pnpm lint` (root) passes — 5 pre-existing warnings in unrelated test files, none in the changed pages.
- [ ] Log in as a workspace owner: verify the **Settings** tab appears in the top nav on `/`, `/ask`, `/search`, `/r/{slug}`, `/inbox`, `/inbox/proposals/{id}`, `/w`, and `/w/{path}`.
- [ ] Log in as a non-owner member: verify the Settings tab does **not** appear on those pages.
- [ ] Navigate to `/settings/*` pages: confirm no regression — Settings tab still visible (those pages already passed the prop).

https://claude.ai/code/session_01Tf7m5ctq2qUCEPzjmDGSBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tf7m5ctq2qUCEPzjmDGSBp)_