### PR TITLE
feat: user-defined scheduled prompts

### DIFF
--- a/apps/web/src/components/settings/ScheduledActionsSettings.tsx
+++ b/apps/web/src/components/settings/ScheduledActionsSettings.tsx
@@ -1,0 +1,405 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Scheduled-actions settings surface. Members can view, create, pause/resume,
+// and delete scheduled prompts for rooms they belong to.
+//
+// Design decisions (SPEC §20 / issue #33):
+//   - Q-sched-4: 50 active/workspace, 10 active/room (enforced server-side)
+//   - Q-sched-6: created_by or workspace owner may pause/edit/delete
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Toaster } from "@/components/ui/sonner";
+import { Textarea } from "@/components/ui/textarea";
+import { apiDelete, apiGet, apiPost, request } from "@/lib/api";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+interface Room {
+  id: string;
+  slug: string;
+  name: string;
+  workspace_id: string;
+  topic: string | null;
+  created_by: string;
+  created_at: string;
+}
+
+interface ScheduledAction {
+  id: string;
+  workspace_id: string;
+  room_id: string;
+  created_by: string;
+  kind: "cron" | "once";
+  cron_expr: string | null;
+  fire_at: number | null;
+  prompt: string;
+  status: "active" | "paused" | "fired" | "failed";
+  failure_count: number;
+  last_fired_at: number | null;
+  next_fire_at: number;
+  created_at: number;
+  updated_at: number;
+}
+
+interface ScheduledActionsSettingsProps {
+  userId: string;
+  isOwner: boolean;
+}
+
+function epochToLocal(epochS: number): string {
+  return new Date(epochS * 1000).toLocaleString();
+}
+
+function canModify(action: ScheduledAction, userId: string, isOwner: boolean): boolean {
+  return action.created_by === userId || isOwner;
+}
+
+export function ScheduledActionsSettings({ userId, isOwner }: ScheduledActionsSettingsProps) {
+  const [rooms, setRooms] = useState<Room[] | null>(null);
+  const [selectedRoomId, setSelectedRoomId] = useState<string>("");
+  const [actions, setActions] = useState<ScheduledAction[]>([]);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Create form state
+  const [showCreate, setShowCreate] = useState(false);
+  const [createKind, setCreateKind] = useState<"cron" | "once">("cron");
+  const [createCronExpr, setCreateCronExpr] = useState("0 9 * * 1-5");
+  const [createFireAt, setCreateFireAt] = useState("");
+  const [createPrompt, setCreatePrompt] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    apiGet<{ workspace: { id: string } }>("/api/me")
+      .then((me) => {
+        if (cancelled) return;
+        return apiGet<{ rooms: Room[] }>(`/api/workspaces/${me.workspace.id}/rooms`);
+      })
+      .then((data) => {
+        if (cancelled || !data) return;
+        setRooms(data.rooms);
+        if (data.rooms.length > 0 && data.rooms[0]) {
+          setSelectedRoomId(data.rooms[0].id);
+        }
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setLoadError(err instanceof Error ? err.message : "Failed to load rooms");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!selectedRoomId) return;
+    let cancelled = false;
+    setLoading(true);
+    apiGet<{ actions: ScheduledAction[]; hasMore: boolean }>(
+      `/api/rooms/${selectedRoomId}/scheduled-actions`,
+    )
+      .then((data) => {
+        if (cancelled) return;
+        setActions(data.actions);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        toast.error(err instanceof Error ? err.message : "Failed to load scheduled actions");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedRoomId]);
+
+  async function handleCreate(): Promise<void> {
+    if (!selectedRoomId) return;
+    setCreating(true);
+    try {
+      let body: Record<string, unknown>;
+      if (createKind === "cron") {
+        body = { kind: "cron", cron_expr: createCronExpr, prompt: createPrompt };
+      } else {
+        const fireAtS = Math.floor(new Date(createFireAt).getTime() / 1000);
+        if (Number.isNaN(fireAtS)) {
+          toast.error("Invalid date/time for one-time action");
+          return;
+        }
+        body = { kind: "once", fire_at: fireAtS, prompt: createPrompt };
+      }
+
+      const data = await apiPost<{ action: ScheduledAction }>(
+        `/api/rooms/${selectedRoomId}/scheduled-actions`,
+        body,
+      );
+      setActions((prev) => [...prev, data.action]);
+      setShowCreate(false);
+      setCreatePrompt("");
+      toast.success("Scheduled action created");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to create scheduled action");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function handleTogglePause(action: ScheduledAction): Promise<void> {
+    const newStatus = action.status === "paused" ? "active" : "paused";
+    try {
+      const data = await request<{ action: ScheduledAction }>(
+        `/api/rooms/${selectedRoomId}/scheduled-actions/${action.id}`,
+        { method: "PATCH", body: { status: newStatus } },
+      );
+      setActions((prev) => prev.map((a) => (a.id === action.id ? data.action : a)));
+      toast.success(newStatus === "paused" ? "Paused" : "Resumed");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to update action");
+    }
+  }
+
+  async function handleDelete(actionId: string): Promise<void> {
+    if (!confirm("Delete this scheduled action?")) return;
+    try {
+      await apiDelete(`/api/rooms/${selectedRoomId}/scheduled-actions/${actionId}`);
+      setActions((prev) => prev.filter((a) => a.id !== actionId));
+      toast.success("Deleted");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to delete action");
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="p-6 text-sm text-destructive" role="alert">
+        Failed to load: {loadError}
+      </div>
+    );
+  }
+
+  if (rooms === null) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground" aria-busy="true">
+        Loading…
+      </div>
+    );
+  }
+
+  if (rooms.length === 0) {
+    return (
+      <div className="p-6 text-sm text-muted-foreground">
+        No rooms yet. Create a room first, then add scheduled prompts.
+      </div>
+    );
+  }
+
+  const statusBadge = (s: ScheduledAction["status"]) => {
+    const classes: Record<ScheduledAction["status"], string> = {
+      active: "bg-green-100 text-green-800",
+      paused: "bg-yellow-100 text-yellow-800",
+      fired: "bg-blue-100 text-blue-800",
+      failed: "bg-red-100 text-red-800",
+    };
+    return (
+      <span
+        className={`inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${classes[s]}`}
+      >
+        {s}
+      </span>
+    );
+  };
+
+  return (
+    <div className="space-y-6 p-6">
+      <header className="space-y-1">
+        <h1 className="text-lg font-semibold">Scheduled Prompts</h1>
+        <p className="text-sm text-muted-foreground">
+          Automated prompts that post into a room on a cron schedule or once at a future time.
+          Limit: 50 active per workspace, 10 per room.
+        </p>
+      </header>
+
+      {/* Room selector */}
+      <div className="space-y-1">
+        <label htmlFor="room-select" className="text-sm font-medium">
+          Room
+        </label>
+        <select
+          id="room-select"
+          value={selectedRoomId}
+          onChange={(e) => setSelectedRoomId(e.target.value)}
+          className="flex h-9 w-full max-w-xs rounded-md border border-input bg-background px-3 py-1 text-sm shadow-xs"
+        >
+          {rooms.map((r) => (
+            <option key={r.id} value={r.id}>
+              #{r.slug} — {r.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Action list */}
+      {loading ? (
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      ) : actions.length === 0 ? (
+        <p className="text-sm text-muted-foreground">No scheduled actions for this room yet.</p>
+      ) : (
+        <ul className="divide-y divide-border rounded-md border">
+          {actions.map((action) => (
+            <li key={action.id} className="flex flex-col gap-1 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="min-w-0 flex-1 space-y-0.5">
+                  <div className="flex items-center gap-2">
+                    {statusBadge(action.status)}
+                    <span className="text-xs text-muted-foreground">
+                      {action.kind === "cron"
+                        ? `cron: ${action.cron_expr}`
+                        : `once: ${action.fire_at ? epochToLocal(action.fire_at) : "—"}`}
+                    </span>
+                  </div>
+                  <p className="truncate text-sm font-medium">{action.prompt}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Next fire: {epochToLocal(action.next_fire_at)}
+                    {action.last_fired_at !== null
+                      ? ` · Last fired: ${epochToLocal(action.last_fired_at)}`
+                      : ""}
+                    {action.failure_count > 0 ? ` · Failures: ${action.failure_count}` : ""}
+                  </p>
+                </div>
+                {canModify(action, userId, isOwner) && (
+                  <div className="flex shrink-0 gap-2">
+                    {(action.status === "active" || action.status === "paused") && (
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => void handleTogglePause(action)}
+                      >
+                        {action.status === "paused" ? "Resume" : "Pause"}
+                      </Button>
+                    )}
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      className="text-destructive hover:text-destructive"
+                      onClick={() => void handleDelete(action.id)}
+                    >
+                      Delete
+                    </Button>
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Create form */}
+      {showCreate ? (
+        <div className="rounded-md border p-4">
+          <h2 className="mb-4 text-sm font-semibold">New Scheduled Action</h2>
+          <form
+            className="space-y-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void handleCreate();
+            }}
+          >
+            <fieldset className="space-y-1">
+              <legend className="text-sm font-medium">Kind</legend>
+              <div className="flex gap-4">
+                <label className="flex items-center gap-1.5 text-sm">
+                  <input
+                    type="radio"
+                    name="kind"
+                    value="cron"
+                    checked={createKind === "cron"}
+                    onChange={() => setCreateKind("cron")}
+                  />
+                  Recurring (cron)
+                </label>
+                <label className="flex items-center gap-1.5 text-sm">
+                  <input
+                    type="radio"
+                    name="kind"
+                    value="once"
+                    checked={createKind === "once"}
+                    onChange={() => setCreateKind("once")}
+                  />
+                  Once
+                </label>
+              </div>
+            </fieldset>
+
+            {createKind === "cron" ? (
+              <div className="space-y-1">
+                <label htmlFor="cron-expr" className="text-sm font-medium">
+                  Cron expression
+                </label>
+                <Input
+                  id="cron-expr"
+                  value={createCronExpr}
+                  onChange={(e) => setCreateCronExpr(e.target.value)}
+                  placeholder="0 9 * * 1-5"
+                  required
+                />
+                <p className="text-xs text-muted-foreground">
+                  Five-field POSIX cron (UTC). Example: 0 9 * * 1-5 = weekdays 09:00 UTC.
+                </p>
+              </div>
+            ) : (
+              <div className="space-y-1">
+                <label htmlFor="fire-at" className="text-sm font-medium">
+                  Fire at (UTC)
+                </label>
+                <Input
+                  id="fire-at"
+                  type="datetime-local"
+                  value={createFireAt}
+                  onChange={(e) => setCreateFireAt(e.target.value)}
+                  required
+                />
+                <p className="text-xs text-muted-foreground">
+                  Date and time (your local timezone — converted to UTC server-side).
+                </p>
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <label htmlFor="prompt" className="text-sm font-medium">
+                Prompt
+              </label>
+              <Textarea
+                id="prompt"
+                value={createPrompt}
+                onChange={(e) => setCreatePrompt(e.target.value)}
+                placeholder="Post a daily standup reminder…"
+                maxLength={4096}
+                rows={3}
+                required
+              />
+              <p className="text-xs text-muted-foreground">
+                The message text posted into the room. Max 4096 characters.
+              </p>
+            </div>
+
+            <div className="flex gap-2">
+              <Button type="submit" disabled={creating}>
+                {creating ? "Creating…" : "Create"}
+              </Button>
+              <Button type="button" variant="outline" onClick={() => setShowCreate(false)}>
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </div>
+      ) : (
+        <Button onClick={() => setShowCreate(true)}>New scheduled action</Button>
+      )}
+
+      <Toaster />
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/SettingsTabs.astro
+++ b/apps/web/src/components/settings/SettingsTabs.astro
@@ -6,7 +6,7 @@
 // the AppShell's MPA model and keeps the React island per-tab small.
 
 interface Props {
-  active: "byok" | "agentsmd" | "workspace";
+  active: "byok" | "agentsmd" | "workspace" | "schedules";
 }
 
 const { active } = Astro.props;
@@ -15,6 +15,7 @@ const tabs: { id: Props["active"]; href: string; label: string }[] = [
   { id: "byok", href: "/settings/byok", label: "BYOK" },
   { id: "agentsmd", href: "/settings/agentsmd", label: "AGENTS.md" },
   { id: "workspace", href: "/settings/workspace", label: "Workspace" },
+  { id: "schedules", href: "/settings/schedules", label: "Schedules" },
 ];
 ---
 

--- a/apps/web/src/pages/settings/schedules.astro
+++ b/apps/web/src/pages/settings/schedules.astro
@@ -1,0 +1,42 @@
+---
+// SPDX-License-Identifier: Apache-2.0
+// Scheduled actions settings page. Members can view/create/pause/delete
+// scheduled prompts for rooms they belong to.
+
+import AppShell from "@/components/AppShell.astro";
+import { ScheduledActionsSettings } from "@/components/settings/ScheduledActionsSettings";
+import SettingsTabs from "@/components/settings/SettingsTabs.astro";
+import Layout from "@/layouts/Layout.astro";
+import { SsrAuthRequiredError, ssrApiGet } from "@/lib/ssr-api";
+import type { CurrentUserPayload } from "@/lib/types";
+
+const env = Astro.locals.runtime?.env;
+let me: CurrentUserPayload;
+try {
+  me = await ssrApiGet<CurrentUserPayload>(Astro.request, "/api/me", env);
+} catch (err) {
+  if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
+  throw err;
+}
+
+const isOwner = me.workspace.owner_id === me.user.id;
+---
+
+<Layout title={`Schedules — ${me.workspace.name}`}>
+  <AppShell
+    workspaceName={me.workspace.name}
+    userDisplayName={me.user.display_name}
+    isOwner={isOwner}
+  >
+    <div slot="sidebar" class="p-4 text-xs text-muted-foreground">
+      <p class="font-medium text-foreground">Scheduled Prompts</p>
+      <p class="mt-1">Configure automated prompts that fire into rooms on a schedule.</p>
+    </div>
+    <div slot="main" class="flex h-full min-h-0 flex-col">
+      <SettingsTabs active="schedules" />
+      <div class="min-h-0 flex-1 overflow-y-auto">
+        <ScheduledActionsSettings client:load userId={me.user.id} isOwner={isOwner} />
+      </div>
+    </div>
+  </AppShell>
+</Layout>

--- a/apps/worker/src/__tests__/__fixtures__/db.ts
+++ b/apps/worker/src/__tests__/__fixtures__/db.ts
@@ -25,6 +25,7 @@ const TRUNCATE_ORDER = [
   "ingest_runs",
   "messages",
   "room_members",
+  "scheduled_actions",
   "rooms",
   "workspaces",
   "users",

--- a/apps/worker/src/__tests__/routes-scheduled-actions.test.ts
+++ b/apps/worker/src/__tests__/routes-scheduled-actions.test.ts
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Integration tests for scheduled-actions routes:
+//   POST   /api/rooms/:roomId/scheduled-actions
+//   GET    /api/rooms/:roomId/scheduled-actions
+//   PATCH  /api/rooms/:roomId/scheduled-actions/:id
+//   DELETE /api/rooms/:roomId/scheduled-actions/:id
+
+import { SELF, env } from "cloudflare:test";
+import { id } from "@loomwiki/shared";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+interface OkBody<T> {
+  ok: true;
+  data: T;
+}
+interface ErrBody {
+  ok: false;
+  error: { code: string; message: string };
+}
+
+async function authedFetch(jwt: string, path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers ?? {});
+  headers.set("CF-Access-Jwt-Assertion", jwt);
+  return SELF.fetch(`https://api.local${path}`, { ...init, headers });
+}
+
+interface Bootstrap {
+  ownerJwt: string;
+  ownerId: string;
+  workspaceId: string;
+  roomId: string;
+}
+
+async function bootstrapOwnerAndRoom(): Promise<Bootstrap> {
+  const ownerJwt = await fixture.mint({ email: "owner@example.com" });
+  const me = await authedFetch(ownerJwt, "/api/me");
+  const meBody = (await me.json()) as {
+    data: { user: { id: string }; workspace: { id: string; owner_id: string } };
+  };
+  const ownerId = meBody.data.user.id;
+  const workspaceId = meBody.data.workspace.id;
+
+  const createRoom = await authedFetch(ownerJwt, `/api/workspaces/${workspaceId}/rooms`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ slug: "general", name: "General" }),
+  });
+  const roomBody = (await createRoom.json()) as { data: { room: { id: string } } };
+  const roomId = roomBody.data.room.id;
+
+  return { ownerJwt, ownerId, workspaceId, roomId };
+}
+
+async function bootstrapNonMember(): Promise<{ jwt: string; userId: string }> {
+  const jwt = await fixture.mint({ email: "outsider@example.com" });
+  const me = await authedFetch(jwt, "/api/me");
+  const meBody = (await me.json()) as { data: { user: { id: string } } };
+  return { jwt, userId: meBody.data.user.id };
+}
+
+// Future epoch 1 hour from now (as epoch seconds)
+function futureEpoch(offsetS = 3600): number {
+  return Math.floor(Date.now() / 1000) + offsetS;
+}
+
+describe("POST /api/rooms/:roomId/scheduled-actions", () => {
+  it("returns 401 without JWT", async () => {
+    const res = await SELF.fetch("https://api.local/api/rooms/fake-room/scheduled-actions", {
+      method: "POST",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 for non-existent room", async () => {
+    const { ownerJwt } = await bootstrapOwnerAndRoom();
+    const res = await authedFetch(ownerJwt, `/api/rooms/${id()}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(), prompt: "hello" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 for non-member", async () => {
+    const { roomId } = await bootstrapOwnerAndRoom();
+    const { jwt } = await bootstrapNonMember();
+    const res = await authedFetch(jwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(), prompt: "hello" }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as ErrBody;
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("creates a once action and returns correct next_fire_at", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const fireAt = futureEpoch(7200);
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: fireAt, prompt: "Run daily standup" }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as OkBody<{
+      action: { id: string; kind: string; next_fire_at: number; status: string };
+    }>;
+    expect(body.ok).toBe(true);
+    expect(body.data.action.kind).toBe("once");
+    expect(body.data.action.next_fire_at).toBe(fireAt);
+    expect(body.data.action.status).toBe("active");
+  });
+
+  it("creates a cron action and computes next_fire_at", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "cron", cron_expr: "0 9 * * 1", prompt: "Weekly standup" }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as OkBody<{
+      action: { id: string; kind: string; next_fire_at: number; cron_expr: string };
+    }>;
+    expect(body.ok).toBe(true);
+    expect(body.data.action.kind).toBe("cron");
+    expect(body.data.action.cron_expr).toBe("0 9 * * 1");
+    expect(body.data.action.next_fire_at).toBeGreaterThan(Math.floor(Date.now() / 1000));
+  });
+
+  it("returns 400 for an invalid cron expression", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "cron", cron_expr: "not a cron expression!", prompt: "test" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ErrBody;
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 for a once action with fire_at in the past", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: 1000, prompt: "Old event" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ErrBody;
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+
+  it("returns 400 for missing discriminated union fields", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    // Missing cron_expr for kind='cron'
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "cron", prompt: "test" }),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/rooms/:roomId/scheduled-actions", () => {
+  it("returns empty list for a new room", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as OkBody<{ actions: unknown[]; hasMore: boolean }>;
+    expect(body.ok).toBe(true);
+    expect(body.data.actions).toHaveLength(0);
+    expect(body.data.hasMore).toBe(false);
+  });
+
+  it("returns created actions in the list", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(3600), prompt: "P1" }),
+    });
+    await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(7200), prompt: "P2" }),
+    });
+
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`);
+    const body = (await res.json()) as OkBody<{ actions: { prompt: string }[] }>;
+    expect(body.data.actions).toHaveLength(2);
+  });
+
+  it("returns 403 for non-member", async () => {
+    const { roomId } = await bootstrapOwnerAndRoom();
+    const { jwt } = await bootstrapNonMember();
+    const res = await authedFetch(jwt, `/api/rooms/${roomId}/scheduled-actions`);
+    expect(res.status).toBe(403);
+  });
+
+  it("filters by status query param", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+
+    // Create one active action
+    const createRes = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(3600), prompt: "Active" }),
+    });
+    const created = (await createRes.json()) as OkBody<{ action: { id: string } }>;
+    const actionId = created.data.action.id;
+
+    // Pause it
+    await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions/${actionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "paused" }),
+    });
+
+    const activeRes = await authedFetch(
+      ownerJwt,
+      `/api/rooms/${roomId}/scheduled-actions?status=active`,
+    );
+    const active = (await activeRes.json()) as OkBody<{ actions: unknown[] }>;
+    expect(active.data.actions).toHaveLength(0);
+
+    const pausedRes = await authedFetch(
+      ownerJwt,
+      `/api/rooms/${roomId}/scheduled-actions?status=paused`,
+    );
+    const paused = (await pausedRes.json()) as OkBody<{ actions: { status: string }[] }>;
+    expect(paused.data.actions).toHaveLength(1);
+    expect(paused.data.actions[0]?.status).toBe("paused");
+  });
+});
+
+describe("PATCH /api/rooms/:roomId/scheduled-actions/:id", () => {
+  it("pauses an action", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const createRes = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(3600), prompt: "Test" }),
+    });
+    const created = (await createRes.json()) as OkBody<{ action: { id: string } }>;
+    const actionId = created.data.action.id;
+
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions/${actionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "paused" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as OkBody<{ action: { status: string } }>;
+    expect(body.data.action.status).toBe("paused");
+  });
+
+  it("resumes a paused action and recomputes next_fire_at", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const fireAt = futureEpoch(7200);
+    const createRes = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "cron", cron_expr: "0 0 * * *", prompt: "Midnight" }),
+    });
+    const created = (await createRes.json()) as OkBody<{
+      action: { id: string; next_fire_at: number };
+    }>;
+    const actionId = created.data.action.id;
+    const originalNextFire = created.data.action.next_fire_at;
+
+    // Pause
+    await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions/${actionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "paused" }),
+    });
+
+    // Resume
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions/${actionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "active" }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as OkBody<{ action: { status: string; next_fire_at: number } }>;
+    expect(body.data.action.status).toBe("active");
+    // next_fire_at should be recomputed from now, not from original
+    expect(body.data.action.next_fire_at).toBeGreaterThan(Math.floor(Date.now() / 1000));
+    // For "0 0 * * *", next fire is at midnight — should be tomorrow or later
+    expect(body.data.action.next_fire_at).toBeGreaterThan(originalNextFire - 1);
+    // Suppress unused variable warning
+    void fireAt;
+  });
+
+  it("returns 404 for non-existent action", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions/${id()}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "paused" }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when non-author non-owner tries to patch", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+
+    // Create action as owner
+    const createRes = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(3600), prompt: "Owner's action" }),
+    });
+    const created = (await createRes.json()) as OkBody<{ action: { id: string } }>;
+    const actionId = created.data.action.id;
+
+    // Second member joins the room
+    const memberJwt = await fixture.mint({ email: "member@example.com" });
+    const memberMe = await authedFetch(memberJwt, "/api/me");
+    const memberBody = (await memberMe.json()) as { data: { user: { id: string } } };
+    await env.DB.prepare(
+      "INSERT OR IGNORE INTO room_members (room_id, user_id, role) VALUES (?, ?, 'member')",
+    )
+      .bind(roomId, memberBody.data.user.id)
+      .run();
+
+    // Member tries to patch owner's action
+    const res = await authedFetch(memberJwt, `/api/rooms/${roomId}/scheduled-actions/${actionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "paused" }),
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as ErrBody;
+    expect(body.error.code).toBe("FORBIDDEN");
+  });
+
+  it("returns 400 when patching with empty body", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const createRes = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(3600), prompt: "Test" }),
+    });
+    const created = (await createRes.json()) as OkBody<{ action: { id: string } }>;
+    const actionId = created.data.action.id;
+
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions/${actionId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as ErrBody;
+    expect(body.error.code).toBe("VALIDATION_FAILED");
+  });
+});
+
+describe("DELETE /api/rooms/:roomId/scheduled-actions/:id", () => {
+  it("deletes an action", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const createRes = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(3600), prompt: "Temporary" }),
+    });
+    const created = (await createRes.json()) as OkBody<{ action: { id: string } }>;
+    const actionId = created.data.action.id;
+
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions/${actionId}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as OkBody<{ deleted: boolean }>;
+    expect(body.data.deleted).toBe(true);
+
+    // Verify it's gone
+    const listRes = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`);
+    const list = (await listRes.json()) as OkBody<{ actions: unknown[] }>;
+    expect(list.data.actions).toHaveLength(0);
+  });
+
+  it("returns 404 for non-existent action", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions/${id()}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when non-author non-owner tries to delete", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+    const createRes = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(3600), prompt: "Important" }),
+    });
+    const created = (await createRes.json()) as OkBody<{ action: { id: string } }>;
+    const actionId = created.data.action.id;
+
+    const memberJwt = await fixture.mint({ email: "member2@example.com" });
+    const memberMe = await authedFetch(memberJwt, "/api/me");
+    const memberBody = (await memberMe.json()) as { data: { user: { id: string } } };
+    await env.DB.prepare(
+      "INSERT OR IGNORE INTO room_members (room_id, user_id, role) VALUES (?, ?, 'member')",
+    )
+      .bind(roomId, memberBody.data.user.id)
+      .run();
+
+    const res = await authedFetch(memberJwt, `/api/rooms/${roomId}/scheduled-actions/${actionId}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("workspace owner can delete any action", async () => {
+    const { ownerJwt, roomId } = await bootstrapOwnerAndRoom();
+
+    // A member creates an action
+    const memberJwt = await fixture.mint({ email: "creator@example.com" });
+    const memberMe = await authedFetch(memberJwt, "/api/me");
+    const memberBody = (await memberMe.json()) as { data: { user: { id: string } } };
+    await env.DB.prepare(
+      "INSERT OR IGNORE INTO room_members (room_id, user_id, role) VALUES (?, ?, 'member')",
+    )
+      .bind(roomId, memberBody.data.user.id)
+      .run();
+
+    const createRes = await authedFetch(memberJwt, `/api/rooms/${roomId}/scheduled-actions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ kind: "once", fire_at: futureEpoch(3600), prompt: "Member's action" }),
+    });
+    const created = (await createRes.json()) as OkBody<{ action: { id: string } }>;
+    const actionId = created.data.action.id;
+
+    // Owner deletes it
+    const res = await authedFetch(ownerJwt, `/api/rooms/${roomId}/scheduled-actions/${actionId}`, {
+      method: "DELETE",
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/apps/worker/src/__tests__/scheduled-actions-tick.test.ts
+++ b/apps/worker/src/__tests__/scheduled-actions-tick.test.ts
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Integration tests for the scheduled-actions every-minute tick handler.
+// Tests use the scheduled() handler and inspect D1 state to verify
+// that cron/once actions fire correctly.
+
+import { SELF, env } from "cloudflare:test";
+import { id } from "@loomwiki/shared";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { runScheduledActionsTick } from "../scheduled.js";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+beforeEach(async () => {
+  await resetDb();
+});
+
+interface Bootstrap {
+  ownerJwt: string;
+  ownerId: string;
+  workspaceId: string;
+  roomId: string;
+}
+
+async function authedFetch(jwt: string, path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers ?? {});
+  headers.set("CF-Access-Jwt-Assertion", jwt);
+  return SELF.fetch(`https://api.local${path}`, { ...init, headers });
+}
+
+async function bootstrapOwnerAndRoom(): Promise<Bootstrap> {
+  const ownerJwt = await fixture.mint({ email: "owner@example.com" });
+  const me = await authedFetch(ownerJwt, "/api/me");
+  const meBody = (await me.json()) as {
+    data: { user: { id: string }; workspace: { id: string } };
+  };
+  const ownerId = meBody.data.user.id;
+  const workspaceId = meBody.data.workspace.id;
+
+  const createRoom = await authedFetch(ownerJwt, `/api/workspaces/${workspaceId}/rooms`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ slug: "general", name: "General" }),
+  });
+  const roomBody = (await createRoom.json()) as { data: { room: { id: string } } };
+  const roomId = roomBody.data.room.id;
+
+  return { ownerJwt, ownerId, workspaceId, roomId };
+}
+
+/**
+ * Seed a scheduled_action row directly in D1 with a next_fire_at in the
+ * past (so the tick handler claims it).
+ */
+async function seedAction(opts: {
+  workspaceId: string;
+  roomId: string;
+  createdBy: string;
+  kind: "cron" | "once";
+  cronExpr?: string;
+  prompt?: string;
+  nextFireAt?: number;
+}): Promise<string> {
+  const actionId = id();
+  const nowS = Math.floor(Date.now() / 1000);
+  const nextFire = opts.nextFireAt ?? nowS - 60; // default: 1 minute ago (eligible)
+
+  await env.DB.prepare(
+    `INSERT INTO scheduled_actions
+       (id, workspace_id, room_id, created_by, kind, cron_expr, fire_at, prompt, status,
+        failure_count, last_fired_at, next_fire_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', 0, NULL, ?, ?, ?)`,
+  )
+    .bind(
+      actionId,
+      opts.workspaceId,
+      opts.roomId,
+      opts.createdBy,
+      opts.kind,
+      opts.cronExpr ?? null,
+      opts.kind === "once" ? nextFire : null,
+      opts.prompt ?? "Test prompt",
+      nextFire,
+      nowS,
+      nowS,
+    )
+    .run();
+
+  return actionId;
+}
+
+describe("runScheduledActionsTick", () => {
+  it("does nothing when no eligible actions", async () => {
+    const { roomId, workspaceId, ownerId } = await bootstrapOwnerAndRoom();
+
+    // Seed action with next_fire_at in the future
+    const futureFireAt = Math.floor(Date.now() / 1000) + 3600;
+    await seedAction({
+      workspaceId,
+      roomId,
+      createdBy: ownerId,
+      kind: "once",
+      nextFireAt: futureFireAt,
+    });
+
+    const nowS = Math.floor(Date.now() / 1000);
+    await runScheduledActionsTick(env, nowS);
+
+    const row = await env.DB.prepare("SELECT status FROM scheduled_actions WHERE room_id = ?")
+      .bind(roomId)
+      .first<{ status: string }>();
+    // Should still be active with unchanged status
+    expect(row?.status).toBe("active");
+  });
+
+  it("fires a once action and marks it as fired", async () => {
+    const { roomId, workspaceId, ownerId } = await bootstrapOwnerAndRoom();
+
+    const actionId = await seedAction({
+      workspaceId,
+      roomId,
+      createdBy: ownerId,
+      kind: "once",
+      prompt: "Once-only prompt",
+    });
+
+    const nowS = Math.floor(Date.now() / 1000);
+    await runScheduledActionsTick(env, nowS);
+
+    const row = await env.DB.prepare(
+      "SELECT status, last_fired_at FROM scheduled_actions WHERE id = ?",
+    )
+      .bind(actionId)
+      .first<{ status: string; last_fired_at: number | null }>();
+
+    expect(row?.status).toBe("fired");
+    expect(row?.last_fired_at).not.toBeNull();
+  });
+
+  it("fires a cron action and computes a new next_fire_at", async () => {
+    const { roomId, workspaceId, ownerId } = await bootstrapOwnerAndRoom();
+
+    const actionId = await seedAction({
+      workspaceId,
+      roomId,
+      createdBy: ownerId,
+      kind: "cron",
+      cronExpr: "* * * * *", // every minute
+      prompt: "Minutely check-in",
+    });
+
+    const nowS = Math.floor(Date.now() / 1000);
+    await runScheduledActionsTick(env, nowS);
+
+    const row = await env.DB.prepare(
+      "SELECT status, last_fired_at, next_fire_at FROM scheduled_actions WHERE id = ?",
+    )
+      .bind(actionId)
+      .first<{ status: string; last_fired_at: number | null; next_fire_at: number }>();
+
+    // Cron action should remain active with a new next_fire_at
+    expect(row?.status).toBe("active");
+    expect(row?.last_fired_at).not.toBeNull();
+    // next_fire_at should be pushed forward
+    expect(row?.next_fire_at).toBeGreaterThan(nowS);
+  });
+
+  it("increments failure_count when DO call fails", async () => {
+    const { workspaceId, ownerId } = await bootstrapOwnerAndRoom();
+
+    // Use a non-existent room_id so the DO fetch will fail (room not found in
+    // the DO). We still need to insert it without FK constraints failing —
+    // seed a fake room row first.
+    const fakeRoomId = id();
+    await env.DB.prepare(
+      "INSERT INTO rooms (id, workspace_id, slug, name, created_by) VALUES (?, ?, ?, ?, ?)",
+    )
+      .bind(fakeRoomId, workspaceId, "fake-room", "Fake Room", ownerId)
+      .run();
+
+    const actionId = await seedAction({
+      workspaceId,
+      roomId: fakeRoomId,
+      createdBy: ownerId,
+      kind: "once",
+      prompt: "Will fail",
+    });
+
+    // Make the DO stub return an error by spying
+    const origGet = env.CHAT_ROOM.get.bind(env.CHAT_ROOM);
+    const fetchSpy = vi.fn().mockResolvedValue(new Response("error", { status: 500 }));
+    vi.spyOn(env.CHAT_ROOM, "get").mockReturnValue({
+      fetch: fetchSpy,
+    } as unknown as ReturnType<typeof origGet>);
+
+    const nowS = Math.floor(Date.now() / 1000);
+    await runScheduledActionsTick(env, nowS);
+
+    vi.restoreAllMocks();
+
+    const row = await env.DB.prepare(
+      "SELECT status, failure_count FROM scheduled_actions WHERE id = ?",
+    )
+      .bind(actionId)
+      .first<{ status: string; failure_count: number }>();
+
+    // Should have incremented failure_count
+    expect(row?.failure_count).toBe(1);
+    // Should still be active for retry
+    expect(row?.status).toBe("active");
+  });
+
+  it("marks status=failed after 3 consecutive failures", async () => {
+    const { workspaceId, ownerId } = await bootstrapOwnerAndRoom();
+
+    const fakeRoomId = id();
+    await env.DB.prepare(
+      "INSERT INTO rooms (id, workspace_id, slug, name, created_by) VALUES (?, ?, ?, ?, ?)",
+    )
+      .bind(fakeRoomId, workspaceId, "fail-room", "Fail Room", ownerId)
+      .run();
+
+    // Seed with failure_count=2 already (one more will tip it to failed)
+    const actionId = id();
+    const nowS = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO scheduled_actions
+         (id, workspace_id, room_id, created_by, kind, cron_expr, fire_at, prompt, status,
+          failure_count, last_fired_at, next_fire_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'once', NULL, ?, 'Will fail', 'active', 2, NULL, ?, ?, ?)`,
+    )
+      .bind(actionId, workspaceId, fakeRoomId, ownerId, nowS - 60, nowS - 60, nowS, nowS)
+      .run();
+
+    // Mock DO to return 500
+    const fetchSpy = vi.fn().mockResolvedValue(new Response("error", { status: 500 }));
+    vi.spyOn(env.CHAT_ROOM, "get").mockReturnValue({
+      fetch: fetchSpy,
+    } as unknown as ReturnType<typeof env.CHAT_ROOM.get>);
+
+    await runScheduledActionsTick(env, nowS);
+
+    vi.restoreAllMocks();
+
+    const row = await env.DB.prepare(
+      "SELECT status, failure_count FROM scheduled_actions WHERE id = ?",
+    )
+      .bind(actionId)
+      .first<{ status: string; failure_count: number }>();
+
+    expect(row?.failure_count).toBe(3);
+    expect(row?.status).toBe("failed");
+  });
+
+  it("prevents double-fire via optimistic claim", async () => {
+    // Run the tick twice concurrently — only one should claim the action.
+    const { roomId, workspaceId, ownerId } = await bootstrapOwnerAndRoom();
+
+    const actionId = await seedAction({
+      workspaceId,
+      roomId,
+      createdBy: ownerId,
+      kind: "once",
+      prompt: "Once only",
+    });
+
+    const nowS = Math.floor(Date.now() / 1000);
+    // Run two ticks at the same nowS in parallel
+    await Promise.all([runScheduledActionsTick(env, nowS), runScheduledActionsTick(env, nowS)]);
+
+    // The action should be fired exactly once (status=fired, not active).
+    // The optimistic claim ensures only one tick can transition the row.
+    const row = await env.DB.prepare(
+      "SELECT status, last_fired_at FROM scheduled_actions WHERE id = ?",
+    )
+      .bind(actionId)
+      .first<{ status: string; last_fired_at: number | null }>();
+
+    expect(row?.status).toBe("fired");
+    // The action must have been fired (last_fired_at set)
+    expect(row?.last_fired_at).not.toBeNull();
+  });
+});

--- a/apps/worker/src/do/ChatRoom.ts
+++ b/apps/worker/src/do/ChatRoom.ts
@@ -115,6 +115,12 @@ export class ChatRoom extends DurableObject<Env> {
   }
 
   override async fetch(request: Request): Promise<Response> {
+    // Internal system endpoint: inject a message from the scheduled-actions tick.
+    // Must appear BEFORE the WebSocket upgrade check.
+    if (request.method === "POST" && new URL(request.url).pathname.endsWith("/_sys/message")) {
+      return this.handleSysPost(request);
+    }
+
     if (request.headers.get("Upgrade") !== "websocket") {
       return new Response("expected upgrade", { status: 426 });
     }
@@ -438,6 +444,99 @@ export class ChatRoom extends DurableObject<Env> {
     const current = await this.ctx.storage.getAlarm();
     if (current === null) {
       await this.ctx.storage.setAlarm(Date.now() + MIRROR_RETRY_ALARM_MS);
+    }
+  }
+
+  // ---------- system message injection (scheduled-actions tick) ----------
+
+  /**
+   * POST /_sys/message — inject a system-authored message into the room.
+   * Called only from the scheduled-actions tick handler via stub.fetch();
+   * the DO's fetch() is only reachable from within the Worker, not from
+   * the public internet. Still validated by the x-loomwiki-sys header as
+   * defense-in-depth.
+   *
+   * Body JSON: { userId: string; roomId: string; body: string; parentId?: string | null }
+   */
+  private async handleSysPost(request: Request): Promise<Response> {
+    if (request.headers.get("x-loomwiki-sys") !== "1") {
+      return new Response("forbidden", { status: 403 });
+    }
+
+    let payload: { userId: string; roomId: string; body: string; parentId?: string | null };
+    try {
+      payload = (await request.json()) as {
+        userId: string;
+        roomId: string;
+        body: string;
+        parentId?: string | null;
+      };
+    } catch {
+      return new Response("invalid json", { status: 400 });
+    }
+
+    if (!payload.userId || !payload.roomId || !payload.body) {
+      return new Response("missing required fields", { status: 400 });
+    }
+
+    const messageId = id();
+    const createdAt = Math.floor(Date.now() / 1000);
+    const parentId = payload.parentId ?? null;
+
+    // Persist roomId so the alarm path can recover it.
+    setRoomId(this.sql, payload.roomId);
+
+    let wireMessage: WireMessage | null = null;
+
+    await this.ctx.blockConcurrencyWhile(async () => {
+      appendMessage(this.sql, {
+        id: messageId,
+        userId: payload.userId,
+        body: payload.body,
+        parentId,
+        createdAt,
+        pendingMirror: true,
+      });
+      wireMessage = {
+        id: messageId,
+        room_id: payload.roomId,
+        user_id: payload.userId,
+        body: payload.body,
+        parent_id: parentId,
+        created_at: createdAt,
+        edited_at: null,
+        deleted_at: null,
+      };
+    });
+
+    if (wireMessage) {
+      this.broadcastAll({ kind: "message", message: wireMessage });
+
+      // D1 mirror: best-effort, off the critical path.
+      this.scheduleMirror({
+        id: messageId,
+        roomId: payload.roomId,
+        userId: payload.userId,
+        body: payload.body,
+        parentId,
+        createdAt,
+        editedAt: null,
+        deletedAt: null,
+      });
+    }
+
+    return Response.json({ ok: true });
+  }
+
+  /** Broadcast to ALL open WebSocket clients (no exclusion). */
+  private broadcastAll(msg: ServerMsg): void {
+    const payload = JSON.stringify(msg);
+    for (const ws of this.ctx.getWebSockets()) {
+      try {
+        ws.send(payload);
+      } catch {
+        // Drop and let webSocketClose run.
+      }
     }
   }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -20,6 +20,7 @@ import { meRoute } from "./routes/me.js";
 import { proposalsRoute } from "./routes/proposals.js";
 import { roomsRoute } from "./routes/rooms.js";
 import { runsRoute } from "./routes/runs.js";
+import { scheduledActionsRoute } from "./routes/scheduled-actions.js";
 import { searchRoute } from "./routes/search.js";
 import { agentsMdSettingsRoute } from "./routes/settings/agentsmd.js";
 import { byokSettingsRoute } from "./routes/settings/byok.js";
@@ -71,6 +72,7 @@ app.use("/api/_admin/audit", authMiddleware);
 app.route("/api/me", meRoute);
 app.route("/api/workspaces", workspacesRoute);
 app.route("/api/rooms", roomsRoute);
+app.route("/api/rooms", scheduledActionsRoute);
 // Wiki routes share a Hono router so the /wiki-tree, /wiki/*, and
 // /_admin/wiki/* paths can be defined in one place. Mounting at the
 // root means the route handlers can use the absolute paths above.

--- a/apps/worker/src/routes/scheduled-actions.ts
+++ b/apps/worker/src/routes/scheduled-actions.ts
@@ -1,0 +1,403 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Scheduled-actions routes — user-defined cron/once prompts that fire into
+// a ChatRoom as system-authored messages.
+//
+// Mounted at /api/rooms (see index.ts), so the full paths are:
+//   POST   /api/rooms/:roomId/scheduled-actions
+//   GET    /api/rooms/:roomId/scheduled-actions
+//   PATCH  /api/rooms/:roomId/scheduled-actions/:id
+//   DELETE /api/rooms/:roomId/scheduled-actions/:id
+//
+// Auth: verified room membership (same as rooms.ts). Workspace ownership
+// from c.var.workspace.owner_id. Soft quota: 50 active per workspace,
+// 10 active per room.
+
+import {
+  CreateScheduledActionRequestSchema,
+  PatchScheduledActionRequestSchema,
+  type ScheduledActionRow,
+  ScheduledActionRowSchema,
+} from "@loomwiki/schema";
+import { parseScheduledActionRow } from "@loomwiki/schema/parsers";
+import { ErrorCodes, LoomwikiError, apiOk, id, nextFireAt, parseCronExpr } from "@loomwiki/shared";
+import { Hono } from "hono";
+import type { AuthEnv } from "../middleware/auth.js";
+
+const WORKSPACE_QUOTA_ACTIVE = 50;
+const ROOM_QUOTA_ACTIVE = 10;
+const LIST_PAGE_SIZE = 50;
+const LIST_MAX_PAGE_SIZE = 200;
+
+// Serialize a ScheduledActionRow → wire-safe JSON shape (epoch seconds as numbers, nulls intact).
+function serializeAction(r: ScheduledActionRow): ScheduledActionRow {
+  // Row is already the right shape — we return it directly. The Zod schema
+  // mirrors the D1 column types, so no conversion needed here.
+  return r;
+}
+
+/** Verify the caller is a member of the given room within the caller's workspace. */
+async function requireRoomMember(
+  env: AuthEnv["Bindings"],
+  userId: string,
+  workspaceId: string,
+  roomId: string,
+): Promise<void> {
+  const row = await env.DB.prepare("SELECT workspace_id FROM rooms WHERE id = ?")
+    .bind(roomId)
+    .first<{ workspace_id: string }>();
+  if (!row) {
+    throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Room not found", { status: 404 });
+  }
+  if (row.workspace_id !== workspaceId) {
+    throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Room not found", { status: 404 });
+  }
+  const member = await env.DB.prepare(
+    "SELECT 1 FROM room_members WHERE room_id = ? AND user_id = ? LIMIT 1",
+  )
+    .bind(roomId, userId)
+    .first();
+  if (!member) {
+    throw new LoomwikiError(ErrorCodes.FORBIDDEN, "Not a member of this room", { status: 403 });
+  }
+}
+
+/** Check that the caller is either the row's creator or the workspace owner. */
+function requireAuthorOrOwner(createdBy: string, callerId: string, workspaceOwnerId: string): void {
+  if (callerId !== createdBy && callerId !== workspaceOwnerId) {
+    throw new LoomwikiError(
+      ErrorCodes.FORBIDDEN,
+      "Only the creator or workspace owner may modify this scheduled action",
+      {
+        status: 403,
+      },
+    );
+  }
+}
+
+export const scheduledActionsRoute = new Hono<AuthEnv>()
+  // ---------- POST /:roomId/scheduled-actions — create ----------
+  .post("/:roomId/scheduled-actions", async (c) => {
+    const roomId = c.req.param("roomId");
+    await requireRoomMember(c.env, c.var.user.id, c.var.workspace.id, roomId);
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "Request body must be JSON", {
+        status: 400,
+      });
+    }
+
+    const parsed = CreateScheduledActionRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "Invalid request body", {
+        status: 400,
+        details: parsed.error.issues,
+      });
+    }
+
+    const req = parsed.data;
+    const nowS = Math.floor(Date.now() / 1000);
+
+    // Validate cron_expr and compute next_fire_at
+    let nextFire: number;
+    if (req.kind === "cron") {
+      const cronParsed = parseCronExpr(req.cron_expr);
+      if (!cronParsed) {
+        throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "Invalid cron expression", {
+          status: 400,
+        });
+      }
+      try {
+        nextFire = nextFireAt(req.cron_expr, nowS);
+      } catch {
+        throw new LoomwikiError(
+          ErrorCodes.VALIDATION_FAILED,
+          "Cron expression produces no valid next fire time within 4 years",
+          {
+            status: 400,
+          },
+        );
+      }
+    } else {
+      // kind === 'once'
+      if (req.fire_at <= nowS) {
+        throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "fire_at must be in the future", {
+          status: 400,
+        });
+      }
+      nextFire = req.fire_at;
+    }
+
+    // Soft quota checks
+    const wsCount = await c.env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM scheduled_actions WHERE workspace_id = ? AND status = 'active'",
+    )
+      .bind(c.var.workspace.id)
+      .first<{ n: number }>();
+    if ((wsCount?.n ?? 0) >= WORKSPACE_QUOTA_ACTIVE) {
+      throw new LoomwikiError(
+        ErrorCodes.VALIDATION_FAILED,
+        `Workspace quota of ${WORKSPACE_QUOTA_ACTIVE} active scheduled actions reached`,
+        { status: 400 },
+      );
+    }
+
+    const roomCount = await c.env.DB.prepare(
+      "SELECT COUNT(*) AS n FROM scheduled_actions WHERE room_id = ? AND status = 'active'",
+    )
+      .bind(roomId)
+      .first<{ n: number }>();
+    if ((roomCount?.n ?? 0) >= ROOM_QUOTA_ACTIVE) {
+      throw new LoomwikiError(
+        ErrorCodes.VALIDATION_FAILED,
+        `Room quota of ${ROOM_QUOTA_ACTIVE} active scheduled actions reached`,
+        { status: 400 },
+      );
+    }
+
+    const actionId = id();
+    const cron_expr = req.kind === "cron" ? req.cron_expr : null;
+    const fire_at = req.kind === "once" ? req.fire_at : null;
+
+    await c.env.DB.prepare(
+      `INSERT INTO scheduled_actions
+         (id, workspace_id, room_id, created_by, kind, cron_expr, fire_at, prompt, status,
+          failure_count, last_fired_at, next_fire_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', 0, NULL, ?, ?, ?)`,
+    )
+      .bind(
+        actionId,
+        c.var.workspace.id,
+        roomId,
+        c.var.user.id,
+        req.kind,
+        cron_expr,
+        fire_at,
+        req.prompt,
+        nextFire,
+        nowS,
+        nowS,
+      )
+      .run();
+
+    const row = await c.env.DB.prepare("SELECT * FROM scheduled_actions WHERE id = ?")
+      .bind(actionId)
+      .first();
+    const action = parseScheduledActionRow(row);
+
+    return c.json(apiOk({ action: serializeAction(action) }), 201);
+  })
+
+  // ---------- GET /:roomId/scheduled-actions — list ----------
+  .get("/:roomId/scheduled-actions", async (c) => {
+    const roomId = c.req.param("roomId");
+    await requireRoomMember(c.env, c.var.user.id, c.var.workspace.id, roomId);
+
+    const statusFilter = c.req.query("status"); // optional: active|paused|fired|failed
+    const beforeParam = c.req.query("before"); // cursor: action id
+    const limitRaw = c.req.query("limit");
+    let limit = LIST_PAGE_SIZE;
+    if (limitRaw !== undefined) {
+      const n = Number.parseInt(limitRaw, 10);
+      if (!Number.isFinite(n) || n <= 0) {
+        throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "limit must be a positive integer", {
+          status: 400,
+        });
+      }
+      limit = Math.min(n, LIST_MAX_PAGE_SIZE);
+    }
+
+    // Validate status filter if provided
+    if (statusFilter !== undefined) {
+      const statusResult = ScheduledActionRowSchema.shape.status.safeParse(statusFilter);
+      if (!statusResult.success) {
+        throw new LoomwikiError(
+          ErrorCodes.VALIDATION_FAILED,
+          "status must be one of: active, paused, fired, failed",
+          { status: 400 },
+        );
+      }
+    }
+
+    const fetched = limit + 1;
+    let rows: { results: unknown[] };
+
+    if (statusFilter !== undefined && beforeParam !== undefined) {
+      rows = await c.env.DB.prepare(
+        "SELECT * FROM scheduled_actions WHERE room_id = ? AND status = ? AND id < ? ORDER BY id DESC LIMIT ?",
+      )
+        .bind(roomId, statusFilter, beforeParam, fetched)
+        .all();
+    } else if (statusFilter !== undefined) {
+      rows = await c.env.DB.prepare(
+        "SELECT * FROM scheduled_actions WHERE room_id = ? AND status = ? ORDER BY id DESC LIMIT ?",
+      )
+        .bind(roomId, statusFilter, fetched)
+        .all();
+    } else if (beforeParam !== undefined) {
+      rows = await c.env.DB.prepare(
+        "SELECT * FROM scheduled_actions WHERE room_id = ? AND id < ? ORDER BY id DESC LIMIT ?",
+      )
+        .bind(roomId, beforeParam, fetched)
+        .all();
+    } else {
+      rows = await c.env.DB.prepare(
+        "SELECT * FROM scheduled_actions WHERE room_id = ? ORDER BY id DESC LIMIT ?",
+      )
+        .bind(roomId, fetched)
+        .all();
+    }
+
+    const parsed = rows.results.map(parseScheduledActionRow);
+    const hasMore = parsed.length > limit;
+    const trimmed = hasMore ? parsed.slice(0, limit) : parsed;
+    trimmed.reverse();
+
+    return c.json(apiOk({ actions: trimmed.map(serializeAction), hasMore }));
+  })
+
+  // ---------- PATCH /:roomId/scheduled-actions/:id — update ----------
+  .patch("/:roomId/scheduled-actions/:id", async (c) => {
+    const roomId = c.req.param("roomId");
+    const actionId = c.req.param("id");
+    await requireRoomMember(c.env, c.var.user.id, c.var.workspace.id, roomId);
+
+    const existing = await c.env.DB.prepare(
+      "SELECT * FROM scheduled_actions WHERE id = ? AND room_id = ?",
+    )
+      .bind(actionId, roomId)
+      .first();
+    if (!existing) {
+      throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Scheduled action not found", { status: 404 });
+    }
+    const action = parseScheduledActionRow(existing);
+
+    requireAuthorOrOwner(action.created_by, c.var.user.id, c.var.workspace.owner_id);
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "Request body must be JSON", {
+        status: 400,
+      });
+    }
+
+    const parsed = PatchScheduledActionRequestSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "Invalid request body", {
+        status: 400,
+        details: parsed.error.issues,
+      });
+    }
+
+    const patch = parsed.data;
+    const nowS = Math.floor(Date.now() / 1000);
+
+    // Validate cron_expr if provided
+    if (patch.cron_expr !== undefined) {
+      const cronParsed = parseCronExpr(patch.cron_expr);
+      if (!cronParsed) {
+        throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "Invalid cron expression", {
+          status: 400,
+        });
+      }
+    }
+
+    // Validate fire_at if provided
+    if (patch.fire_at !== undefined && patch.fire_at <= nowS) {
+      throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "fire_at must be in the future", {
+        status: 400,
+      });
+    }
+
+    // Compute new next_fire_at
+    let nextFire = action.next_fire_at;
+    const newStatus = patch.status ?? action.status;
+    const newCronExpr = patch.cron_expr ?? action.cron_expr;
+    const newFireAt = patch.fire_at ?? action.fire_at;
+
+    if (newStatus === "active") {
+      // On resume or when cron_expr/fire_at changes, recompute next_fire_at
+      if (
+        patch.status === "active" ||
+        patch.cron_expr !== undefined ||
+        patch.fire_at !== undefined
+      ) {
+        if (action.kind === "cron") {
+          const exprToUse = newCronExpr ?? "";
+          if (!exprToUse) {
+            throw new LoomwikiError(
+              ErrorCodes.VALIDATION_FAILED,
+              "cron_expr required for cron kind",
+              {
+                status: 400,
+              },
+            );
+          }
+          try {
+            nextFire = nextFireAt(exprToUse, nowS);
+          } catch {
+            throw new LoomwikiError(
+              ErrorCodes.VALIDATION_FAILED,
+              "Cron expression produces no valid next fire time within 4 years",
+              {
+                status: 400,
+              },
+            );
+          }
+        } else if (action.kind === "once") {
+          nextFire = newFireAt ?? action.next_fire_at;
+        }
+      }
+    }
+
+    await c.env.DB.prepare(
+      `UPDATE scheduled_actions
+       SET status = ?, cron_expr = ?, fire_at = ?, prompt = ?, next_fire_at = ?, updated_at = ?
+       WHERE id = ?`,
+    )
+      .bind(
+        newStatus,
+        newCronExpr,
+        newFireAt,
+        patch.prompt ?? action.prompt,
+        nextFire,
+        nowS,
+        actionId,
+      )
+      .run();
+
+    const updated = await c.env.DB.prepare("SELECT * FROM scheduled_actions WHERE id = ?")
+      .bind(actionId)
+      .first();
+    const updatedAction = parseScheduledActionRow(updated);
+
+    return c.json(apiOk({ action: serializeAction(updatedAction) }));
+  })
+
+  // ---------- DELETE /:roomId/scheduled-actions/:id — delete ----------
+  .delete("/:roomId/scheduled-actions/:id", async (c) => {
+    const roomId = c.req.param("roomId");
+    const actionId = c.req.param("id");
+    await requireRoomMember(c.env, c.var.user.id, c.var.workspace.id, roomId);
+
+    const existing = await c.env.DB.prepare(
+      "SELECT * FROM scheduled_actions WHERE id = ? AND room_id = ?",
+    )
+      .bind(actionId, roomId)
+      .first();
+    if (!existing) {
+      throw new LoomwikiError(ErrorCodes.NOT_FOUND, "Scheduled action not found", { status: 404 });
+    }
+    const action = parseScheduledActionRow(existing);
+
+    requireAuthorOrOwner(action.created_by, c.var.user.id, c.var.workspace.owner_id);
+
+    await c.env.DB.prepare("DELETE FROM scheduled_actions WHERE id = ?").bind(actionId).run();
+
+    return c.json(apiOk({ deleted: true }));
+  });

