### PR TITLE
fix: de-flake rate-limit test by eliminating wall-clock dependency

### DIFF
--- a/apps/worker/src/__tests__/chat-room.test.ts
+++ b/apps/worker/src/__tests__/chat-room.test.ts
@@ -4,9 +4,10 @@
 // route + DO upgrade all run as one unit. Reserves runInDurableObject for
 // cases the route layer cannot reach (alarm fire, mirror failure paths).
 
-import { SELF, env } from "cloudflare:test";
+import { SELF, env, runInDurableObject } from "cloudflare:test";
 import { PROTOCOL_VERSION } from "@loomwiki/shared";
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import type { ChatRoom } from "../do/ChatRoom.js";
 import { applyMigrations, resetDb } from "./__fixtures__/db.js";
 import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
 import { type WsSession, openWs } from "./__fixtures__/ws.js";
@@ -162,6 +163,20 @@ describe("ChatRoom DO — WebSocket flow", () => {
 
   it("rate-limits beyond 100 msg/sec/room with RATE_LIMITED", async () => {
     const alice = await bootstrapMember("alice@example.com", "general");
+
+    // Freeze the rate-limiter clock via the _nowFn seam so the 1-second
+    // rolling window never advances during the ack-drain loop. Without this,
+    // the ack-drain (100 × `await ws.next()`) can exceed 1000ms wall-clock on
+    // a loaded CI runner, causing the window to expire and the 101st send to
+    // be allowed instead of rejected — the original flake (#55).
+    const frozenNow = Date.now();
+    const stub = (env.CHAT_ROOM as DurableObjectNamespace<ChatRoom>).get(
+      (env.CHAT_ROOM as DurableObjectNamespace<ChatRoom>).idFromName(alice.roomId),
+    );
+    await runInDurableObject(stub, (instance: ChatRoom) => {
+      instance._nowFn = () => frozenNow;
+    });
+
     const ws = await track(await openWs(alice.roomId, alice.jwt));
     ws.send({ kind: "hello", protocolVersion: PROTOCOL_VERSION });
     await ws.next();
@@ -170,15 +185,16 @@ describe("ChatRoom DO — WebSocket flow", () => {
     for (let i = 0; i < 100; i++) {
       ws.send({ kind: "send", tempId: `t-${i}`, body: `m${i}` });
     }
-    // Drain acks (and any echoed messages — there's only one socket so we
-    // expect 100 acks total).
+    // Drain acks — the frozen clock guarantees all 100 hits remain in window
+    // no matter how long this loop takes in real time.
     let acks = 0;
     while (acks < 100) {
       const m = await ws.next(2000);
       if (m.kind === "ack") acks++;
     }
 
-    // The 101st must be rejected.
+    // The 101st must be rejected because the frozen clock keeps all 100 prior
+    // hits inside the window.
     ws.send({ kind: "send", tempId: "rate", body: "rate-me" });
     const next = await ws.next();
     expect(next.kind).toBe("error");

--- a/apps/worker/src/do/ChatRoom.ts
+++ b/apps/worker/src/do/ChatRoom.ts
@@ -115,6 +115,14 @@ export class ChatRoom extends DurableObject<Env> {
    */
   _mirrorFn: typeof mirrorMessageToD1 | undefined = undefined;
 
+  /**
+   * Optional clock override for the rate limiter. Defaults to `undefined`
+   * (production uses `Date.now()`). Tests can inject a frozen timestamp via
+   * `runInDurableObject` so the rolling window never advances during the
+   * ack-drain loop, making the rate-limit test deterministic (#55).
+   */
+  _nowFn: (() => number) | undefined = undefined;
+
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     this.sql = ctx.storage.sql;
@@ -277,7 +285,7 @@ export class ChatRoom extends DurableObject<Env> {
       sendError(ws, ErrorCodes.VALIDATION_FAILED, "body exceeds 4096 chars", env.tempId);
       return;
     }
-    if (!this.limiter.tryAcquire(Date.now())) {
+    if (!this.limiter.tryAcquire((this._nowFn ?? Date.now.bind(Date))())) {
       sendError(ws, ErrorCodes.RATE_LIMITED, "100 msg/sec/room cap reached", env.tempId);
       return;
     }


### PR DESCRIPTION
## Summary

- **Race condition**: The rate-limit test sent 100 messages, drained 100 acks via `await ws.next()` in a loop, then sent a 101st and asserted `RATE_LIMITED`. On a loaded CI runner, the ack-drain loop could take >1000ms, expiring the `RollingWindowLimiter`'s 1-second rolling window so the 101st send was allowed — producing `ack` instead of `error` (flake).
- **Fix**: Added a `_nowFn: (() => number) | undefined` seam on `ChatRoom` (matching the existing `_mirrorFn` pattern). The test injects a frozen timestamp via `runInDurableObject` before any sends, so all 101 messages are evaluated at the same timestamp. The window never expires during the ack-drain, making the test deterministic regardless of runner speed.
- **Production unchanged**: `_nowFn` defaults to `undefined`; the production path falls back to `Date.now()` exactly as before. The 100 msg/sec/room cap is unaffected.

Closes #55

## Test plan

- [x] `pnpm --filter @loomwiki/worker test` run 1: 49 files passed, 406 tests passed, 1 skipped
- [x] `pnpm --filter @loomwiki/worker test` run 2: 49 files passed, 406 tests passed, 1 skipped
- [x] `pnpm --filter @loomwiki/worker test` run 3: 49 files passed, 406 tests passed, 1 skipped
- [x] `pnpm test && pnpm typecheck && pnpm lint` all pass from repo root (0 errors)
- [x] The test still genuinely exercises rate limiting — the frozen clock ensures all 100 prior hits remain inside the window when the 101st is evaluated, not trivially weakened

## Files changed

- `apps/worker/src/do/ChatRoom.ts` — added `_nowFn` seam; `handleSend` uses `(this._nowFn ?? Date.now.bind(Date))()` for the limiter call
- `apps/worker/src/__tests__/chat-room.test.ts` — inject frozen clock via `runInDurableObject` before the send burst; test structure otherwise unchanged

https://claude.ai/code/session_014EdSay1kM3F5aYhgS9jHGy

---
_Generated by [Claude Code](https://claude.ai/code/session_014EdSay1kM3F5aYhgS9jHGy)_