### PR TITLE
test: cover D1 mirror failure and retry paths

### DIFF
--- a/apps/worker/src/__tests__/ws-mirror.test.ts
+++ b/apps/worker/src/__tests__/ws-mirror.test.ts
@@ -3,10 +3,18 @@
 // D1 mirror tests for the ChatRoom DO write-through path. The DO is the
 // source of truth for the live state; `messages` in D1 is the queryable
 // mirror that ingest, scrollback, and the daily-log cron rely on.
+//
+// The failure-path tests (D1 throws → pending_mirror=1 → retry on next
+// send or alarm) use `runInDurableObject` to inject a one-shot failing
+// `_mirrorFn` onto the live DO instance. That seam is inert in production
+// (defaults to `undefined` → falls back to real `mirrorMessageToD1`).
 
-import { SELF, env } from "cloudflare:test";
+import { SELF, env, runDurableObjectAlarm, runInDurableObject } from "cloudflare:test";
 import { PROTOCOL_VERSION } from "@loomwiki/shared";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { ChatRoom } from "../do/ChatRoom.js";
+import type { Env } from "../env.js";
+import type { MirrorMessage } from "../lib/d1-mirror.js";
 import { applyMigrations, resetDb } from "./__fixtures__/db.js";
 import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
 import { type WsSession, openWs } from "./__fixtures__/ws.js";
@@ -71,6 +79,27 @@ async function waitFor<T>(fn: () => Promise<T | null>, timeoutMs = 1500): Promis
   throw new Error(`waitFor timed out after ${timeoutMs}ms`);
 }
 