--- a/apps/worker/src/scheduled.ts
+++ b/apps/worker/src/scheduled.ts
@@ -16,6 +16,8 @@
 // synchronous return.
 
 import type { ExecutionContext, ScheduledController } from "@cloudflare/workers-types";
+import { parseScheduledActionRow } from "@loomwiki/schema/parsers";
+import { nextFireAt } from "@loomwiki/shared";
 import { runIngestForRoom } from "./agents/ingest-agent.js";
 import type { Env } from "./env.js";
 import { archiveDay, previousUtcDayFromScheduledTime } from "./lib/chat-log.js";
@@ -24,6 +26,7 @@ import { DEFAULT_WORKSPACE_ID } from "./lib/workspace.js";
 
 const ARCHIVE_CRON = "0 2 * * *";
 const INGEST_CRON = "0 3 * * *";
+const SCHEDULED_ACTIONS_CRON = "* * * * *";
 
 export async function scheduled(
   controller: ScheduledController,
@@ -39,6 +42,11 @@ export async function scheduled(
     case INGEST_CRON: {
       const dateUtc = utcDay(controller.scheduledTime);
       ctx.waitUntil(runIngestScan(env, dateUtc, controller.cron));
+      return;
+    }
+    case SCHEDULED_ACTIONS_CRON: {
+      const nowS = Math.floor(controller.scheduledTime / 1000);
+      ctx.waitUntil(runScheduledActionsTick(env, nowS));
       return;
     }
     default: {
@@ -179,4 +187,182 @@ async function runIngestScan(env: Env, dateUtc: string, cron: string): Promise<v
     runs_failed: runFailed,
     duration_ms: Date.now() - startedAt,
   });
+}
+
+// --------------------------------------------------------------------
+// Scheduled-actions tick (every minute)
+// --------------------------------------------------------------------
+
+/** Row shape selected from scheduled_actions for the tick handler. */
+interface ScheduledActionTickRow {
+  id: string;
+  room_id: string;
+  created_by: string;
+  kind: string;
+  cron_expr: string | null;
+  prompt: string;
+  failure_count: number;
+  next_fire_at: number;
+}
+
+/**
+ * Every-minute tick: claim and fire all scheduled_actions whose
+ * next_fire_at <= nowS and status = 'active'.
+ *
+ * Optimistic-claim pattern:
+ *   1. Push next_fire_at 1 hour forward BEFORE calling the DO (prevents
+ *      double-fire even if the Worker is retried).
+ *   2. Call the ChatRoom DO's /_sys/message endpoint.
+ *   3. On success: compute real next_fire_at (cron) or mark fired (once).
+ *   4. On failure: increment failure_count, set status='failed' if >= 3,
+ *      else set next_fire_at = nowS + 60 (retry in 1 min).
+ */
+export async function runScheduledActionsTick(env: Env, nowS: number): Promise<void> {
+  // Claim: atomically push next_fire_at forward for all eligible rows.
+  // The WHERE guard (next_fire_at <= nowS AND status = 'active') is the
+  // claimant check — two concurrent ticks would both try to claim, but
+  // only the first write wins due to the next_fire_at push; the second
+  // worker's WHERE condition fails and it claims nothing.
+  //
+  // We use a two-step SELECT then UPDATE-per-row rather than a single
+  // RETURNING because D1 has limited RETURNING support across versions.
+  const claimed = await env.DB.prepare(
+    `SELECT id, room_id, created_by, kind, cron_expr, prompt, failure_count, next_fire_at
+     FROM scheduled_actions
+     WHERE next_fire_at <= ? AND status = 'active'
+     ORDER BY next_fire_at ASC
+     LIMIT 50`,
+  )
+    .bind(nowS)
+    .all<ScheduledActionTickRow>();
+
+  if (!claimed.results || claimed.results.length === 0) return;
+
+  const rows = claimed.results as ScheduledActionTickRow[];
+
+  for (const row of rows) {
+    await claimAndFire(env, row, nowS);
+  }
+
+  console.log({
+    event: "scheduled_actions_tick_complete",
+    fired: rows.length,
+    now_s: nowS,
+  });
+}
+
+async function claimAndFire(env: Env, row: ScheduledActionTickRow, nowS: number): Promise<void> {
+  // Optimistic claim: push next_fire_at 1 hour forward to prevent double-fire.
+  // Only succeeds if the row is still in the state we expect (status='active',
+  // next_fire_at unchanged since we read it).
+  const claim = await env.DB.prepare(
+    `UPDATE scheduled_actions
+     SET next_fire_at = ?, updated_at = ?
+     WHERE id = ? AND status = 'active' AND next_fire_at = ?`,
+  )
+    .bind(nowS + 3600, nowS, row.id, row.next_fire_at)
+    .run();
+
+  // If no row was updated, another tick already claimed this row — skip.
+  if (!claim.meta.changes || claim.meta.changes === 0) return;
+
+  try {
+    // Call the ChatRoom DO's /_sys/message endpoint.
+    const stubId = env.CHAT_ROOM.idFromName(row.room_id);
+    const stub = env.CHAT_ROOM.get(stubId);
+
+    // Post as the action creator — this is a valid user in D1 (the
+    // scheduled_actions.created_by FK guarantees it), so the D1 mirror
+    // will not fail on a foreign-key constraint.
+    // TODO(Q-sched-8): consider a dedicated "system" user concept for
+    // clearly marking automated messages in the UI.
+    const sysUserId = row.created_by;
+
+    const doRes = await stub.fetch(
+      new Request(`https://do-internal/${row.room_id}/_sys/message`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-loomwiki-sys": "1",
+        },
+        body: JSON.stringify({
+          userId: sysUserId,
+          roomId: row.room_id,
+          body: row.prompt,
+          parentId: null,
+        }),
+      }),
+    );
+
+    if (!doRes.ok) {
+      throw new Error(`DO returned ${doRes.status}`);
+    }
+
+    // Success: update to real next state.
+    const updatedAt = Math.floor(Date.now() / 1000);
+    if (row.kind === "cron" && row.cron_expr) {
+      let realNextFire: number;
+      try {
+        realNextFire = nextFireAt(row.cron_expr, nowS);
+      } catch {
+        // Cron expression broken; mark failed.
+        await env.DB.prepare(
+          `UPDATE scheduled_actions
+           SET status = 'failed', failure_count = failure_count + 1, last_fired_at = ?,
+               updated_at = ?
+           WHERE id = ?`,
+        )
+          .bind(updatedAt, updatedAt, row.id)
+          .run();
+        return;
+      }
+      await env.DB.prepare(
+        `UPDATE scheduled_actions
+         SET status = 'active', last_fired_at = ?, next_fire_at = ?, failure_count = 0,
+             updated_at = ?
+         WHERE id = ?`,
+      )
+        .bind(updatedAt, realNextFire, updatedAt, row.id)
+        .run();
+    } else {
+      // kind = 'once': mark fired
+      await env.DB.prepare(
+        `UPDATE scheduled_actions
+         SET status = 'fired', last_fired_at = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+        .bind(updatedAt, updatedAt, row.id)
+        .run();
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn({
+      event: "scheduled_action_fire_failed",
+      action_id: row.id,
+      room_id: row.room_id,
+      error: message,
+    });
+
+    const updatedAt = Math.floor(Date.now() / 1000);
+    const newFailureCount = (row.failure_count ?? 0) + 1;
+    if (newFailureCount >= 3) {
+      // Too many failures: mark permanently failed.
+      await env.DB.prepare(
+        `UPDATE scheduled_actions
+         SET status = 'failed', failure_count = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+        .bind(newFailureCount, updatedAt, row.id)
+        .run();
+    } else {
+      // Retry in 1 minute.
+      await env.DB.prepare(
+        `UPDATE scheduled_actions
+         SET status = 'active', failure_count = ?, next_fire_at = ?, updated_at = ?
+         WHERE id = ?`,
+      )
+        .bind(newFailureCount, nowS + 60, updatedAt, row.id)
+        .run();
+    }
+  }
 }

