### PR TITLE
chore: add project .claude config — permission allowlist + Cloudflare convention guard

### DIFF
--- a/.claude/hooks/check-cloudflare-conventions.sh
+++ b/.claude/hooks/check-cloudflare-conventions.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# PreToolUse guard: blocks the two Cloudflare DO regressions CLAUDE.md warns
+# about in prose ("regressed twice" failure mode) before they ever land in a
+# file. Exit 2 = block; stderr is fed back to Claude so it can self-correct.
+#
+# Guards (see CLAUDE.md > Cloudflare conventions):
+#   1. Legacy WS pattern   — ws.addEventListener('message'|'close', ...) in
+#      worker code. Must use the Hibernation API instead.
+#   2. Legacy DO storage   — ctx/state/this.storage.{put,get,delete,list}().
+#      Must use ctx.storage.sql (SQLite) instead.
+#
+# This is intentionally narrow: it only fires on .ts/.tsx writes, scopes the
+# WS check to apps/worker, and matches `.storage.` (not `.put(` broadly) so
+# KV (env.CACHE) and R2 (env.ATTACHMENTS) calls are never false-positived.
+
+# jq is required to parse the hook payload. If it's missing, degrade to a
+# no-op (non-blocking) rather than spewing "jq: command not found" on every
+# Edit/Write — a contributor without jq shouldn't be stonewalled by a guard.
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat)
+
+tool=$(printf '%s' "$input" | jq -r '.tool_name // ""')
+case "$tool" in
+  Edit | Write | MultiEdit) ;;
+  *) exit 0 ;;
+esac
+
+path=$(printf '%s' "$input" | jq -r '.tool_input.file_path // ""')
+case "$path" in
+  *.ts | *.tsx) ;;
+  *) exit 0 ;;
+esac
+
+# Test code legitimately uses the patterns this hook forbids: WS *client*
+# fixtures call ws.addEventListener (the Hibernation rule is about the DO
+# *server*), and tests may stub storage. Skip them.
+case "$path" in
+  *__tests__* | *__fixtures__* | *.test.ts | *.test.tsx | *.spec.ts | *.spec.tsx) exit 0 ;;
+esac
+
+# New content across Write (.content), Edit (.new_string), MultiEdit (.edits[]).
+content=$(printf '%s' "$input" | jq -r '
+  [ .tool_input.content?,
+    .tool_input.new_string?,
+    ( .tool_input.edits[]?.new_string? )
+  ] | map(select(. != null)) | join("\n")')
+
+violations=""
+
+case "$path" in
+  *apps/worker*)
+    if printf '%s' "$content" | grep -qE '\.addEventListener\(\s*["'\''](message|close)["'\'']'; then
+      violations="${violations}
+- Legacy WebSocket pattern: use the Hibernation API (ctx.acceptWebSocket(ws) + webSocketMessage() + webSocketClose()), not ws.addEventListener. See CLAUDE.md > Cloudflare conventions."
+    fi
+    ;;
+esac
+
+if printf '%s' "$content" | grep -qE '\.storage\.(put|get|delete|deleteAll|list)\('; then
+  violations="${violations}
+- Legacy Durable Object storage API: use ctx.storage.sql (SQLite-backed), not ctx.storage.put/get. See CLAUDE.md > Cloudflare conventions."
+fi
+
+if [ -n "$violations" ]; then
+  printf 'Blocked: Cloudflare convention violation in %s%s\n' "$path" "$violations" >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm lint)",
+      "Bash(pnpm typecheck)",
+      "Bash(pnpm test)",
+      "Bash(pnpm test --filter *)",
+      "mcp__ccd_session_mgmt__search_session_transcripts"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/check-cloudflare-conventions.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/biome.json
+++ b/biome.json
@@ -14,6 +14,7 @@
       "**/.astro",
       "**/.wrangler",
       "**/coverage",
+      "**/.claude/**",
       "pnpm-lock.yaml",
       "**/*.md",
       "apps/worker/src/generated/**",


### PR DESCRIPTION
## What

From an audit against [Anthropic's large-codebase guidance](https://claude.com/blog/how-claude-code-works-in-large-codebases-best-practices-and-where-to-start): loomwiki is **not** a large codebase (~30k LOC, 4 packages), so the heavyweight machinery (subdir CLAUDE.md trees, codebase maps, org LSP, DRIs) is intentionally skipped. This PR adds only the two cheap, size-independent practices we were missing.

- **`.claude/settings.json` — read-only permission allowlist.** `pnpm lint/typecheck/test`, scoped `pnpm test --filter *`, and `mcp__ccd_session_mgmt__search_session_transcripts`. Derived from a frequency scan of the 50 most recent session transcripts; deliberately excludes anything mutating or arbitrary-exec (bare `pnpm`, `npx`, `pnpm exec`, `gc *`).
- **`.claude/hooks/check-cloudflare-conventions.sh` — PreToolUse guard.** Deterministically blocks the two Cloudflare DO regressions CLAUDE.md previously only warned about in prose: legacy `ws.addEventListener` in worker server code, and legacy `ctx.storage.put/get`. This is the "regressed twice" failure mode the global guardrails cite for dmarcheck — same pattern applied here.
- **`biome.json` — ignore `**/.claude/**`.** Adjacent fix: biome was linting agent config (incl. auto-generated `settings.local.json`), failing local `pnpm lint` whenever a permission is flipped.

## Verification

- Grep sweep of real non-test `apps/worker/src`: **clean** for both patterns — no false positives on actual code.
- 9 hook cases pass: both regressions blocked on DO server files; no false positives on the real WS-client fixture (`__tests__/__fixtures__/ws.ts`), `.test.ts`, KV (`env.CACHE`), R2 (`env.ATTACHMENTS`), or frontend; jq-missing degrades to a no-op; `MultiEdit` handled.
- `pnpm test`: **375 passing / 46 files**. `pnpm typecheck`: **0 errors**. `pnpm lint`: **exit 0** (5 remaining are pre-existing `noNonNullAssertion` *warnings* in `*.test.tsx`, present on `main`, non-blocking — follow-up issue filed).

## SPEC §20 assumptions

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)