### PR TITLE
chore: resolve noNonNullAssertion lint warnings in settings tests

### DIFF
--- a/apps/web/src/components/settings/AgentsMdEditor.test.tsx
+++ b/apps/web/src/components/settings/AgentsMdEditor.test.tsx
@@ -79,7 +79,9 @@ describe("AgentsMdEditor", () => {
 
     // Click Save changes button (top-level, not the dialog one yet).
     const saveButtons = screen.getAllByRole("button", { name: /Save changes/ });
-    await user.click(saveButtons[0]!);
+    const [firstSaveBtn] = saveButtons;
+    if (!firstSaveBtn) throw new Error("Expected at least one Save changes button");
+    await user.click(firstSaveBtn);
 
     // Confirm dialog appears.
     expect(await screen.findByText(/Update AGENTS\.md\?/)).toBeInTheDocument();
@@ -89,7 +91,8 @@ describe("AgentsMdEditor", () => {
     // last one which is the dialog button).
     const dialogSave = screen.getAllByRole("button", { name: /Save changes/ }).at(-1);
     expect(dialogSave).toBeDefined();
-    await user.click(dialogSave!);
+    if (!dialogSave) throw new Error("Expected dialog Save changes button to exist");
+    await user.click(dialogSave);
 
     await waitFor(() => {
       const putCall = calls.find(

--- a/apps/web/src/components/settings/BYOKSettings.test.tsx
+++ b/apps/web/src/components/settings/BYOKSettings.test.tsx
@@ -102,7 +102,9 @@ describe("BYOKSettings", () => {
     // Wait for load.
     const addButtons = await screen.findAllByRole("button", { name: /Add key/ });
     // Click the Anthropic Add Key button (first card).
-    await user.click(addButtons[0]!);
+    const [firstAddBtn] = addButtons;
+    if (!firstAddBtn) throw new Error("Expected at least one Add key button");
+    await user.click(firstAddBtn);
 
     const textarea = screen.getByLabelText(/Paste API key/);
     const SECRET = "sk-ant-test-XYZ-do-not-leak";
@@ -134,7 +136,9 @@ describe("BYOKSettings", () => {
 
     render(<BYOKSettings />);
     const addButtons = await screen.findAllByRole("button", { name: /Add key/ });
-    await user.click(addButtons[0]!);
+    const [firstAddBtnCancel] = addButtons;
+    if (!firstAddBtnCancel) throw new Error("Expected at least one Add key button");
+    await user.click(firstAddBtnCancel);
     const textarea = screen.getByLabelText(/Paste API key/);
     await user.type(textarea, "sk-secret-cancelled");
     await user.click(screen.getByRole("button", { name: /^Cancel$/ }));
@@ -184,7 +188,8 @@ describe("BYOKSettings", () => {
       .getAllByRole("button", { name: /^Remove$/ })
       .find((b) => b !== removeButton);
     expect(dialogRemove).toBeDefined();
-    await user.click(dialogRemove!);
+    if (!dialogRemove) throw new Error("Expected dialog Remove button to exist");
+    await user.click(dialogRemove);
 
     await waitFor(() => {
       const deleteCall = calls.find(


### PR DESCRIPTION
## Summary

- Replaces 5 `lint/style/noNonNullAssertion` violations in `BYOKSettings.test.tsx` (lines 105, 137, 187) and `AgentsMdEditor.test.tsx` (lines 82, 92) with explicit guard checks: destructure the element, assert with `if (!x) throw new Error(...)`, then use the now-narrowed variable — no `!` operator anywhere.
- No `biome-ignore` comments added. No component code changed. No test behavior/coverage altered.
- `pnpm lint` now reports 0 errors and 0 warnings.

Closes #42

## Test plan

- [x] `pnpm lint` — `Checked 265 files in 453ms. No fixes applied.` (0 errors, 0 warnings)
- [x] `pnpm test` — 673 tests pass (54 shared + 75 schema + 138 web + 406 worker), 1 skipped, 0 failures
- [x] `pnpm typecheck` — 0 errors, 0 warnings across all packages
- [x] Both `BYOKSettings.test.tsx` and `AgentsMdEditor.test.tsx` pass with all assertions intact

https://claude.ai/code/session_014EdSay1kM3F5aYhgS9jHGy

---
_Generated by [Claude Code](https://claude.ai/code/session_014EdSay1kM3F5aYhgS9jHGy)_