--- a/packages/schema/d1-migrations/0005_scheduled_actions.sql
+++ b/packages/schema/d1-migrations/0005_scheduled_actions.sql
@@ -1,0 +1,31 @@
+-- SPDX-License-Identifier: Apache-2.0
+--
+-- Scheduled actions: user-defined cron/once prompts that fire into a ChatRoom.
+-- Forward-only. See issue #33.
+
+CREATE TABLE IF NOT EXISTS scheduled_actions (
+  id             TEXT PRIMARY KEY,            -- UUIDv7
+  workspace_id   TEXT NOT NULL REFERENCES workspaces(id),
+  room_id        TEXT NOT NULL REFERENCES rooms(id),
+  created_by     TEXT NOT NULL REFERENCES users(id),
+  kind           TEXT NOT NULL CHECK(kind IN ('cron','once')),
+  cron_expr      TEXT,                        -- non-null when kind='cron'
+  fire_at        INTEGER,                     -- epoch s, non-null when kind='once'
+  prompt         TEXT NOT NULL,
+  status         TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active','paused','fired','failed')),
+  failure_count  INTEGER NOT NULL DEFAULT 0,
+  last_fired_at  INTEGER,
+  next_fire_at   INTEGER NOT NULL,            -- epoch s, indexed
+  created_at     INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at     INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_actions_tick
+  ON scheduled_actions(next_fire_at)
+  WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_actions_room
+  ON scheduled_actions(room_id, status);
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_actions_workspace
+  ON scheduled_actions(workspace_id, status);

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -600,3 +600,58 @@ export type AuditLogRow = z.infer<typeof AuditLogRowSchema>;
 // without changing the on-disk row schema.
 export const AuditLogEntrySchema = AuditLogRowSchema;
 export type AuditLogEntry = z.infer<typeof AuditLogEntrySchema>;
+
+// ---------- Scheduled actions (issue #33) ----------
+
+export const ScheduledActionKindSchema = z.enum(["cron", "once"]);
+export type ScheduledActionKind = z.infer<typeof ScheduledActionKindSchema>;
+
+export const ScheduledActionStatusSchema = z.enum(["active", "paused", "fired", "failed"]);
+export type ScheduledActionStatus = z.infer<typeof ScheduledActionStatusSchema>;
+
+export const ScheduledActionRowSchema = z.object({
+  id: Uuidv7Schema,
+  workspace_id: Uuidv7Schema,
+  room_id: Uuidv7Schema,
+  created_by: Uuidv7Schema,
+  kind: ScheduledActionKindSchema,
+  cron_expr: z.string().nullable(),
+  fire_at: EpochSeconds.nullable(),
+  prompt: z.string().min(1).max(4096),
+  status: ScheduledActionStatusSchema,
+  failure_count: z.number().int().nonnegative(),
+  last_fired_at: EpochSeconds.nullable(),
+  next_fire_at: EpochSeconds,
+  created_at: EpochSeconds,
+  updated_at: EpochSeconds,
+});
+export type ScheduledActionRow = z.infer<typeof ScheduledActionRowSchema>;
+
+// Validated at create-time: either {kind:'cron', cron_expr} or {kind:'once', fire_at}
+export const CreateScheduledActionRequestSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("cron"),
+    cron_expr: z.string().min(9).max(100),
+    prompt: z.string().min(1).max(4096),
+    description: z.string().max(200).optional(),
+  }),
+  z.object({
+    kind: z.literal("once"),
+    fire_at: EpochSeconds,
+    prompt: z.string().min(1).max(4096),
+    description: z.string().max(200).optional(),
+  }),
+]);
+export type CreateScheduledActionRequest = z.infer<typeof CreateScheduledActionRequestSchema>;
+
+export const PatchScheduledActionRequestSchema = z
+  .object({
+    status: z.enum(["active", "paused"]).optional(),
+    cron_expr: z.string().min(9).max(100).optional(),
+    fire_at: EpochSeconds.optional(),
+    prompt: z.string().min(1).max(4096).optional(),
+  })
+  .refine((o) => Object.values(o).some((v) => v !== undefined), {
+    message: "at least one field required",
+  });
+export type PatchScheduledActionRequest = z.infer<typeof PatchScheduledActionRequestSchema>;

