### PR TITLE
security: patch 8 dependabot alerts (undici, fast-uri, devalue, yaml, hono)

### DIFF
--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -15,7 +15,7 @@
     "@loomwiki/schema": "workspace:*",
     "@loomwiki/shared": "workspace:*",
     "gray-matter": "^4.0.3",
-    "hono": "^4.6.14",
+    "hono": "^4.12.18",
     "jose": "^5.9.6"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,12 @@
     "ws": "^8.18.2"
   },
   "pnpm": {
-    "onlyBuiltDependencies": ["@biomejs/biome", "esbuild", "sharp", "workerd"]
+    "onlyBuiltDependencies": ["@biomejs/biome", "esbuild", "sharp", "workerd"],
+    "overrides": {
+      "undici@>=7.0.0 <7.24.0": ">=7.24.0",
+      "fast-uri@<3.1.2": ">=3.1.2",
+      "devalue@<5.8.1": ">=5.8.1",
+      "yaml@<2.8.3": ">=2.8.3"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,12 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  undici@>=7.0.0 <7.24.0: '>=7.24.0'
+  fast-uri@<3.1.2: '>=3.1.2'
+  devalue@<5.8.1: '>=5.8.1'
+  yaml@<2.8.3: '>=2.8.3'
+
 importers:
 
   .:
@@ -163,8 +169,8 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       hono:
-        specifier: ^4.6.14
-        version: 4.12.16
+        specifier: ^4.12.18
+        version: 4.12.19
       jose:
         specifier: ^5.9.6
         version: 5.10.0
@@ -2764,8 +2770,8 @@ packages:
     resolution: {integrity: sha512-KxektNH63SrbfUyDiwXqRb1rLwKt33AmMv+5Nhsw1kqZ13SJBRTgZHtGbE+hH3a1mVW1cz+4pqSWVPAtLVXTzQ==}
     engines: {node: '>=18'}
 
-  devalue@5.8.0:
-    resolution: {integrity: sha512-2zA9pFEsnp7vWBZbXF5JAgAq0fsUIt/1XPbRiAmRV3lp/2C3upzH+sADiyy66aFCihoLEsrQHxNM5w1gIDfsBg==}
+  devalue@5.8.1:
+    resolution: {integrity: sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw==}
 
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
@@ -2896,8 +2902,8 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -2997,8 +3003,8 @@ packages:
   hastscript@9.0.1:
     resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
-  hono@4.12.16:
-    resolution: {integrity: sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==}
+  hono@4.12.19:
+    resolution: {integrity: sha512-xa3eYXYXx68XTT4hZ7dRzsXBhaq85ToSrlUJNoR0gwz/1Ap/CNwX47wfvV7pc/xWhjKVVkLT7zBJy8chhNguqQ==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@3.0.3:
@@ -3884,10 +3890,6 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici@7.14.0:
-    resolution: {integrity: sha512-Vqs8HTzjpQXZeXdpsfChQTlafcMQaaIwnGwLam1wudSSjlJeQ3bw1j+TLPePgrCnCpUXx7Ba5Pdpf5OBih62NQ==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
     engines: {node: '>=20.18.1'}
@@ -4049,7 +4051,7 @@ packages:
       sugarss: '*'
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -4324,11 +4326,6 @@ packages:
 
   yaml-language-server@1.20.0:
     resolution: {integrity: sha512-qhjK/bzSRZ6HtTvgeFvjNPJGWdZ0+x5NREV/9XZWFjIGezew2b4r5JPy66IfOhd5OA7KeFwk1JfmEbnTvev0cA==}
-    hasBin: true
-
-  yaml@2.7.1:
-    resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
-    engines: {node: '>= 14'}
     hasBin: true
 
   yaml@2.8.4:
@@ -6709,7 +6706,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -6776,7 +6773,7 @@ snapshots:
       cssesc: 3.0.0
       debug: 4.4.3
       deterministic-object-hash: 2.0.2
-      devalue: 5.8.0
+      devalue: 5.8.1
       diff: 8.0.4
       dlv: 1.1.3
       dset: 3.1.4
@@ -7038,7 +7035,7 @@ snapshots:
     dependencies:
       base-64: 1.0.0
 
-  devalue@5.8.0: {}
+  devalue@5.8.1: {}
 
   devlop@1.1.0:
     dependencies:
@@ -7244,7 +7241,7 @@ snapshots:
 
   fast-deep-equal@3.1.3: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -7398,7 +7395,7 @@ snapshots:
       property-information: 7.1.0
       space-separated-tokens: 2.0.2
 
-  hono@4.12.16: {}
+  hono@4.12.19: {}
 
   html-escaper@3.0.3: {}
 
@@ -7883,7 +7880,7 @@ snapshots:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.34.5
-      undici: 7.14.0
+      undici: 7.24.8
       workerd: 1.20260114.0
       ws: 8.18.0
       youch: 4.1.0-beta.10
@@ -8520,8 +8517,6 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici@7.14.0: {}
-
   undici@7.24.8: {}
 
   unenv@2.0.0-rc.24:
@@ -8897,9 +8892,7 @@ snapshots:
       vscode-languageserver-textdocument: 1.0.12
       vscode-languageserver-types: 3.17.5
       vscode-uri: 3.1.0
-      yaml: 2.7.1
-
-  yaml@2.7.1: {}
+      yaml: 2.8.4
 
   yaml@2.8.4: {}
 


### PR DESCRIPTION
## Summary

Patches **8 distinct dependabot security alerts** that resolve without breaking changes — the safe two tiers of the 25 open alerts. The 3 breaking majors (astro 5→6, @astrojs/cloudflare 12→13, happy-dom 16→20) are tracked separately in #57.

### Tier 1 — transitive, via `pnpm.overrides`
| Package | Range → Resolved | Worst severity |
|---|---|---|
| `undici` | `>=7.0.0 <7.24.0` → `7.24.8` | **high** — WS parser crash, mem exhaustion, request smuggling, CRLF injection (6 alerts) |
| `fast-uri` | `<3.1.2` → `3.1.2` | **high** — path traversal, host confusion |
| `devalue` | `<5.8.1` → `5.8.1` | **high** — DoS via sparse arrays |
| `yaml` | `<2.8.3` → `2.8.4` | medium — stack overflow |

### Tier 2 — direct dep, semver-minor
- `hono` `^4.6.14` → `^4.12.18` (resolves `4.12.19`): fixes cross-user **cache leak** (Vary: Authorization/Cookie ignored), **JWT NumericDate** validation, and CSS declaration injection in JSX SSR. Directly relevant — `hono` is the worker framework and this project does JWT auth.

## Verification

- `pnpm test` — **673 passed, 1 skipped, 0 failing** (shared 54 / schema 75 / web 138 / worker 406+1skip)
- `pnpm typecheck` — 0 errors
- `pnpm lint` — exit 0
- Lockfile deduped: single `undici@7.24.8`, no pre-patch copies remain.

## Notes

- No SPEC §20 assumptions made.
- Follow-up: #57 (Tier 3 breaking majors).

Refs #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)
