### PR TITLE
fix(web): pass isOwner to AppShell on all non-settings pages

### DIFF
--- a/apps/web/src/pages/ask.astro
+++ b/apps/web/src/pages/ask.astro
@@ -18,10 +18,12 @@ try {
   if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
   throw err;
 }
+
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Ask — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <div slot="sidebar" class="p-4 text-xs text-muted-foreground">
       <p class="font-medium text-foreground">Ask</p>
       <p class="mt-1">Answers grounded in your wiki, with citations.</p>

--- a/apps/web/src/pages/inbox/index.astro
+++ b/apps/web/src/pages/inbox/index.astro
@@ -26,10 +26,11 @@ try {
 
 const today = new Date().toISOString().slice(0, 10);
 const digestHref = `/w/_inbox/${today}.md`;
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Inbox — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/inbox/proposals/[id].astro
+++ b/apps/web/src/pages/inbox/proposals/[id].astro
@@ -41,6 +41,7 @@ try {
   throw err;
 }
 
+const isOwner = me.workspace.owner_id === me.user.id;
 let currentPage: WikiPagePayload | null = null;
 if (detail.proposal.action === "update") {
   try {
@@ -58,7 +59,7 @@ if (detail.proposal.action === "update") {
 ---
 
 <Layout title={`Proposal — ${detail.proposal.page_path}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/index.astro
+++ b/apps/web/src/pages/index.astro
@@ -20,10 +20,12 @@ try {
   }
   throw err;
 }
+
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Loomwiki — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/r/[slug].astro
+++ b/apps/web/src/pages/r/[slug].astro
@@ -26,10 +26,11 @@ try {
 }
 
 const room = me.rooms.find((r) => r.slug === slug);
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={room ? `#${room.slug} — ${me.workspace.name}` : "Room not found"}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <RoomList
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/search.astro
+++ b/apps/web/src/pages/search.astro
@@ -17,10 +17,12 @@ try {
   if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
   throw err;
 }
+
+const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Search — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <div slot="sidebar" class="p-4 text-xs text-muted-foreground">
       Search across the wiki. Use the sidebar nav to switch surfaces.
     </div>

--- a/apps/web/src/pages/w/[...path].astro
+++ b/apps/web/src/pages/w/[...path].astro
@@ -88,7 +88,7 @@ const draft: WikiPagePayload | null =
 ---
 
 <Layout title={page ? `${page.frontmatter.title} — ${me.workspace.name}` : "Wiki page not found"}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <WikiTree
       slot="sidebar"
       client:idle

--- a/apps/web/src/pages/w/index.astro
+++ b/apps/web/src/pages/w/index.astro
@@ -43,7 +43,7 @@ const isOwner = me.workspace.owner_id === me.user.id;
 ---
 
 <Layout title={`Wiki — ${me.workspace.name}`}>
-  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name}>
+  <AppShell workspaceName={me.workspace.name} userDisplayName={me.user.display_name} isOwner={isOwner}>
     <WikiTree
       slot="sidebar"
       client:idle


### PR DESCRIPTION
## Summary

- Settings tab was hidden for workspace owners on every page outside `/settings/*` because those pages omitted the `isOwner` prop on `<AppShell>`, leaving it at the safe default (`false`)
- Added `const isOwner = me.workspace.owner_id === me.user.id;` in frontmatter and `isOwner={isOwner}` on `<AppShell>` for all 8 affected pages
- Two wiki pages (`w/index.astro`, `w/[...path].astro`) already computed `isOwner` for in-page logic but forgot to forward it to the shell — those now thread it through too

Closes #28

## Test plan

- [x] `pnpm --filter @loomwiki/web typecheck` — 0 errors
- [x] `pnpm --filter @loomwiki/web test --run` — 26 test files, 138 tests passing
- [x] `pnpm lint` — 0 errors (5 pre-existing warnings in unrelated test files)
- [ ] Manual: log in as workspace owner → Settings tab visible on `/`, `/ask`, `/search`, `/r/{slug}`, `/inbox`, `/inbox/proposals/{id}`, `/w`, `/w/{path}`
- [ ] Manual: log in as non-owner → Settings tab absent on all those pages
- [ ] No change to `/settings/*` pages (they already passed the prop)

## Acceptance deferred

None — all 8 pages from the issue's Pointers list are covered.

https://claude.ai/code/session_01RT2uAey5fD7mB3pv8EozAR

---
_Generated by [Claude Code](https://claude.ai/code/session_01RT2uAey5fD7mB3pv8EozAR)_