### PR TITLE
fix: use CF_VERSION_METADATA.tag (git SHA) not .id (UUID) in /api/health

### DIFF
--- a/apps/worker/src/routes/health.ts
+++ b/apps/worker/src/routes/health.ts
@@ -7,7 +7,11 @@ import type { Env } from "../env.js";
 export const VERSION = "0.0.1";
 
 export const healthRoute = new Hono<{ Bindings: Env }>().get("/", (c) => {
-  const commit = c.env.CF_VERSION_METADATA?.id ?? c.env.GIT_COMMIT ?? "dev";
+  // Prefer the user-defined tag (set via `wrangler deploy --tag $SHA` in CI)
+  // which carries the git SHA. Fall back to the deployment UUID (.id), then
+  // to the GIT_COMMIT env var (set in GitHub Actions CI), then "dev".
+  const meta = c.env.CF_VERSION_METADATA;
+  const commit = (meta?.tag || meta?.id) ?? c.env.GIT_COMMIT ?? "dev";
   return c.json(
     apiOk({
       status: "ok" as const,


### PR DESCRIPTION
## Summary

- `CF_VERSION_METADATA.id` is a Cloudflare-assigned deployment UUID — it never matches the git SHA that the post-deploy verifier expects in `data.commit`.
- `CF_VERSION_METADATA.tag` is the user-defined string set via `wrangler deploy --tag $SHA`, which is the correct field for surfacing the git SHA at runtime.
- Updated the commit fallback chain to: `meta.tag || meta.id || GIT_COMMIT || "dev"`.

## Operator action required

Configure Cloudflare Workers CI to pass `--tag $GITHUB_SHA` on each deploy. This makes `CF_VERSION_METADATA.tag` carry the exact git SHA so the post-deploy health check passes.

Without this operator step, the verifier step `/api/health (200 + ok:true + matching commit)` will continue to fail (the tag will be empty, falling back to the deployment UUID).

## Context

The post-deploy verifier (`.github/workflows/post-deploy.yml`) checks:
```bash
echo "$BODY" | jq -e --arg sha "$EXPECTED_SHA" '.data.commit == $sha'
```
This has been failing on every deploy because `.id` returns a UUID. Issues #60, #59, #56, #50, #49, #48, #46, #45, #29, #26 are all filed by this check.

## Test plan

- [ ] `pnpm typecheck` — 0 errors (verified locally)
- [ ] `pnpm lint` — 0 warnings (pre-existing lint warnings in settings test files are being fixed in PR #64; unrelated to this change)
- [ ] `pnpm test` — pre-existing rate-limit flake in `chat-room.test.ts` is being fixed in the #55 PR; all other 405+ tests pass
- [ ] After merge + operator adds `--tag $GITHUB_SHA` to Cloudflare Workers CI config, re-run post-deploy verifier

https://claude.ai/code/session_014EdSay1kM3F5aYhgS9jHGy

---
_Generated by [Claude Code](https://claude.ai/code/session_014EdSay1kM3F5aYhgS9jHGy)_