### PR TITLE
fix: pass isOwner prop to AppShell on all non-settings pages

### DIFF
--- a/apps/web/src/pages/ask.astro
+++ b/apps/web/src/pages/ask.astro
@@ -18,10 +18,12 @@ try {
   if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
   throw err;
 }
+
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Ask — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <div slot="sidebar" class="p-4 text-xs text-muted-foreground">
       <p class="font-medium text-foreground">Ask</p>
       <p class="mt-1">Answers grounded in your wiki, with citations.</p>

--- a/apps/web/src/pages/inbox/index.astro
+++ b/apps/web/src/pages/inbox/index.astro
@@ -24,12 +24,13 @@ try {
   throw err;
 }
 
+const isOwner = me.workspace.owner_id === me.user.id;
 const today = new Date().toISOString().slice(0, 10);
 const digestHref = `/w/_inbox/${today}.md`;
 ---
 
 <Layout title={`Inbox — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/inbox/proposals/[id].astro
+++ b/apps/web/src/pages/inbox/proposals/[id].astro
@@ -41,6 +41,8 @@ try {
   throw err;
 }
 
+const isOwner = me.workspace.owner_id === me.user.id;
+
 let currentPage: WikiPagePayload | null = null;
 if (detail.proposal.action === "update") {
   try {
@@ -58,7 +60,7 @@ if (detail.proposal.action === "update") {
 ---
 
 <Layout title={`Proposal — ${detail.proposal.page_path}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -20,10 +20,12 @@ try {
   }
   throw err;
 }
+
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Loomwiki — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/r/[slug].astro
+++ b/apps/web/src/pages/r/[slug].astro
@@ -26,10 +26,11 @@ try {
 }
 
 const room = me.rooms.find((r) => r.slug === slug);
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={room ? `#${room.slug} — ${me.workspace.name}` : "Room not found"}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/search.astro
+++ b/apps/web/src/pages/search.astro
@@ -17,10 +17,12 @@ try {
   if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
   throw err;
 }
+
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Search — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <div slot="sidebar" class="p-4 text-xs text-muted-foreground">
       Search across the wiki. Use the sidebar nav to switch surfaces.
     </div>

--- a/apps/web/src/pages/w/[...path].astro
+++ b/apps/web/src/pages/w/[...path].astro
@@ -88,7 +88,7 @@ const draft: WikiPagePayload | null =
 ---
 
 <Layout title={page ? `${page.frontmatter.title} — ${me.workspace.name}` : "Wiki page not found"}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <WikiTree
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/w/index.astro
+++ b/apps/web/src/pages/w/index.astro
@@ -43,7 +43,7 @@ const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Wiki — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <WikiTree
       slot="sidebar"
       client:idle


### PR DESCRIPTION
## Summary

- Settings tab was invisible to workspace owners on every page except `/settings/*` because only those 3 pages computed `isOwner` and forwarded it to `<AppShell isOwner={...}>`.
- Adds `const isOwner = me.workspace.owner_id === me.user.id;` to the frontmatter of 6 pages that lacked it entirely, and passes the prop to `<AppShell>` on all 8 affected pages.
- `w/index.astro` and `w/[...path].astro` already computed `isOwner` locally for in-page logic but forgot to pass it to the shell — fixed.

Closes #28

## Test plan

- [x] `pnpm --filter @loomwiki/web typecheck` — 0 errors
- [x] `pnpm --filter @loomwiki/web test --run` — 138 passing, 0 failing
- [x] `pnpm lint` — 0 new warnings (5 pre-existing in unrelated test files)
- [ ] Manual: log in as workspace owner → Settings tab visible on `/`, `/ask`, `/search`, `/r/{slug}`, `/inbox`, `/inbox/proposals/{id}`, `/w`, `/w/{path}`
- [ ] Manual: log in as non-owner → Settings tab absent on all those pages
- [ ] No change to rendered output on existing `/settings/*` pages

## Notes

One pre-existing worker test failure (`rate-limits beyond 100 msg/sec/room with RATE_LIMITED` in `chat-room.test.ts`) is unrelated to this change — this PR only touches Astro pages in `apps/web`. Tracked separately.

https://claude.ai/code/session_01ANYJpDh3wRE83DhvBchC3d

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANYJpDh3wRE83DhvBchC3d)_