--- a/packages/schema/src/parsers.ts
+++ b/packages/schema/src/parsers.ts
@@ -17,6 +17,7 @@ import {
   ProposalRowSchema,
   RoomMemberRowSchema,
   RoomRowSchema,
+  ScheduledActionRowSchema,
   UserRowSchema,
   type WikiPageFrontmatter,
   WikiPageFrontmatterSchema,
@@ -48,6 +49,8 @@ export const parseProposalRow = (row: unknown) => parseRow(ProposalRowSchema, ro
 export const parseAuditLogRow = (row: unknown) => parseRow(AuditLogRowSchema, row, "audit_log");
 export const parseWorkspaceSettingsRow = (row: unknown) =>
   parseRow(WorkspaceSettingsRowSchema, row, "workspace_settings");
+export const parseScheduledActionRow = (row: unknown) =>
+  parseRow(ScheduledActionRowSchema, row, "scheduled_actions");
 
 /**
  * Parse a Zod-validated wiki frontmatter object. Caller hands in an
@@ -98,6 +101,9 @@ export type {
   Room,
   RoomMember,
   RoomMemberRole,
+  ScheduledActionKind,
+  ScheduledActionRow,
+  ScheduledActionStatus,
   SearchReindexError,
   SearchReindexResponse,
   User,

--- a/packages/shared/src/__tests__/cron-parser.test.ts
+++ b/packages/shared/src/__tests__/cron-parser.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the pure-TS cron parser in packages/shared/src/cron.ts.
+
+import { describe, expect, it } from "vitest";
+import { nextFireAt, parseCronExpr } from "../cron.js";
+
+// Epoch seconds for a known UTC time: 2024-01-01T00:00:00Z
+const JAN_1_2024 = Math.floor(Date.parse("2024-01-01T00:00:00Z") / 1000);
+// 2024-02-28T23:59:00Z — just before Feb 29 in a leap year
+const FEB_28_2024_NIGHT = Math.floor(Date.parse("2024-02-28T23:59:00Z") / 1000);
+// Monday 2026-01-05T08:00:00Z
+const MON_JAN_5_2026 = Math.floor(Date.parse("2026-01-05T08:00:00Z") / 1000);
+
+describe("parseCronExpr", () => {
+  it("parses a minimal valid expression (every minute)", () => {
+    const parsed = parseCronExpr("* * * * *");
+    expect(parsed).not.toBeNull();
+    expect(parsed?.minutes).toHaveLength(60);
+    expect(parsed?.hours).toHaveLength(24);
+    expect(parsed?.doms).toHaveLength(31);
+    expect(parsed?.months).toHaveLength(12);
+    expect(parsed?.dows).toHaveLength(7);
+  });
+
+  it("returns null for wrong field count", () => {
+    expect(parseCronExpr("* * * *")).toBeNull();
+    expect(parseCronExpr("* * * * * *")).toBeNull();
+    expect(parseCronExpr("")).toBeNull();
+  });
+
+  it("returns null for out-of-range values", () => {
+    expect(parseCronExpr("60 * * * *")).toBeNull(); // minute > 59
+    expect(parseCronExpr("* 24 * * *")).toBeNull(); // hour > 23
+    expect(parseCronExpr("* * 0 * *")).toBeNull(); // dom < 1
+    expect(parseCronExpr("* * * 0 *")).toBeNull(); // month < 1
+    expect(parseCronExpr("* * * * 7")).toBeNull(); // dow > 6
+  });
+
+  it("parses exact single values", () => {
+    const parsed = parseCronExpr("5 3 15 6 2");
+    expect(parsed).not.toBeNull();
+    expect(parsed?.minutes).toEqual([5]);
+    expect(parsed?.hours).toEqual([3]);
+    expect(parsed?.doms).toEqual([15]);
+    expect(parsed?.months).toEqual([6]);
+    expect(parsed?.dows).toEqual([2]);
+  });
+
+  it("parses step expressions (*/N)", () => {
+    const parsed = parseCronExpr("*/15 */6 * * *");
+    expect(parsed?.minutes).toEqual([0, 15, 30, 45]);
+    expect(parsed?.hours).toEqual([0, 6, 12, 18]);
+  });
+
+  it("parses comma lists", () => {
+    const parsed = parseCronExpr("1,3,5 * * * *");
+    expect(parsed?.minutes).toEqual([1, 3, 5]);
+  });
+
+  it("parses ranges", () => {
+    const parsed = parseCronExpr("0-5 * * * *");
+    expect(parsed?.minutes).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it("parses combined range-and-list", () => {
+    const parsed = parseCronExpr("1-3,7 * * * *");
+    expect(parsed?.minutes).toEqual([1, 2, 3, 7]);
+  });
+
+  it("parses range-with-step", () => {
+    const parsed = parseCronExpr("0-30/10 * * * *");
+    expect(parsed?.minutes).toEqual([0, 10, 20, 30]);
+  });
+
+  it("returns null for an invalid step value of 0", () => {
+    expect(parseCronExpr("*/0 * * * *")).toBeNull();
+  });
+});
+
+describe("nextFireAt", () => {
+  it("returns the next whole minute for '* * * * *'", () => {
+    // fromEpochS = 00:00:30 on Jan 1; next minute is 00:01:00
+    const from = JAN_1_2024 + 30; // 30 seconds into the first minute
+    const next = nextFireAt("* * * * *", from);
+    // Should be the next whole minute
+    expect(next % 60).toBe(0);
+    expect(next).toBeGreaterThan(from);
+  });
+
+  it("fires on a specific minute/hour", () => {
+    // "0 9 * * *" — every day at 09:00 UTC
+    const from = JAN_1_2024; // 2024-01-01T00:00:00Z
+    const next = nextFireAt("0 9 * * *", from);
+    const d = new Date(next * 1000);
+    expect(d.getUTCHours()).toBe(9);
+    expect(d.getUTCMinutes()).toBe(0);
+    expect(d.getUTCFullYear()).toBe(2024);
+    expect(d.getUTCMonth()).toBe(0); // January
+    expect(d.getUTCDate()).toBe(1);
+  });
+
+  it("skips past midnight when no matching minute in current hour", () => {
+    // "0 0 * * *" — midnight; from = Jan 1 00:01:00
+    const from = JAN_1_2024 + 60; // 00:01:00
+    const next = nextFireAt("0 0 * * *", from);
+    const d = new Date(next * 1000);
+    // Should fire on Jan 2 at 00:00
+    expect(d.getUTCDate()).toBe(2);
+    expect(d.getUTCHours()).toBe(0);
+    expect(d.getUTCMinutes()).toBe(0);
+  });
+
+  it("handles leap day: fires on 2024-02-29", () => {
+    // "0 0 29 2 *" — midnight Feb 29
+    const next = nextFireAt("0 0 29 2 *", FEB_28_2024_NIGHT);
+    const d = new Date(next * 1000);
+    expect(d.getUTCFullYear()).toBe(2024);
+    expect(d.getUTCMonth()).toBe(1); // February (0-indexed)
+    expect(d.getUTCDate()).toBe(29);
+    expect(d.getUTCHours()).toBe(0);
+    expect(d.getUTCMinutes()).toBe(0);
+  });
+
+  it("fires on matching day-of-week", () => {
+    // "0 9 * * 1" — Mondays at 09:00; from = Mon Jan 5 2026 08:00
+    const next = nextFireAt("0 9 * * 1", MON_JAN_5_2026);
+    const d = new Date(next * 1000);
+    expect(d.getUTCDay()).toBe(1); // Monday
+    expect(d.getUTCHours()).toBe(9);
+    expect(d.getUTCMinutes()).toBe(0);
+  });
+
+  it("skips to next matching month", () => {
+    // "0 0 1 6 *" — June 1 at midnight
+    const from = JAN_1_2024;
+    const next = nextFireAt("0 0 1 6 *", from);
+    const d = new Date(next * 1000);
+    expect(d.getUTCMonth()).toBe(5); // June
+    expect(d.getUTCDate()).toBe(1);
+    expect(d.getUTCHours()).toBe(0);
+  });
+
+  it("throws for an invalid expression", () => {
+    expect(() => nextFireAt("not valid", JAN_1_2024)).toThrow();
+  });
+
+  it("throws if no match within 4 years (impossible schedule)", () => {
+    // "0 0 31 2 *" — Feb 31 never exists
+    expect(() => nextFireAt("0 0 31 2 *", JAN_1_2024)).toThrow(/4 years/);
+  });
+
+  it("handles step expressions correctly across hours", () => {
+    // "*/30 * * * *" — every 30 minutes
+    const from = JAN_1_2024 + 15 * 60; // 00:15:00
+    const next = nextFireAt("*/30 * * * *", from);
+    const d = new Date(next * 1000);
+    expect(d.getUTCMinutes()).toBe(30);
+    expect(d.getUTCHours()).toBe(0);
+  });
+
+  it("each call to nextFireAt returns a time strictly after fromEpochS", () => {
+    const from = JAN_1_2024;
+    const next = nextFireAt("* * * * *", from);
+    expect(next).toBeGreaterThan(from);
+  });
+
+  it("handles comma-list minutes", () => {
+    // "15,45 * * * *"
+    const from = JAN_1_2024 + 10 * 60; // 00:10:00
+    const next = nextFireAt("15,45 * * * *", from);
+    const d = new Date(next * 1000);
+    expect(d.getUTCMinutes()).toBe(15);
+  });
+
+  it("UTC only — no DST shift", () => {
+    // "0 2 * * *" — 02:00 UTC daily; DST-affected timezones shift their
+    // clocks but UTC does not. The result must always be 02:00 UTC.
+    const from = JAN_1_2024;
+    for (let i = 0; i < 7; i++) {
+      const advancedFrom = from + i * 86400;
+      const next = nextFireAt("0 2 * * *", advancedFrom);
+      const d = new Date(next * 1000);
+      expect(d.getUTCHours()).toBe(2);
+      expect(d.getUTCMinutes()).toBe(0);
+    }
+  });
+});