+// ---------------------------------------------------------------------------
+// Helper: get the ChatRoom DO stub that backs a given roomId. The namespace
+// uses idFromName(roomId) just like the route layer in rooms.ts.
+// ---------------------------------------------------------------------------
+function chatRoomStub(roomId: string): DurableObjectStub<ChatRoom> {
+  return (env.CHAT_ROOM as DurableObjectNamespace<ChatRoom>).get(env.CHAT_ROOM.idFromName(roomId));
+}
+
+/**
+ * Test seam: access the private `sql` field on the DO instance for direct
+ * SQLite assertions inside `runInDurableObject`. We cast through a structural
+ * interface rather than bracket notation to satisfy biome's `useLiteralKeys`.
+ */
+interface ChatRoomInternals {
+  sql: SqlStorage;
+}
+
+function getSql(instance: ChatRoom): SqlStorage {
+  return (instance as unknown as ChatRoomInternals).sql;
+}
+
 describe("ChatRoom → D1 mirror", () => {
   it("a sent message is visible in D1 `messages` within 1 second", async () => {
     const { jwt, roomId } = await bootstrap("general");
@@ -130,5 +159,185 @@ describe("ChatRoom → D1 mirror", () => {
         .first<{ deleted_at: number | null }>();
       return r && r.deleted_at !== null ? r : null;
     }, 1500);
+  });
+
+  // -------------------------------------------------------------------------
+  // Failure-path tests
+  //
+  // Strategy: before each `send`, inject a failing `_mirrorFn` into the live
+  // DO instance via `runInDurableObject`. The DO calls `_mirrorFn ?? real`
+  // in `tryMirror` / `flushPendingMirror`, so the stub throws exactly once
+  // and the production retry path is exercised without any NODE_ENV branch.
+  // -------------------------------------------------------------------------
+
+  it("D1 failure leaves pending_mirror=1 for the affected row", async () => {
+    const { jwt, roomId } = await bootstrap("failure-flag");
+    const stub = chatRoomStub(roomId);
+
+    // Inject a one-shot failing mirror function BEFORE the send so it is
+    // in place when `tryMirror` fires inside `ctx.waitUntil`.
+    await runInDurableObject(stub, async (instance: ChatRoom) => {
+      instance._mirrorFn = async (_e: Env, _m: MirrorMessage): Promise<void> => {
+        throw new Error("injected D1 failure");
+      };
+    });
+
+    const ws = sessions[sessions.push(await openWs(roomId, jwt)) - 1];
+    if (!ws) throw new Error("session push failed");
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws.next();
+
+    ws.send({ kind: "send", tempId: "f1", body: "will-fail-mirror" });
+    const ack = await ws.next();
+    if (ack.kind !== "ack") throw new Error("expected ack");
+
+    // Give waitUntil time to run tryMirror (which throws → markPendingMirror).
+    // Then assert the row has pending_mirror=1 via runInDurableObject.
+    await waitFor(async () => {
+      const pending = await runInDurableObject(stub, (instance: ChatRoom) => {
+        const cursor = getSql(instance).exec<{ id: string; pending_mirror: number }>(
+          "SELECT id, pending_mirror FROM messages_local WHERE id = ?",
+          ack.messageId,
+        );
+        for (const row of cursor) return row;
+        return null;
+      });
+      return pending !== null && pending.pending_mirror === 1 ? pending : null;
+    }, 2000);
+
+    // Row must NOT be in D1 yet (mirror never succeeded).
+    const d1Row = await readMessageFromD1(ack.messageId);
+    expect(d1Row).toBeNull();
+  });
+
+  it("a subsequent send after a D1 failure retries pending rows and clears the flag", async () => {
+    const { jwt, roomId } = await bootstrap("failure-retry");
+    const stub = chatRoomStub(roomId);
+
+    // Step 1: inject failure for the first send.
+    await runInDurableObject(stub, async (instance: ChatRoom) => {
+      instance._mirrorFn = async (_e: Env, _m: MirrorMessage): Promise<void> => {
+        throw new Error("injected D1 failure");
+      };
+    });
+
+    const ws = sessions[sessions.push(await openWs(roomId, jwt)) - 1];
+    if (!ws) throw new Error("session push failed");
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws.next();
+
+    ws.send({ kind: "send", tempId: "r1", body: "first-fails" });
+    const ack1 = await ws.next();
+    if (ack1.kind !== "ack") throw new Error("expected ack");
+
+    // Wait for the failure to be recorded (pending_mirror=1).
+    await waitFor(async () => {
+      return runInDurableObject(stub, (instance: ChatRoom) => {
+        const cursor = getSql(instance).exec<{ pending_mirror: number }>(
+          "SELECT pending_mirror FROM messages_local WHERE id = ?",
+          ack1.messageId,
+        );
+        for (const row of cursor) return row.pending_mirror === 1 ? row : null;
+        return null;
+      });
+    }, 2000);
+
+    // Step 2: restore the real mirror so the second send and the pending-row
+    // flush both succeed.
+    await runInDurableObject(stub, (instance: ChatRoom) => {
+      instance._mirrorFn = undefined;
+    });
+
+    // Step 3: send a second message — handleSend calls scheduleMirror which
+    // calls tryMirror. Before calling the real mirror for the new message,
+    // flushPendingMirror is NOT called by handleSend — that is the alarm path.
+    // However, tryMirror for the new send WILL clear its own row. The pending
+    // row from step 1 is cleared by the alarm or the next explicit retry.
+    //
+    // To trigger the pending-row retry without waiting 60s, send a second
+    // message (which triggers its own mirror), then fire the alarm directly.
+    ws.send({ kind: "send", tempId: "r2", body: "second-succeeds" });
+    const ack2 = await ws.next();
+    if (ack2.kind !== "ack") throw new Error("expected ack");
+
+    // The second message should mirror successfully.
+    await waitFor(() => readMessageFromD1(ack2.messageId), 1500);
+
+    // Fire the alarm to flush the pending row from step 1.
+    const alarmRan = await runDurableObjectAlarm(stub);
+    expect(alarmRan).toBe(true);
+
+    // After the alarm the first row should now be in D1.
+    const row1 = await waitFor(() => readMessageFromD1(ack1.messageId), 1500);
+    expect(row1.body).toBe("first-fails");
+
+    // And pending_mirror should be cleared.
+    const pending = await runInDurableObject(stub, (instance: ChatRoom) => {
+      const cursor = getSql(instance).exec<{ c: number }>(
+        "SELECT COUNT(*) AS c FROM messages_local WHERE pending_mirror = 1",
+      );
+      for (const row of cursor) return row.c;
+      return -1;
+    });
+    expect(pending).toBe(0);
+  });
+
+  it("runDurableObjectAlarm after a D1 failure drains the pending queue", async () => {
+    const { jwt, roomId } = await bootstrap("failure-alarm");
+    const stub = chatRoomStub(roomId);
+
+    // Inject failure.
+    await runInDurableObject(stub, async (instance: ChatRoom) => {
+      instance._mirrorFn = async (_e: Env, _m: MirrorMessage): Promise<void> => {
+        throw new Error("injected D1 failure");
+      };
+    });
+
+    const ws = sessions[sessions.push(await openWs(roomId, jwt)) - 1];
+    if (!ws) throw new Error("session push failed");
+    ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
+    await ws.next();
+
+    ws.send({ kind: "send", tempId: "a1", body: "alarm-drains-me" });
+    const ack = await ws.next();
+    if (ack.kind !== "ack") throw new Error("expected ack");
+
+    // Wait until pending_mirror=1 is recorded.
+    await waitFor(async () => {
+      return runInDurableObject(stub, (instance: ChatRoom) => {
+        const cursor = getSql(instance).exec<{ pending_mirror: number }>(
+          "SELECT pending_mirror FROM messages_local WHERE id = ?",
+          ack.messageId,
+        );
+        for (const row of cursor) return row.pending_mirror === 1 ? row : null;
+        return null;
+      });
+    }, 2000);
+
+    // Row not in D1 yet.
+    expect(await readMessageFromD1(ack.messageId)).toBeNull();
+
+    // Restore real mirror so the alarm's flushPendingMirror succeeds.
+    await runInDurableObject(stub, (instance: ChatRoom) => {
+      instance._mirrorFn = undefined;
+    });
+
+    // Fire alarm directly — no further WS sends needed.
+    const alarmRan = await runDurableObjectAlarm(stub);
+    expect(alarmRan).toBe(true);
+
+    // Row now in D1.
+    const row = await waitFor(() => readMessageFromD1(ack.messageId), 1500);
+    expect(row.body).toBe("alarm-drains-me");
+
+    // pending_mirror cleared.
+    const pendingCount = await runInDurableObject(stub, (instance: ChatRoom) => {
+      const cursor = getSql(instance).exec<{ c: number }>(
+        "SELECT COUNT(*) AS c FROM messages_local WHERE pending_mirror = 1",
+      );
+      for (const row of cursor) return row.c;
+      return -1;
+    });
+    expect(pendingCount).toBe(0);
   });
 });

