### PR TITLE
fix: surface ingest run outcome via polling and improve button discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,32 @@ style, "do-not-touch" zones — live in [`CLAUDE.md`](./CLAUDE.md). The
 master spec is [`SPEC.md`](./SPEC.md). The threat model is
 [`docs/SECURITY.md`](./docs/SECURITY.md).
 
+## Running ingest manually
+
+The ingest agent reads recent chat messages in a room and extracts wiki
+proposals. To trigger it manually:
+
+1. Open a room as a member.
+2. Click the **▶ Run ingest** button in the room header (top-right).
+3. The button is disabled while the trigger is in flight; once it
+   returns, the UI polls `GET /api/runs/:id` and shows a success or
+   error toast when the run reaches a terminal state.
+
+**Required operator config** (set via `wrangler secret put` or the
+Cloudflare dashboard → Workers → your worker → Settings → Variables):
+
+| Setting | Purpose |
+|---|---|
+| `AI_GATEWAY_ID` | AI Gateway slug (enables cost guards) |
+| `CF_ACCOUNT_ID` | Cloudflare account ID for Gateway URL composition |
+
+The `AI` Workers AI binding must also be enabled in `wrangler.jsonc`.
+If neither a gateway nor the binding is configured, the run will fail
+immediately with an actionable error shown in the UI.
+
+For the full ingest-agent design, see
+[`docs/ADR/0005-ingest-agent-design.md`](./docs/ADR/0005-ingest-agent-design.md).
+
 ## Roadmap to v0.1
 
 The v0.0.1 release is the dogfood-first milestone. The v0.1 effort

--- a/apps/web/src/components/chat/RoomView.test.tsx
+++ b/apps/web/src/components/chat/RoomView.test.tsx
@@ -2,10 +2,11 @@
 
 // RoomView pins the wiring of the "Run ingest" button:
 //   - clicking calls triggerIngest(roomId)
-//   - 200 running   → toast.success
-//   - 202 lock_held → toast.info
+//   - 202 lock_held → toast.info immediately
 //   - ApiError      → toast.error("<code>: <message>") + button re-enabled
-//   - button is disabled while the request is in flight
+//   - button is disabled while the trigger request is in-flight
+//   - 200 running   → polls getRunStatus; shows toast.success on "succeeded"
+//                     or toast.error on "failed"
 //
 // useChat is mocked because the real hook opens a WebSocket on mount;
 // happy-dom has no WebSocket, and the chat plumbing is already covered
@@ -13,7 +14,12 @@
 
 import { ApiError } from "@/lib/api";
 import * as apiInbox from "@/lib/api-inbox";
-import type { SerializedRoom, SerializedUser } from "@/lib/types";
+import type {
+  IngestRunStatus,
+  SerializedIngestRun,
+  SerializedRoom,
+  SerializedUser,
+} from "@/lib/types";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -54,14 +60,30 @@ const USER: SerializedUser = {
   created_at: "2026-01-01T00:00:00.000Z",
 };
 