--- a/packages/shared/src/cron.ts
+++ b/packages/shared/src/cron.ts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Pure-TS five-field POSIX cron parser (no deps, no Node APIs).
+//
+// Fields: minute hour dom month dow
+//   minute : 0-59
+//   hour   : 0-23
+//   dom    : 1-31
+//   month  : 1-12
+//   dow    : 0-6  (Sunday=0)
+//
+// Supported syntax per field:
+//   *        any value
+//   */N      every N (step)
+//   5        exact value
+//   1,3,5    comma list
+//   1-5      range (inclusive)
+//   1-5,7    combination
+//
+// All computations are in UTC (no DST). Cap: 4 years (~2,102,400 minutes).
+
+export interface ParsedCron {
+  minutes: number[]; // sorted
+  hours: number[];
+  doms: number[];
+  months: number[];
+  dows: number[];
+}
+
+// ---------------------------------------------------------------------------
+// Field parsing helpers
+// ---------------------------------------------------------------------------
+
+function parseRange(s: string, min: number, max: number): number[] | null {
+  // Single value
+  if (/^\d+$/.test(s)) {
+    const n = Number(s);
+    if (n < min || n > max) return null;
+    return [n];
+  }
+  // Range: a-b
+  const rangeMatch = /^(\d+)-(\d+)$/.exec(s);
+  if (rangeMatch) {
+    const a = Number(rangeMatch[1]);
+    const b = Number(rangeMatch[2]);
+    if (a < min || b > max || a > b) return null;
+    const result: number[] = [];
+    for (let i = a; i <= b; i++) result.push(i);
+    return result;
+  }
+  return null;
+}
+
+function parseField(field: string, min: number, max: number): number[] | null {
+  // "*" — every value
+  if (field === "*") {
+    const all: number[] = [];
+    for (let i = min; i <= max; i++) all.push(i);
+    return all;
+  }
+
+  // "*/N" — every-N step
+  const stepStarMatch = /^\*\/(\d+)$/.exec(field);
+  if (stepStarMatch) {
+    const step = Number(stepStarMatch[1]);
+    if (step <= 0) return null;
+    const result: number[] = [];
+    for (let i = min; i <= max; i += step) result.push(i);
+    return result;
+  }
+
+  // "a-b/N" — range with step
+  const stepRangeMatch = /^(\d+)-(\d+)\/(\d+)$/.exec(field);
+  if (stepRangeMatch) {
+    const a = Number(stepRangeMatch[1]);
+    const b = Number(stepRangeMatch[2]);
+    const step = Number(stepRangeMatch[3]);
+    if (a < min || b > max || a > b || step <= 0) return null;
+    const result: number[] = [];
+    for (let i = a; i <= b; i += step) result.push(i);
+    return result;
+  }
+
+  // Comma-separated list (each part may be a range or a single value)
+  const parts = field.split(",");
+  if (parts.length > 1 || (parts.length === 1 && !field.includes("-") && /^\d+$/.test(field))) {
+    const result: number[] = [];
+    for (const part of parts) {
+      const parsed = parseRange(part.trim(), min, max);
+      if (!parsed) return null;
+      for (const v of parsed) {
+        if (!result.includes(v)) result.push(v);
+      }
+    }
+    result.sort((a, b) => a - b);
+    return result;
+  }
+
+  // Single range a-b (already handled above in parseRange but let's route through)
+  return parseRange(field, min, max);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a five-field cron expression.
+ * Returns `null` if the expression is syntactically invalid.
+ */
+export function parseCronExpr(expr: string): ParsedCron | null {
+  const fields = expr.trim().split(/\s+/);
+  if (fields.length !== 5) return null;
+
+  const [minuteF, hourF, domF, monthF, dowF] = fields as [string, string, string, string, string];
+
+  const minutes = parseField(minuteF, 0, 59);
+  if (!minutes || minutes.length === 0) return null;
+
+  const hours = parseField(hourF, 0, 23);
+  if (!hours || hours.length === 0) return null;
+
+  const doms = parseField(domF, 1, 31);
+  if (!doms || doms.length === 0) return null;
+
+  const months = parseField(monthF, 1, 12);
+  if (!months || months.length === 0) return null;
+
+  const dows = parseField(dowF, 0, 6);
+  if (!dows || dows.length === 0) return null;
+
+  return { minutes, hours, doms, months, dows };
+}
+
+// ---------------------------------------------------------------------------
+// Next-fire computation
+// ---------------------------------------------------------------------------
+
+// Maximum search window: 4 years in seconds (leap-day safe).
+const MAX_SEARCH_S = 4 * 366 * 24 * 60 * 60;
+
+/**
+ * Return the next epoch second (> `fromEpochS`) when `expr` fires.
+ * All computation is UTC. Throws on invalid expr or if no match is found
+ * within 4 years.
+ */
+export function nextFireAt(expr: string, fromEpochS: number): number {
+  const parsed = parseCronExpr(expr);
+  if (!parsed) throw new Error(`Invalid cron expression: ${expr}`);
+
+  const { minutes, hours, doms, months, dows } = parsed;
+
+  // Start from the next whole minute (fromEpochS is exclusive).
+  const startMs = (Math.floor(fromEpochS) + 60) * 1000;
+  const limitMs = (fromEpochS + MAX_SEARCH_S) * 1000;
+
+  // Align to the start of the minute
+  let tMs = Math.floor(startMs / 60_000) * 60_000;
+
+  while (tMs <= limitMs) {
+    const d = new Date(tMs);
+    const month = d.getUTCMonth() + 1; // 1-12
+    const dom = d.getUTCDate(); // 1-31
+    const dow = d.getUTCDay(); // 0-6 Sunday=0
+    const hour = d.getUTCHours();
+    const minute = d.getUTCMinutes();
+
+    if (!months.includes(month)) {
+      // Skip to the 1st of next month
+      const nextMonth = month === 12 ? 1 : month + 1;
+      const nextYear = month === 12 ? d.getUTCFullYear() + 1 : d.getUTCFullYear();
+      tMs = Date.UTC(nextYear, nextMonth - 1, 1, 0, 0, 0, 0);
+      continue;
+    }
+
+    if (!doms.includes(dom) || !dows.includes(dow)) {
+      // Skip to next day
+      tMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), dom + 1, 0, 0, 0, 0);
+      continue;
+    }
+
+    if (!hours.includes(hour)) {
+      // Skip to next matching hour today
+      const nextHour = hours.find((h) => h > hour);
+      if (nextHour !== undefined) {
+        tMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), dom, nextHour, 0, 0, 0);
+      } else {
+        // No matching hour today — advance to next day
+        tMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), dom + 1, 0, 0, 0, 0);
+      }
+      continue;
+    }
+
+    if (!minutes.includes(minute)) {
+      // Skip to next matching minute in this hour
+      const nextMin = minutes.find((m) => m > minute);
+      if (nextMin !== undefined) {
+        tMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), dom, hour, nextMin, 0, 0);
+      } else {
+        // No matching minute in this hour — advance to next hour
+        tMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), dom, hour + 1, 0, 0, 0);
+      }
+      continue;
+    }
+
+    // All fields match!
+    return Math.floor(tMs / 1000);
+  }
+
+  throw new Error(`No cron match found within 4 years for: ${expr}`);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -20,3 +20,4 @@ export {
   createMarkdownAstParser,
 } from "./markdown-sanitize.js";
 export { chunkPageBySection, slugifyHeading, type WikiChunk } from "./markdown-chunk.js";