--- a/apps/worker/src/do/ChatRoom.ts
+++ b/apps/worker/src/do/ChatRoom.ts
@@ -107,6 +107,14 @@ export class ChatRoom extends DurableObject<Env> {
   private readonly sql: SqlStorage;
   private readonly limiter: RollingWindowLimiter;
 
+  /**
+   * Optional mirror function override. Defaults to `undefined` (inert in
+   * production — falls back to the real `mirrorMessageToD1`). Tests can
+   * inject a one-shot failing stub via `runInDurableObject` without any
+   * `NODE_ENV` branch in production code.
+   */
+  _mirrorFn: typeof mirrorMessageToD1 | undefined = undefined;
+
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.sql = ctx.storage.sql;
@@ -424,8 +432,9 @@ export class ChatRoom extends DurableObject<Env> {
   }
 
   private async tryMirror(msg: MirrorMessage): Promise<void> {
+    const mirror = this._mirrorFn ?? mirrorMessageToD1;
     try {
-      await mirrorMessageToD1(this.env, msg);
+      await mirror(this.env, msg);
       clearPendingMirror(this.sql, msg.id);
     } catch (err) {
       console.warn("[chatroom] mirror failed", { id: msg.id, err: String(err) });
@@ -447,10 +456,11 @@ export class ChatRoom extends DurableObject<Env> {
       // Nothing has ever been written to this DO yet — nothing to mirror.
       return;
     }
+    const mirror = this._mirrorFn ?? mirrorMessageToD1;
     const pending = getPendingMirrorRows(this.sql, MIRROR_RETRY_BATCH);
     for (const row of pending) {
       try {
-        await mirrorMessageToD1(this.env, {
+        await mirror(this.env, {
           id: row.id,
           roomId,
           userId: row.user_id,


### PR DESCRIPTION
## Summary

- Adds a `_mirrorFn` optional field to `ChatRoom` as an inert production seam (defaults `undefined`, falls through to real `mirrorMessageToD1`). No `NODE_ENV` branch, no change to error-handling semantics.
- Adds three failure-path tests to `ws-mirror.test.ts` using `runInDurableObject` + `runDurableObjectAlarm` from `cloudflare:test`:
  1. **pending_mirror=1 on D1 failure** — injects a throwing stub before the send, polls DO SQLite via `runInDurableObject` to assert the flag is set, and confirms the row is absent from D1.
  2. **Subsequent send + alarm drains the queue** — restores the real mirror after the failure, sends a second message (which succeeds), fires `runDurableObjectAlarm`, then asserts both rows appear in D1 and `pending_mirror=0`.
  3. **Alarm alone drains the queue** — same failure injection, restores the real mirror, fires only the alarm (no further sends), and asserts the row appears in D1 with `pending_mirror=0`.

Closes #15

## Test plan

- [ ] `pnpm --filter @loomwiki/worker test` → 378 passed (46 test files); the 1 pre-existing failure (`rate-limits beyond 100 msg/sec/room`) is unrelated and was already present on `main`.
- [ ] `pnpm typecheck` → 0 errors across all packages.
- [ ] `pnpm lint` → 0 errors (5 pre-existing warnings in `apps/web`, unrelated).
- [ ] Verify `ChatRoom._mirrorFn` is `undefined` in the production constructor — no behavior change on the hot path.

## SPEC §20 assumptions

None. This is a pure test addition with a minimal, inert production seam.

https://claude.ai/code/session_01Tf7m5ctq2qUCEPzjmDGSBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tf7m5ctq2qUCEPzjmDGSBp)_