### PR TITLE
chore: allowlist read-only commands to reduce permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,6 +5,14 @@
       "Bash(pnpm typecheck)",
       "Bash(pnpm test)",
       "Bash(pnpm test --filter *)",
+      "Bash(pnpm lint *)",
+      "Bash(pnpm typecheck *)",
+      "Bash(pnpm test *)",
+      "Bash(git fetch *)",
+      "Bash(gh label list *)",
+      "Bash(gh search code *)",
+      "Bash(npm test *)",
+      "Bash(npm run typecheck)",
       "mcp__ccd_session_mgmt__search_session_transcripts"
     ]
   },


### PR DESCRIPTION
## What

Adds 8 prefix patterns to `permissions.allow` in `.claude/settings.json`:

- `Bash(pnpm lint *)`, `Bash(pnpm typecheck *)`, `Bash(pnpm test *)` — arg/redirect forms (the no-arg exacts were already allowed but `pnpm lint 2>&1`-style calls still prompted)
- `Bash(git fetch *)`, `Bash(gh label list *)`, `Bash(gh search code *)`, `Bash(npm test *)`, `Bash(npm run typecheck)`

## Why

A scan of the 50 most-recent Claude Code session transcripts showed these read-only commands repeatedly triggering permission prompts (e.g. `pnpm lint` ~38×, `git fetch` 12×, `gh label list` 12×). Allowlisting them removes recurring friction.

## Reviewer notes

- All entries are read-only. Commands granting arbitrary code execution were deliberately excluded (`pnpm exec *`, `pnpm --filter *`, `python3 *`, `npm run *` wildcard).
- `pnpm test`/`npm test` arg forms are included on the basis that tests here are sandboxed vitest runs and CLAUDE.md mandates running them pre-commit; flag if you'd rather they keep prompting.
- Existing `permissions.allow` entries and the `hooks` block are preserved unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)