+export { parseCronExpr, nextFireAt, type ParsedCron } from "./cron.js";

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -154,6 +154,6 @@
     // lands so the same day's chat is fully reflected in /rooms/* before
     // the agent runs. Both crons dispatch through scheduled() in
     // apps/worker/src/scheduled.ts via controller.cron switch.
-    "crons": ["0 2 * * *", "0 3 * * *"]
+    "crons": ["0 2 * * *", "0 3 * * *", "* * * * *"]
   }
 }


### PR DESCRIPTION
## Summary

- Adds `scheduled_actions` D1 table (migration `0005_scheduled_actions.sql`) with indexes on `next_fire_at` for efficient tick queries
- Implements a pure-TS 5-field POSIX cron parser (`packages/shared/src/cron.ts`) with no new dependencies — supports `*`, `*/N`, ranges, comma lists
- REST CRUD at `/api/rooms/:roomId/scheduled-actions` (POST / GET / PATCH / DELETE) with soft quotas (50 active/workspace, 10 active/room) and author-or-owner authorization
- Adds `/_sys/message` internal POST endpoint to the ChatRoom DO for system-authored message injection
- Every-minute cron tick handler (`runScheduledActionsTick`) with optimistic-claim double-fire prevention, failure tracking (increments `failure_count`, sets `status=failed` after 3 failures)
- Basic settings UI at `/settings/schedules` with room selector, action list (pause/resume, delete), and create form (cron / once-at)
- 27 new tests: 22 cron-parser unit tests, 21 route integration tests, 6 tick-handler integration tests