+function makeRun(status: IngestRunStatus, error: string | null = null): SerializedIngestRun {
+  return {
+    id: "run-1",
+    room_id: ROOM_ID,
+    triggered_by: USER_ID,
+    started_at: "2026-01-01T00:00:00.000Z",
+    finished_at: status !== "running" ? "2026-01-01T00:01:00.000Z" : null,
+    last_message_id: null,
+    status,
+    summary: null,
+    error,
+  };
+}
+
 describe("RoomView — Run ingest button", () => {
   let triggerIngestSpy: ReturnType<typeof vi.spyOn>;
+  let getRunStatusSpy: ReturnType<typeof vi.spyOn>;
   let toastSuccess: ReturnType<typeof vi.spyOn>;
   let toastInfo: ReturnType<typeof vi.spyOn>;
   let toastError: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     triggerIngestSpy = vi.spyOn(apiInbox, "triggerIngest");
+    getRunStatusSpy = vi.spyOn(apiInbox, "getRunStatus");
     toastSuccess = vi.spyOn(toast, "success").mockImplementation(() => "id");
     toastInfo = vi.spyOn(toast, "info").mockImplementation(() => "id");
     toastError = vi.spyOn(toast, "error").mockImplementation(() => "id");
@@ -71,22 +93,39 @@ describe("RoomView — Run ingest button", () => {
     vi.restoreAllMocks();
   });
 
-  it("renders the button in the room header", () => {
+  it("renders the Run ingest button in the room header", () => {
     render(<RoomView room={ROOM} currentUser={USER} />);
     expect(screen.getByRole("button", { name: /run ingest/i })).toBeInTheDocument();
   });
 
-  it("calls triggerIngest with the room id and shows a success toast on running", async () => {
+  it("calls triggerIngest with the room id then polls and shows success toast on succeeded", async () => {
     triggerIngestSpy.mockResolvedValue({ run_id: "run-1", status: "running" });
-    render(<RoomView room={ROOM} currentUser={USER} />);
+    getRunStatusSpy.mockResolvedValue({ run: makeRun("succeeded") });
 
+    render(<RoomView room={ROOM} currentUser={USER} />);
     fireEvent.click(screen.getByRole("button", { name: /run ingest/i }));
 
     await waitFor(() => expect(triggerIngestSpy).toHaveBeenCalledWith(ROOM_ID));
+    // Success toast comes from the poll, not the trigger response.
     await waitFor(() => expect(toastSuccess).toHaveBeenCalledTimes(1));
-    expect(toastSuccess.mock.calls[0]?.[0]).toMatch(/ingest started/i);
+    expect(toastSuccess.mock.calls[0]?.[0]).toMatch(/completed/i);
     expect(toastInfo).not.toHaveBeenCalled();
     expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("shows error toast with run.error when the run fails", async () => {
+    triggerIngestSpy.mockResolvedValue({ run_id: "run-1", status: "running" });
+    getRunStatusSpy.mockResolvedValue({
+      run: makeRun("failed", "missing LLM config — set AI_GATEWAY_ID and CF_ACCOUNT_ID"),
+    });
+
+    render(<RoomView room={ROOM} currentUser={USER} />);
+    fireEvent.click(screen.getByRole("button", { name: /run ingest/i }));
+
+    await waitFor(() => expect(toastError).toHaveBeenCalledTimes(1));
+    expect(toastError.mock.calls[0]?.[0]).toMatch(/ingest failed/i);
+    expect(toastError.mock.calls[0]?.[0]).toMatch(/missing LLM config/i);
+    expect(toastSuccess).not.toHaveBeenCalled();
   });
 
   it("shows an info toast when the lock is already held", async () => {
@@ -118,7 +157,7 @@ describe("RoomView — Run ingest button", () => {
     );
   });
 
-  it("disables the button while the request is in flight", async () => {
+  it("disables the button while the trigger request is in flight", async () => {
     let resolve: ((v: { run_id: string; status: "running" }) => void) | undefined;
     triggerIngestSpy.mockReturnValue(
       new Promise((r) => {
@@ -132,6 +171,7 @@ describe("RoomView — Run ingest button", () => {
 
     await waitFor(() => expect(screen.getByRole("button", { name: /starting/i })).toBeDisabled());
 
+    getRunStatusSpy.mockResolvedValue({ run: makeRun("succeeded") });
     resolve?.({ run_id: "run-1", status: "running" });
     await waitFor(() =>
       expect(screen.getByRole("button", { name: /run ingest/i })).not.toBeDisabled(),

--- a/apps/web/src/components/chat/RoomView.tsx
+++ b/apps/web/src/components/chat/RoomView.tsx
@@ -7,8 +7,9 @@
 import { Button } from "@/components/ui/button";
 import { Toaster } from "@/components/ui/sonner";
 import { ApiError } from "@/lib/api";
-import { triggerIngest } from "@/lib/api-inbox";
+import { getRunStatus, triggerIngest } from "@/lib/api-inbox";
 import type { SerializedRoom, SerializedUser } from "@/lib/types";
+import { Play } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
 import { ConnectionBadge } from "./ConnectionBadge";
@@ -21,6 +22,38 @@ export interface RoomViewProps {
   currentUser: SerializedUser;
   /** Pre-fetched workspace members for display-name resolution. */
   members?: SerializedUser[];
+}
+
+const POLL_MAX_ATTEMPTS = 15;
+const POLL_INTERVAL_MS = 2_000;
+
+// Polls GET /api/runs/:id until the run reaches a terminal state, then
+// shows the appropriate toast. Runs fire-and-forget after the trigger
+// returns so the ingest button re-enables immediately.
+async function pollRunOutcome(runId: string): Promise<void> {
+  for (let attempt = 0; attempt < POLL_MAX_ATTEMPTS; attempt++) {
+    if (attempt > 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
+    }
+    try {
+      const { run } = await getRunStatus(runId);
+      if (run.status === "succeeded") {
+        toast.success("Ingest completed — check Inbox for proposals.");
+        return;
+      }
+      if (run.status === "failed") {
+        toast.error(
+          run.error
+            ? `Ingest failed: ${run.error}`
+            : "Ingest failed — check worker logs for details.",
+        );
+        return;
+      }
+    } catch {
+      // transient fetch error — keep retrying
+    }
+  }
+  toast.info("Ingest is still running — check Inbox for proposals shortly.");
 }
 
 export function RoomView({ room, currentUser, members }: RoomViewProps) {
@@ -51,9 +84,11 @@ export function RoomView({ room, currentUser, members }: RoomViewProps) {
       const res = await triggerIngest(room.id);
       if (res.status === "lock_held") {
         toast.info("An ingest run is already in progress for this room.");
-      } else {
-        toast.success("Ingest started — check Inbox for proposals shortly.");
+        return;
       }
+      // Fire-and-forget: poll for the run outcome in the background so
+      // the button re-enables immediately. The toast updates when done.
+      void pollRunOutcome(res.run_id);
     } catch (err) {
       const msg =
         err instanceof ApiError
@@ -80,8 +115,10 @@ export function RoomView({ room, currentUser, members }: RoomViewProps) {
             size="sm"
             onClick={handleRunIngest}
             disabled={ingestPending}
-            title="Run the ingest agent on this room's recent chat"
+            title="Extract wiki proposals from recent chat (requires AI config)"
+            className="gap-1.5"
           >
+            <Play className="size-3.5" aria-hidden="true" />
             {ingestPending ? "Starting…" : "Run ingest"}
           </Button>
           <ConnectionBadge status={chat.status} />


### PR DESCRIPTION
## Summary

- **Polling for actual outcome**: after `triggerIngest` returns, `pollRunOutcome()` fires-and-forgets, polling `GET /api/runs/:id` every 2s (max 15 attempts / ~30s). Success toast only shown when the run status reaches `"succeeded"`; error toast with the run's `error` field shown on `"failed"`.
- **Failure now visible**: a run that fails due to missing LLM config (or any other error) shows `"Ingest failed: <run.error>"` instead of the previous false-success toast.
- **Discoverability**: added `Play` icon (lucide-react) to the Run ingest button and improved `title` tooltip; button re-enables immediately after the trigger returns (not blocked during polling).
- **README**: added "Running ingest manually" section with operator config table (`AI_GATEWAY_ID`, `CF_ACCOUNT_ID`, `AI` binding) and actionable error guidance.

## Test plan

- [ ] `pnpm --filter @loomwiki/web test` — 139 tests passing ✓
- [ ] `pnpm typecheck` — 0 errors ✓
- [ ] `pnpm biome check` — 0 errors (5 pre-existing `noNonNullAssertion` warnings in settings test files fixed in PR #64)
- [ ] New test: `"calls triggerIngest with the room id then polls and shows success toast on succeeded"` — asserts success toast comes from poll, not trigger
- [ ] New test: `"shows error toast with run.error when the run fails"` — asserts failure path shows actionable error message
- [ ] Manual: open a room, click Run ingest on a deploy WITHOUT LLM config, verify error toast shows `"Ingest failed: ..."` instead of `"Ingest started — check Inbox..."`
- [ ] Manual: open a room, click Run ingest on a working deploy, verify success toast shows after the run completes (not immediately)

Closes #44

https://claude.ai/code/session_014EdSay1kM3F5aYhgS9jHGy

---
_Generated by [Claude Code](https://claude.ai/code/session_014EdSay1kM3F5aYhgS9jHGy)_