## SPEC §20 assumptions

| Q | Decision |
|---|---------|
| Q-sched-1 | Every-minute tick via `* * * * *` cron trigger |
| Q-sched-2 | Pure-TS parser, no new npm deps (cronstrue / cron-parser not added) |
| Q-sched-4 | Soft quotas: 50 active/workspace, 10 active/room |
| Q-sched-6 | `created_by` or workspace owner may pause/edit/delete |
| Q-sched-7 | `next_fire_at` preserved on pause; recomputed from `now` on resume |

## Test plan

- [ ] `pnpm test --filter @loomwiki/shared` — 54 tests pass (32 original + 22 cron-parser)
- [ ] `pnpm test --filter @loomwiki/worker` — routes-scheduled-actions (21) and scheduled-actions-tick (6) tests pass
- [ ] `pnpm typecheck` — zero errors
- [ ] `pnpm lint` — zero errors (5 pre-existing warnings in unrelated test files)
- [ ] Manual: create a `* * * * *` cron action in `/settings/schedules`, wait one minute, verify message appears in room
- [ ] Manual: create a `once` action 2 minutes in the future, verify it fires and status transitions to `fired`

Closes #33

https://claude.ai/code/session_01Tf7m5ctq2qUCEPzjmDGSBp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tf7m5ctq2qUCEPzjmDGSBp)_