### PR TITLE
feat: add unified /timeline view (audit + ingest, graceful-empty scheduled/issue)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@astrojs/cloudflare": "^12.2.0",
     "@astrojs/react": "^4.1.2",
+    "@loomwiki/schema": "workspace:*",
     "@loomwiki/shared": "workspace:*",
     "@milkdown/core": "^7.5.8",
     "@milkdown/ctx": "^7.5.8",

--- a/apps/web/src/components/AppShell.astro
+++ b/apps/web/src/components/AppShell.astro
@@ -36,8 +36,9 @@ const pathname = new URL(Astro.request.url).pathname;
 const onWiki = pathname.startsWith("/w");
 const onAsk = pathname.startsWith("/ask");
 const onInbox = pathname.startsWith("/inbox");
+const onTimeline = pathname.startsWith("/timeline");
 const onSettings = pathname.startsWith("/settings");
-const onChat = !onWiki && !onAsk && !onInbox && !onSettings;
+const onChat = !onWiki && !onAsk && !onInbox && !onTimeline && !onSettings;
 ---
 
 <style>
@@ -132,6 +133,22 @@ const onChat = !onWiki && !onAsk && !onInbox && !onSettings;
           <span>Inbox</span>
           <InboxBadge client:idle />
         </a>
+        {
+          isOwner && (
+            <a
+              href="/timeline"
+              class:list={[
+                "flex flex-1 items-center justify-center gap-1 px-3 py-2 text-center text-sm font-medium transition-colors",
+                onTimeline
+                  ? "bg-background text-foreground"
+                  : "text-muted-foreground hover:bg-background/60",
+              ]}
+              aria-current={onTimeline ? "page" : undefined}
+            >
+              <span>Timeline</span>
+            </a>
+          )
+        }
         {
           isOwner && (
             <a

--- a/apps/web/src/components/timeline/TimelineFeed.tsx
+++ b/apps/web/src/components/timeline/TimelineFeed.tsx
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Unified timeline feed (issue #32). Owner-only surface — the Astro
+// page enforces the gate server-side; this island renders the feed and
+// the client-side controls (source pills, day/week/month grouping vs a
+// flat feed). Data comes from GET /api/timeline, which server-side-
+// unions audit_log + ingest_runs + scheduled_actions (+ issue_threads
+// once #30 lands). The same Zod-inferred `TimelineEntry` type the
+// worker emits is imported here from @loomwiki/schema so the two sides
+// never drift.
+//
+// Q-tl-3: the server returns unix-epoch seconds; this island converts
+// to the *viewer's* local timezone for the day/week/month grouping.
+
+import { apiGet } from "@/lib/api";
+import {
+  TIMELINE_FILTER_PILLS,
+  type TimelineEntry,
+  type TimelineFilterPill,
+} from "@loomwiki/schema";
+import { useCallback, useEffect, useState } from "react";
+
+interface RoomRef {
+  id: string;
+  slug: string;
+}
+
+export interface TimelineFeedProps {
+  initialEntries: TimelineEntry[];
+  initialNextCursor: string | null;
+  /** room_id → slug, for deep-linking ingest/scheduled entries. */
+  rooms: RoomRef[];
+}
+
+type ViewMode = "feed" | "day" | "week" | "month";
+
+interface TimelineApiResponse {
+  entries: TimelineEntry[];
+  next_cursor: string | null;
+}
+
+const PILL_LABEL: Record<TimelineFilterPill, string> = {
+  chat: "Chat",
+  wiki: "Wiki",
+  ingest: "Ingest",
+  scheduled: "Scheduled",
+  issue: "Issue",
+};
+
+// Empty-state copy per pill. Each names the upstream that will populate
+// it so the operator understands an empty filter is "not built yet",
+// not "broken".
+const EMPTY_COPY: Record<TimelineFilterPill, string> = {
+  chat: "No chat activity yet — chat-stream timeline rows land with a future producer (Q-tl-2).",
+  wiki: "No wiki activity yet — merged proposals and AGENTS.md edits show here.",
+  ingest: "No ingest runs yet — trigger one from a chat room or wait for the daily 03:00 UTC scan.",
+  scheduled: "No scheduled prompts yet — set one up via Settings → Schedules.",
+  issue: "No issue activity yet — lands with #30 (spec-kit Issue threads).",
+};
+
+function epochToLocal(epochSeconds: number): string {
+  return new Date(epochSeconds * 1000).toLocaleString();
+}
+
+// Day bucket key in the *viewer's* local timezone (Q-tl-3). For
+// week/month we still bucket by the entry's local day, then collapse
+// the heading to the week-start / month.
+function localDayKey(epochSeconds: number): string {
+  const d = new Date(epochSeconds * 1000);
+  const y = d.getFullYear();
+  const m = `${d.getMonth() + 1}`.padStart(2, "0");
+  const day = `${d.getDate()}`.padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function groupHeading(epochSeconds: number, mode: ViewMode): string {
+  const d = new Date(epochSeconds * 1000);
+  if (mode === "month") {
+    return d.toLocaleDateString(undefined, { year: "numeric", month: "long" });
+  }
+  if (mode === "week") {
+    // Week starting Monday, in viewer-local time.
+    const day = d.getDay(); // 0=Sun
+    const diffToMonday = (day + 6) % 7;
+    const monday = new Date(d);
+    monday.setDate(d.getDate() - diffToMonday);
+    return `Week of ${monday.toLocaleDateString(undefined, {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    })}`;
+  }
+  // day
+  return d.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function bucketKey(epochSeconds: number, mode: ViewMode): string {
+  const d = new Date(epochSeconds * 1000);
+  if (mode === "month") return `${d.getFullYear()}-${d.getMonth()}`;
+  if (mode === "week") {
+    const day = d.getDay();
+    const diffToMonday = (day + 6) % 7;
+    const monday = new Date(d);
+    monday.setHours(0, 0, 0, 0);
+    monday.setDate(d.getDate() - diffToMonday);
+    return `w${monday.getTime()}`;
+  }
+  return localDayKey(epochSeconds);
+}
+
+function entryTitle(e: TimelineEntry): string {
+  switch (e.source) {
+    case "audit":
+      return e.action;
+    case "ingest":
+      return `Ingest run ${e.status}`;
+    case "scheduled":
+      return `Scheduled prompt (${e.kind}) — ${e.status}`;
+    case "issue":
+      return `Issue #${e.issue_number} — ${e.status}`;
+  }
+}
+
+function entryDetail(e: TimelineEntry): string {
+  switch (e.source) {
+    case "audit":
+      return `${e.resource_kind}${e.resource_id ? ` · ${e.resource_id}` : ""}`;
+    case "ingest":
+      return e.summary ?? e.error ?? "—";
+    case "scheduled":
+      return e.prompt_preview;
+    case "issue":
+      return e.repo;
+  }
+}
+
+function entryHref(e: TimelineEntry, roomSlugById: Map<string, string>): string | null {
+  switch (e.source) {
+    case "audit":
+      // Proposal merge/reject → deep-link to the proposal detail (which
+      // renders the snapshotted before/after diff). Other audit kinds
+      // have no dedicated page in v0.0.1.
+      if (e.resource_kind === "proposal" && e.resource_id) {
+        return `/inbox/proposals/${e.resource_id}`;
+      }
+      return null;
+    case "ingest": {
+      const slug = roomSlugById.get(e.room_id);
+      return slug ? `/r/${slug}` : null;
+    }
+    case "scheduled": {
+      const slug = roomSlugById.get(e.room_id);
+      return slug ? `/r/${slug}` : null;
+    }
+    case "issue":
+      // Once #30 lands, deep-link to the linked chat thread.
+      if (e.chat_room_id) {
+        const slug = roomSlugById.get(e.chat_room_id);
+        return slug ? `/r/${slug}` : null;
+      }
+      return null;
+  }
+}
+
+export function TimelineFeed({ initialEntries, initialNextCursor, rooms }: TimelineFeedProps) {
+  const roomSlugById = new Map(rooms.map((r) => [r.id, r.slug]));
+  const [active, setActive] = useState<Set<TimelineFilterPill>>(new Set());
+  const [view, setView] = useState<ViewMode>("feed");
+  const [entries, setEntries] = useState<TimelineEntry[]>(initialEntries);
+  const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const buildQuery = useCallback(
+    (cursor: string | null): string => {
+      const params = new URLSearchParams();
+      if (active.size > 0) params.set("sources", Array.from(active).join(","));
+      if (cursor) params.set("cursor", cursor);
+      const qs = params.toString();
+      return `/api/timeline${qs ? `?${qs}` : ""}`;
+    },
+    [active],
+  );
+
+  // Refetch from scratch whenever the active pill set changes. The
+  // initial SSR payload is unfiltered, so any pill change needs a
+  // fresh page-1 fetch (poll-on-filter-change; realtime push is a
+  // documented follow-up, out of scope for #32).
+  useEffect(() => {
+    let cancelled = false;
+    if (active.size === 0) {
+      // Restore the SSR-provided unfiltered first page without a
+      // network round-trip on the very first render.
+      setEntries(initialEntries);
+      setNextCursor(initialNextCursor);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    apiGet<TimelineApiResponse>(buildQuery(null))
+      .then((res) => {
+        if (cancelled) return;
+        setEntries(res.entries);
+        setNextCursor(res.next_cursor);
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : "Failed to load timeline");
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [active, buildQuery, initialEntries, initialNextCursor]);
+
+  const togglePill = (pill: TimelineFilterPill) => {
+    setActive((prev) => {
+      const next = new Set(prev);
+      if (next.has(pill)) next.delete(pill);
+      else next.add(pill);
+      return next;
+    });
+  };
+
+  const loadMore = async () => {
+    if (!nextCursor || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await apiGet<TimelineApiResponse>(buildQuery(nextCursor));
+      setEntries((prev) => [...prev, ...res.entries]);
+      setNextCursor(res.next_cursor);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load more");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // Which empty-state copy to show when the feed is empty: if exactly
+  // one pill is active, name its upstream; otherwise generic.
+  const emptyCopy =
+    active.size === 1
+      ? EMPTY_COPY[Array.from(active)[0] as TimelineFilterPill]
+      : "Nothing here yet. Workspace activity (proposals, wiki edits, agent runs, scheduled prompts) will appear as it happens.";
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border px-4 py-3">
+        <fieldset aria-label="Source filters" className="m-0 flex flex-wrap gap-1.5 border-0 p-0">
+          {TIMELINE_FILTER_PILLS.map((pill) => {
+            const on = active.has(pill);
+            return (
+              <button
+                key={pill}
+                type="button"
+                aria-pressed={on}
+                onClick={() => togglePill(pill)}
+                className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+                  on
+                    ? "border-foreground bg-foreground text-background"
+                    : "border-border text-muted-foreground hover:bg-secondary/60"
+                }`}
+              >
+                {PILL_LABEL[pill]}
+              </button>
+            );
+          })}
+        </fieldset>
+        <fieldset aria-label="View mode" className="m-0 ml-auto flex gap-1.5 border-0 p-0">
+          {(["feed", "day", "week", "month"] as ViewMode[]).map((m) => (
+            <button
+              key={m}
+              type="button"
+              aria-pressed={view === m}
+              onClick={() => setView(m)}
+              className={`rounded-md border px-2.5 py-1 text-xs capitalize transition-colors ${
+                view === m
+                  ? "border-foreground bg-foreground text-background"
+                  : "border-border text-muted-foreground hover:bg-secondary/60"
+              }`}
+            >
+              {m}
+            </button>
+          ))}
+        </fieldset>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto">
+        {error && (
+          <p className="px-4 py-3 text-sm text-destructive" role="alert">
+            {error}
+          </p>
+        )}
+        {entries.length === 0 && !loading ? (
+          <div className="grid h-full place-items-center p-8 text-center">
+            <div className="max-w-md space-y-2">
+              <h2 className="text-lg font-semibold">No activity</h2>
+              <p className="text-sm text-muted-foreground">{emptyCopy}</p>
+            </div>
+          </div>
+        ) : view === "feed" ? (
+          <TimelineList entries={entries} roomSlugById={roomSlugById} />
+        ) : (
+          <GroupedTimeline entries={entries} mode={view} roomSlugById={roomSlugById} />
+        )}
+
+        {nextCursor && (
+          <div className="flex justify-center p-4">
+            <button
+              type="button"
+              onClick={loadMore}
+              disabled={loading}
+              className="rounded-md border border-border px-4 py-2 text-sm hover:bg-secondary/60 disabled:opacity-50"
+            >
+              {loading ? "Loading…" : "Load more"}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function TimelineList({
+  entries,
+  roomSlugById,
+}: {
+  entries: TimelineEntry[];
+  roomSlugById: Map<string, string>;
+}) {
+  return (
+    <ul aria-label="Timeline" className="divide-y divide-border">
+      {entries.map((e) => (
+        <li key={`${e.source}:${e.id}`}>
+          <TimelineRow entry={e} roomSlugById={roomSlugById} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function GroupedTimeline({
+  entries,
+  mode,
+  roomSlugById,
+}: {
+  entries: TimelineEntry[];
+  mode: ViewMode;
+  roomSlugById: Map<string, string>;
+}) {
+  const groups: { key: string; heading: string; items: TimelineEntry[] }[] = [];
+  const byKey = new Map<string, number>();
+  for (const e of entries) {
+    const key = bucketKey(e.at, mode);
+    let idx = byKey.get(key);
+    if (idx === undefined) {
+      idx = groups.length;
+      byKey.set(key, idx);
+      groups.push({ key, heading: groupHeading(e.at, mode), items: [] });
+    }
+    groups[idx]?.items.push(e);
+  }
+  return (
+    <div>
+      {groups.map((g) => (
+        <section key={g.key} aria-label={g.heading}>
+          <h3 className="sticky top-0 z-10 bg-secondary/80 px-4 py-1.5 text-xs font-semibold text-muted-foreground backdrop-blur">
+            {g.heading}
+          </h3>
+          <ul className="divide-y divide-border">
+            {g.items.map((e) => (
+              <li key={`${e.source}:${e.id}`}>
+                <TimelineRow entry={e} roomSlugById={roomSlugById} />
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function TimelineRow({
+  entry,
+  roomSlugById,
+}: {
+  entry: TimelineEntry;
+  roomSlugById: Map<string, string>;
+}) {
+  const href = entryHref(entry, roomSlugById);
+  const body = (
+    <div className="flex items-start gap-3 px-4 py-3">
+      <span
+        aria-hidden="true"
+        className="mt-0.5 rounded bg-secondary px-1.5 py-0.5 text-[10px] font-medium uppercase text-muted-foreground"
+      >
+        {entry.source}
+      </span>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium">{entryTitle(entry)}</p>
+        <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">{entryDetail(entry)}</p>
+      </div>
+      <time className="ml-auto shrink-0 text-[11px] text-muted-foreground">
+        {epochToLocal(entry.at)}
+      </time>
+    </div>
+  );
+  if (href) {
+    return (
+      <a href={href} className="block transition-colors hover:bg-secondary/40">
+        {body}
+      </a>
+    );
+  }
+  return body;
+}

--- a/apps/web/src/pages/timeline.astro
+++ b/apps/web/src/pages/timeline.astro
@@ -1,0 +1,95 @@
+---
+// SPDX-License-Identifier: Apache-2.0
+// Unified timeline (issue #32) — owner-only chronological feed of every
+// consequential workspace event (audit-log actions + ingest runs, plus
+// scheduled prompts and Issue threads once those producers land).
+//
+// The v0.1 follow-through to ADR-0007 §e ("JSON-only access in v0.0.1;
+// no UI"). Server-renders the AppShell + an SSR-fetched first page;
+// the React island owns the source pills and the day/week/month vs
+// feed toggle. Owner-gated server-side here (the API is owner-gated
+// independently, so a non-owner just sees the gate copy, not data).
+
+import AppShell from "@/components/AppShell.astro";
+import { RoomList } from "@/components/RoomList";
+import { TimelineFeed } from "@/components/timeline/TimelineFeed";
+import Layout from "@/layouts/Layout.astro";
+import { SsrApiError, SsrAuthRequiredError, ssrApiGet } from "@/lib/ssr-api";
+import type { CurrentUserPayload } from "@/lib/types";
+import type { TimelineEntry } from "@loomwiki/schema";
+
+interface TimelinePayload {
+  entries: TimelineEntry[];
+  next_cursor: string | null;
+}
+
+const env = Astro.locals.runtime?.env;
+let me: CurrentUserPayload;
+try {
+  me = await ssrApiGet<CurrentUserPayload>(Astro.request, "/api/me", env);
+} catch (err) {
+  if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
+  throw err;
+}
+
+const isOwner = me.workspace.owner_id === me.user.id;
+
+// Only the owner can read /api/timeline (the API 403s otherwise). Fetch
+// the first page SSR for owners; non-owners see the gate copy and we
+// skip the call entirely.
+let timeline: TimelinePayload = { entries: [], next_cursor: null };
+if (isOwner) {
+  try {
+    timeline = await ssrApiGet<TimelinePayload>(Astro.request, "/api/timeline", env);
+  } catch (err) {
+    if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
+    // A 403 here would mean the owner check disagrees with /api/me;
+    // treat any non-auth API error as an empty feed rather than a hard
+    // 500 so the page still renders its chrome + empty state.
+    if (!(err instanceof SsrApiError)) throw err;
+  }
+}
+
+const rooms = me.rooms.map((r) => ({ id: r.id, slug: r.slug }));
+---
+
+<Layout title={`Timeline — ${me.workspace.name}`}>
+  <AppShell
+    workspaceName={me.workspace.name}
+    userDisplayName={me.user.display_name}
+    isOwner={isOwner}
+  >
+    <RoomList slot="sidebar" client:idle workspaceId={me.workspace.id} rooms={me.rooms} />
+    <div slot="main" class="flex h-full min-h-0 flex-col">
+      <header class="flex items-center justify-between border-b border-border px-6 py-4">
+        <div>
+          <h1 class="text-lg font-semibold">Timeline</h1>
+          <p class="text-xs text-muted-foreground">
+            Everything moving in this workspace — newest first. Owner only.
+          </p>
+        </div>
+      </header>
+      <div class="min-h-0 flex-1 overflow-hidden">
+        {
+          isOwner ? (
+            <TimelineFeed
+              client:load
+              initialEntries={timeline.entries}
+              initialNextCursor={timeline.next_cursor}
+              rooms={rooms}
+            />
+          ) : (
+            <div class="grid h-full place-items-center p-8 text-center">
+              <div class="max-w-md space-y-2">
+                <h2 class="text-lg font-semibold">Owner only</h2>
+                <p class="text-sm text-muted-foreground">
+                  The workspace timeline is visible to the workspace owner only.
+                </p>
+              </div>
+            </div>
+          )
+        }
+      </div>
+    </div>
+  </AppShell>
+</Layout>

--- a/apps/worker/src/__tests__/routes-timeline.test.ts
+++ b/apps/worker/src/__tests__/routes-timeline.test.ts
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Unified timeline read API (issue #32). Covers: empty workspace,
+// owner-gating (non-owner → 403), source-pill filtering, cursor
+// pagination round-trip, and graceful handling when the optional
+// scheduled_actions / issue_threads tables are absent.
+
+import { SELF, env } from "cloudflare:test";
+import { id } from "@loomwiki/shared";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { applyMigrations, resetDb } from "./__fixtures__/db.js";
+import { type JwtFixture, makeJwtFixture } from "./__fixtures__/jwt.js";
+
+let fixture: JwtFixture;
+
+beforeAll(async () => {
+  await applyMigrations();
+  fixture = await makeJwtFixture();
+});
+
+beforeEach(async () => {
+  await resetDb();
+  await env.CACHE.put(`access-jwks:${env.ACCESS_TEAM}`, JSON.stringify(fixture.jwks));
+});
+
+async function authed(jwt: string, path: string): Promise<Response> {
+  return SELF.fetch(`https://api.local${path}`, {
+    headers: { "CF-Access-Jwt-Assertion": jwt },
+  });
+}
+
+async function bootstrapOwner(): Promise<{
+  jwt: string;
+  userId: string;
+  workspaceId: string;
+}> {
+  const jwt = await fixture.mint({ email: "owner@example.com" });
+  const res = await SELF.fetch("https://api.local/api/me", {
+    headers: { "CF-Access-Jwt-Assertion": jwt },
+  });
+  const body = (await res.json()) as {
+    data: { user: { id: string }; workspace: { id: string } };
+  };
+  return { jwt, userId: body.data.user.id, workspaceId: body.data.workspace.id };
+}
+
+async function plantNonOwner(): Promise<{ jwt: string }> {
+  const jwt = await fixture.mint({ email: "guest@example.com" });
+  await SELF.fetch("https://api.local/api/me", {
+    headers: { "CF-Access-Jwt-Assertion": jwt },
+  });
+  return { jwt };
+}
+
+async function createRoom(jwt: string, workspaceId: string, slug: string): Promise<string> {
+  const res = await SELF.fetch(`https://api.local/api/workspaces/${workspaceId}/rooms`, {
+    method: "POST",
+    headers: { "CF-Access-Jwt-Assertion": jwt, "content-type": "application/json" },
+    body: JSON.stringify({ slug, name: slug }),
+  });
+  const body = (await res.json()) as { data: { room: { id: string } } };
+  return body.data.room.id;
+}
+
+// UUIDv7 is monotonic within the process, so ids minted later sort
+// after earlier ones. We mint explicitly so a row's cursor ordering is
+// deterministic regardless of created_at ties.
+async function seedAudit(
+  workspaceId: string,
+  userId: string,
+  rows: { action: string; resourceKind: string; resourceId: string; createdAt: number }[],
+): Promise<string[]> {
+  const ids: string[] = [];
+  for (const r of rows) {
+    const rowId = id();
+    ids.push(rowId);
+    await env.DB.prepare(
+      `INSERT INTO audit_log
+         (id, workspace_id, actor_user_id, action, resource_kind, resource_id,
+          before_json, after_json, request_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?)`,
+    )
+      .bind(rowId, workspaceId, userId, r.action, r.resourceKind, r.resourceId, r.createdAt)
+      .run();
+  }
+  return ids;
+}
+
+async function seedRun(
+  roomId: string,
+  triggeredBy: string,
+  status: string,
+  startedAt: number,
+  finishedAt: number | null,
+): Promise<string> {
+  const runId = id();
+  await env.DB.prepare(
+    `INSERT INTO ingest_runs
+       (id, room_id, triggered_by, started_at, finished_at, last_message_id, status, summary, error)
+     VALUES (?, ?, ?, ?, ?, NULL, ?, NULL, NULL)`,
+  )
+    .bind(runId, roomId, triggeredBy, startedAt, finishedAt, status)
+    .run();
+  return runId;
+}
+
+interface TimelineBody {
+  data: {
+    entries: { id: string; source: string; at: number; pill?: string | null }[];
+    next_cursor: string | null;
+  };
+}
+
+describe("GET /api/timeline", () => {
+  it("returns an empty feed for a fresh workspace", async () => {
+    const { jwt } = await bootstrapOwner();
+    const res = await authed(jwt, "/api/timeline");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TimelineBody;
+    expect(body.data.entries).toEqual([]);
+    expect(body.data.next_cursor).toBeNull();
+  });
+
+  it("returns 403 for a non-owner", async () => {
+    await bootstrapOwner();
+    const { jwt: guestJwt } = await plantNonOwner();
+    const res = await authed(guestJwt, "/api/timeline");
+    expect(res.status).toBe(403);
+  });
+
+  it("unions audit + ingest rows newest-first", async () => {
+    const { jwt, userId, workspaceId } = await bootstrapOwner();
+    const roomId = await createRoom(jwt, workspaceId, "ops");
+    const base = Math.floor(Date.now() / 1000);
+    await seedAudit(workspaceId, userId, [
+      { action: "proposal.merge", resourceKind: "proposal", resourceId: "p1", createdAt: base },
+    ]);
+    // Finished run at base+10 → renders newest.
+    await seedRun(roomId, userId, "succeeded", base + 5, base + 10);
+
+    const res = await authed(jwt, "/api/timeline");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as TimelineBody;
+    expect(body.data.entries).toHaveLength(2);
+    expect(body.data.entries[0]?.source).toBe("ingest");
+    expect(body.data.entries[0]?.at).toBe(base + 10);
+    expect(body.data.entries[1]?.source).toBe("audit");
+  });
+
+  it("filters by source pill (wiki vs ingest)", async () => {
+    const { jwt, userId, workspaceId } = await bootstrapOwner();
+    const roomId = await createRoom(jwt, workspaceId, "ops");
+    const base = Math.floor(Date.now() / 1000);
+    await seedAudit(workspaceId, userId, [
+      // proposal → `wiki` pill.
+      { action: "proposal.merge", resourceKind: "proposal", resourceId: "p1", createdAt: base },
+      // byok → no pill (admin-only); never matches a pill filter.
+      { action: "byok.create", resourceKind: "byok", resourceId: "anthropic", createdAt: base + 1 },
+    ]);
+    await seedRun(roomId, userId, "succeeded", base + 2, base + 3);
+
+    const wiki = (await (await authed(jwt, "/api/timeline?sources=wiki")).json()) as TimelineBody;
+    expect(wiki.data.entries).toHaveLength(1);
+    expect(wiki.data.entries[0]?.source).toBe("audit");
+    expect(wiki.data.entries[0]?.pill).toBe("wiki");
+
+    const ing = (await (await authed(jwt, "/api/timeline?sources=ingest")).json()) as TimelineBody;
+    expect(ing.data.entries).toHaveLength(1);
+    expect(ing.data.entries[0]?.source).toBe("ingest");
+
+    // chat pill has no producer yet → empty (Q-tl-2 / TODO).
+    const chat = (await (await authed(jwt, "/api/timeline?sources=chat")).json()) as TimelineBody;
+    expect(chat.data.entries).toEqual([]);
+
+    // Unfiltered still includes the no-pill byok row.
+    const all = (await (await authed(jwt, "/api/timeline")).json()) as TimelineBody;
+    expect(all.data.entries).toHaveLength(3);
+  });
+
+  it("round-trips cursor pagination without gaps or duplicates", async () => {
+    const { jwt, userId, workspaceId } = await bootstrapOwner();
+    const base = Math.floor(Date.now() / 1000);
+    const rows = Array.from({ length: 5 }, (_, i) => ({
+      action: "proposal.merge",
+      resourceKind: "proposal",
+      resourceId: `p${i}`,
+      createdAt: base + i,
+    }));
+    await seedAudit(workspaceId, userId, rows);
+
+    const seen: string[] = [];
+    let cursor: string | null = null;
+    for (let guard = 0; guard < 10; guard++) {
+      const path: string =
+        cursor === null ? "/api/timeline?limit=2" : `/api/timeline?limit=2&cursor=${cursor}`;
+      const body = (await (await authed(jwt, path)).json()) as TimelineBody;
+      for (const e of body.data.entries) seen.push(e.id);
+      cursor = body.data.next_cursor;
+      if (cursor === null) break;
+    }
+    // 5 rows, no dupes, all distinct.
+    expect(seen).toHaveLength(5);
+    expect(new Set(seen).size).toBe(5);
+  });
+
+  it("rejects a malformed cursor with 400", async () => {
+    const { jwt } = await bootstrapOwner();
+    const res = await authed(jwt, "/api/timeline?cursor=not-a-uuid");
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an unknown source filter with 400", async () => {
+    const { jwt } = await bootstrapOwner();
+    const res = await authed(jwt, "/api/timeline?sources=lint");
+    expect(res.status).toBe(400);
+  });
+
+  it("includes scheduled_actions rows under the scheduled pill", async () => {
+    const { jwt, userId, workspaceId } = await bootstrapOwner();
+    const roomId = await createRoom(jwt, workspaceId, "ops");
+    const base = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO scheduled_actions
+         (id, workspace_id, room_id, created_by, kind, cron_expr, fire_at, prompt,
+          status, failure_count, last_fired_at, next_fire_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'cron', '0 9 * * *', NULL, 'daily standup',
+               'active', 0, NULL, ?, ?, ?)`,
+    )
+      .bind(id(), workspaceId, roomId, userId, base + 3600, base, base)
+      .run();
+
+    const body = (await (
+      await authed(jwt, "/api/timeline?sources=scheduled")
+    ).json()) as TimelineBody;
+    expect(body.data.entries).toHaveLength(1);
+    expect(body.data.entries[0]?.source).toBe("scheduled");
+    // Never fired → renders at next_fire_at.
+    expect(body.data.entries[0]?.at).toBe(base + 3600);
+  });
+
+  describe("graceful handling of absent optional tables", () => {
+    afterEach(async () => {
+      // Re-create the dropped table so resetDb's TRUNCATE list and any
+      // later test case don't trip. applyD1Migrations tracks applied
+      // state per-DB and will NOT re-run 0005 once it's marked applied,
+      // so we restore the table with its exact 0005 DDL directly.
+      await env.DB.prepare(
+        `CREATE TABLE IF NOT EXISTS scheduled_actions (
+           id TEXT PRIMARY KEY,
+           workspace_id TEXT NOT NULL REFERENCES workspaces(id),
+           room_id TEXT NOT NULL REFERENCES rooms(id),
+           created_by TEXT NOT NULL REFERENCES users(id),
+           kind TEXT NOT NULL CHECK(kind IN ('cron','once')),
+           cron_expr TEXT,
+           fire_at INTEGER,
+           prompt TEXT NOT NULL,
+           status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active','paused','fired','failed')),
+           failure_count INTEGER NOT NULL DEFAULT 0,
+           last_fired_at INTEGER,
+           next_fire_at INTEGER NOT NULL,
+           created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+           updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+         )`,
+      ).run();
+    });
+
+    it("does not 500 when scheduled_actions / issue_threads are absent", async () => {
+      const { jwt, userId, workspaceId } = await bootstrapOwner();
+      const base = Math.floor(Date.now() / 1000);
+      await seedAudit(workspaceId, userId, [
+        { action: "proposal.merge", resourceKind: "proposal", resourceId: "p1", createdAt: base },
+      ]);
+      // issue_threads never existed; drop scheduled_actions to simulate
+      // a deploy where #33 hasn't shipped.
+      await env.DB.prepare("DROP TABLE IF EXISTS scheduled_actions").run();
+
+      // Unfiltered union still works (audit row comes through).
+      const all = (await (await authed(jwt, "/api/timeline")).json()) as TimelineBody;
+      expect(all.data.entries).toHaveLength(1);
+      expect(all.data.entries[0]?.source).toBe("audit");
+
+      // The scheduled pill simply renders empty, not a 500.
+      const sched = await authed(jwt, "/api/timeline?sources=scheduled");
+      expect(sched.status).toBe(200);
+      expect(((await sched.json()) as TimelineBody).data.entries).toEqual([]);
+
+      // The issue pill (table never built) is also empty, not a 500.
+      const issue = await authed(jwt, "/api/timeline?sources=issue");
+      expect(issue.status).toBe(200);
+      expect(((await issue.json()) as TimelineBody).data.entries).toEqual([]);
+    });
+  });
+});

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -25,6 +25,7 @@ import { searchRoute } from "./routes/search.js";
 import { agentsMdSettingsRoute } from "./routes/settings/agentsmd.js";
 import { byokSettingsRoute } from "./routes/settings/byok.js";
 import { workspaceSettingsRoute } from "./routes/settings/workspace.js";
+import { timelineRoute } from "./routes/timeline.js";
 import { wikiRoute } from "./routes/wiki.js";
 import { workspacesRoute } from "./routes/workspaces.js";
 import { scheduled } from "./scheduled.js";
@@ -68,6 +69,8 @@ app.use("/api/_admin/digest/*", authMiddleware);
 // M8: settings (BYOK, AGENTS.md, workspace) + audit log read.
 app.use("/api/settings/*", authMiddleware);
 app.use("/api/_admin/audit", authMiddleware);
+// Issue #32: unified timeline read API (owner-gated inside the route).
+app.use("/api/timeline", authMiddleware);
 
 app.route("/api/me", meRoute);
 app.route("/api/workspaces", workspacesRoute);
@@ -97,6 +100,9 @@ app.route("/api/settings/byok", byokSettingsRoute);
 app.route("/api/settings/agentsmd", agentsMdSettingsRoute);
 app.route("/api/settings/workspace", workspaceSettingsRoute);
 app.route("/api", adminAuditRoute);
+// Issue #32: unified timeline view (audit + ingest, graceful-empty
+// scheduled/issue). Mounted at /api so the route declares /timeline.
+app.route("/api", timelineRoute);
 
 app.notFound((c) =>
   c.json(apiErr(ErrorCodes.NOT_FOUND, `No route for ${c.req.method} ${c.req.path}`), 404),

--- a/apps/worker/src/routes/timeline.ts
+++ b/apps/worker/src/routes/timeline.ts
@@ -1,0 +1,453 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Unified timeline read API (issue #32 / the v0.1 follow-through to
+// ADR-0007's deferred audit-log UI).
+//
+//   GET /api/timeline?since=&until=&sources=&user=&namespace=&limit=&cursor=
+//
+// Owner-only (reuses the requireOwner pattern from admin-audit.ts).
+// Returns a single chronological feed that server-side-unions four data
+// origins:
+//
+//   - `audit_log`        — admin/proposal actions (ADR-0007).
+//   - `ingest_runs`      — agent run status timeline.
+//   - `scheduled_actions`— user-defined cron/once prompts (issue #33).
+//                          NOTE: issue #32's body calls this
+//                          `scheduled_prompts`; that name is stale —
+//                          #33 shipped the table as `scheduled_actions`.
+//   - `issue_threads`    — spec-kit Issue activity (#30, not yet built).
+//
+// The last two are read through a tolerant table-existence check: if a
+// referenced table is absent (it hasn't shipped yet), that source
+// contributes zero rows rather than 500ing the whole feed.
+//
+// Pagination: a single UUIDv7 cursor (the `id` of the last entry of the
+// previous page). Each source query selects rows with `id < cursor`,
+// ordered `created_at DESC, id DESC`; results are merged in code by
+// `(at DESC, id DESC)` and sliced to `limit`. The cross-table
+// `id < cursor` comparison is sound because UUIDv7 is time-prefix
+// sortable — the same simplification admin-audit.ts already makes
+// within one table, extended across the union. Clock skew between
+// sources sharing a sub-second window is a pragmatic, documented
+// trade-off (no gaps/duplicates at the per-source level; at most a
+// re-order within a shared second across sources).
+//
+// Caveat specific to `scheduled` rows: their render time `at` derives
+// from `next_fire_at` (a *future* instant for not-yet-fired schedules)
+// or `last_fired_at`, while the cursor is still the row `id` (creation
+// time). So a scheduled row can sort high in the feed (far-future
+// fire) yet carry a low (old) cursor id. The failure mode is purely
+// pagination ordering for scheduled rows that straddle a page boundary
+// — never wrong/duplicated data. Acceptable for v0.0.1; a follow-up
+// can switch to a composite (at,id) cursor if it bites in practice.
+//
+// Dedupe note: a `manual_ingest.trigger` audit row and the
+// `ingest_runs` row it spawned are intentionally *both* surfaced. They
+// are distinct events at distinct times — the human's trigger action
+// (audited) vs. the run's lifecycle/outcome. An audit-faithful
+// timeline keeps both; collapsing them would lose the "who pressed the
+// button, when" forensic signal ADR-0007 exists to preserve.
+
+import {
+  AuditResourceKindSchema,
+  type IngestRunStatus,
+  type ScheduledActionStatus,
+  type TimelineEntry,
+  type TimelineFilterPill,
+  TimelineFilterPillSchema,
+  Uuidv7Schema,
+} from "@loomwiki/schema";
+import {
+  parseAuditLogRow,
+  parseIngestRunRow,
+  parseScheduledActionRow,
+} from "@loomwiki/schema/parsers";
+import { ErrorCodes, LoomwikiError, apiOk } from "@loomwiki/shared";
+import { Hono } from "hono";
+import type { Env } from "../env.js";
+import type { AuthEnv } from "../middleware/auth.js";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200; // Q-tl-4: mirror the audit log (50 / 200).
+
+function requireOwner(c: {
+  var: { user: { id: string }; workspace: { owner_id: string } };
+}): void {
+  if (c.var.workspace.owner_id !== c.var.user.id) {
+    throw new LoomwikiError(ErrorCodes.FORBIDDEN, "Workspace admin only", { status: 403 });
+  }
+}
+
+// Audit `resource_kind` → which UI filter pill the row surfaces under.
+// `proposal` + `agentsmd` are vault-content edits → the `wiki` pill.
+// `ingest` audit rows ride alongside the ingest_runs feed → `ingest`.
+// `byok` / `workspace_settings` are admin-only actions that belong to
+// no current pill — they stay visible in the unfiltered feed but match
+// no pill (so the source filter never hides them silently *and* never
+// mislabels them).
+//
+// TODO(Q-tl-2): there is no `chat`-source producer today (audit_log has
+// no chat resource_kind, and per-message streaming is out of scope for
+// v0.0.1). The `chat` pill renders an empty state until a producer
+// lands. `chat`/`wiki` are derived from audit_log per Q-tl-2's default.
+function pillForResourceKind(kind: string): TimelineFilterPill | null {
+  switch (kind) {
+    case "proposal":
+    case "agentsmd":
+      return "wiki";
+    case "ingest":
+      return "ingest";
+    default:
+      // byok, workspace_settings — no pill.
+      return null;
+  }
+}
+
+/**
+ * Returns the subset of `names` that exist as tables in the current
+ * D1 database. Used so the union query can skip not-yet-shipped tables
+ * (`issue_threads`, and defensively `scheduled_actions`) instead of
+ * throwing "no such table".
+ */
+async function existingTables(env: Env, names: string[]): Promise<Set<string>> {
+  if (names.length === 0) return new Set();
+  const placeholders = names.map(() => "?").join(", ");
+  const rs = await env.DB.prepare(
+    `SELECT name FROM sqlite_master WHERE type = 'table' AND name IN (${placeholders})`,
+  )
+    .bind(...names)
+    .all<{ name: string }>();
+  return new Set((rs.results ?? []).map((r) => r.name));
+}
+
+interface ParsedQuery {
+  cursor: string | null;
+  since: number | null;
+  until: number | null;
+  limit: number;
+  pills: Set<TimelineFilterPill> | null; // null = all sources
+  user: string | null;
+  namespace: string | null;
+}
+
+function parseQuery(c: { req: { query: (k: string) => string | undefined } }): ParsedQuery {
+  const cursorRaw = c.req.query("cursor");
+  let cursor: string | null = null;
+  if (cursorRaw !== undefined && cursorRaw.length > 0) {
+    const parsed = Uuidv7Schema.safeParse(cursorRaw);
+    if (!parsed.success) {
+      throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "cursor must be a UUIDv7", {
+        status: 400,
+      });
+    }
+    cursor = parsed.data;
+  }
+
+  const parseEpoch = (key: string): number | null => {
+    const raw = c.req.query(key);
+    if (raw === undefined || raw.length === 0) return null;
+    const n = Number.parseInt(raw, 10);
+    if (!Number.isFinite(n) || n < 0) {
+      throw new LoomwikiError(
+        ErrorCodes.VALIDATION_FAILED,
+        `${key} must be a non-negative unix-seconds integer`,
+        { status: 400 },
+      );
+    }
+    return n;
+  };
+  const since = parseEpoch("since");
+  const until = parseEpoch("until");
+
+  const limitRaw = c.req.query("limit");
+  let limit = DEFAULT_LIMIT;
+  if (limitRaw !== undefined) {
+    const n = Number.parseInt(limitRaw, 10);
+    if (!Number.isFinite(n) || n <= 0) {
+      throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "limit must be a positive integer", {
+        status: 400,
+      });
+    }
+    limit = Math.min(n, MAX_LIMIT);
+  }
+
+  const sourcesRaw = c.req.query("sources");
+  let pills: Set<TimelineFilterPill> | null = null;
+  if (sourcesRaw !== undefined && sourcesRaw.length > 0) {
+    pills = new Set();
+    for (const token of sourcesRaw.split(",")) {
+      const t = token.trim();
+      if (t.length === 0) continue;
+      const parsed = TimelineFilterPillSchema.safeParse(t);
+      if (!parsed.success) {
+        throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, `Unknown source filter: ${t}`, {
+          status: 400,
+        });
+      }
+      pills.add(parsed.data);
+    }
+    if (pills.size === 0) pills = null;
+  }
+
+  const userRaw = c.req.query("user");
+  let user: string | null = null;
+  if (userRaw !== undefined && userRaw.length > 0) {
+    const parsed = Uuidv7Schema.safeParse(userRaw);
+    if (!parsed.success) {
+      throw new LoomwikiError(ErrorCodes.VALIDATION_FAILED, "user must be a UUIDv7", {
+        status: 400,
+      });
+    }
+    user = parsed.data;
+  }
+
+  const namespaceRaw = c.req.query("namespace");
+  const namespace = namespaceRaw !== undefined && namespaceRaw.length > 0 ? namespaceRaw : null;
+
+  return { cursor, since, until, limit, pills, user, namespace };
+}
+
+// Whether the union should consult a given origin given the active
+// pill filter. `audit` backs both `wiki` and `chat` pills (chat is
+// empty today — TODO(Q-tl-2)) plus the ingest-audit rows.
+function wantsSource(pills: Set<TimelineFilterPill> | null, pill: TimelineFilterPill): boolean {
+  return pills === null || pills.has(pill);
+}
+
+/**
+ * Compare two entries for the merged ordering: newest first, ties
+ * broken by descending id (UUIDv7 → stable, monotonic-on-time).
+ */
+function cmpDesc(a: TimelineEntry, b: TimelineEntry): number {
+  if (a.at !== b.at) return b.at - a.at;
+  return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+}
+
+export const timelineRoute = new Hono<AuthEnv>().get("/timeline", async (c) => {
+  requireOwner(c);
+  const q = parseQuery(c);
+  const wsId = c.var.workspace.id;
+
+  // A namespace filter scopes to wiki/ingest/scheduled rows tied to a
+  // room slug. Resolve it to a room id once; if it matches nothing the
+  // feed is simply empty for room-bound sources.
+  // TODO(Q-tl-2): namespace currently maps to a room slug only; wiki
+  // path namespaces land when a chat producer exists.
+  let namespaceRoomId: string | null = null;
+  if (q.namespace !== null) {
+    const room = await c.env.DB.prepare("SELECT id FROM rooms WHERE workspace_id = ? AND slug = ?")
+      .bind(wsId, q.namespace)
+      .first<{ id: string }>();
+    namespaceRoomId = room?.id ?? null;
+    if (namespaceRoomId === null) {
+      // Namespace names a room that doesn't exist — nothing room-bound
+      // can match. audit rows aren't room-scoped so we still let those
+      // through unfiltered; but a namespace filter is room-intent, so
+      // an unresolvable namespace yields an empty page deterministically.
+      return c.json(apiOk({ entries: [], next_cursor: null }));
+    }
+  }
+
+  // Oversample each source at `limit` so the merged top-`limit` is
+  // correct regardless of how rows interleave across sources.
+  const collected: TimelineEntry[] = [];
+
+  const cursorClause = q.cursor !== null ? " AND id < ?" : "";
+  const sinceClause = (col: string) => (q.since !== null ? ` AND ${col} >= ?` : "");
+  const untilClause = (col: string) => (q.until !== null ? ` AND ${col} <= ?` : "");
+
+  // ---- audit_log (backs `wiki` + `chat` + ingest-audit rows) ----
+  // Pull when any of those pills is active. Filter to pill-bearing rows
+  // matching the requested pills (and always include no-pill admin rows
+  // when the feed is unfiltered).
+  const auditWanted =
+    wantsSource(q.pills, "wiki") || wantsSource(q.pills, "chat") || wantsSource(q.pills, "ingest");
+  if (auditWanted) {
+    const params: unknown[] = [wsId];
+    let sql = `SELECT id, workspace_id, actor_user_id, action, resource_kind, resource_id,
+              before_json, after_json, request_id, created_at
+         FROM audit_log
+        WHERE workspace_id = ?`;
+    if (q.cursor !== null) {
+      sql += cursorClause;
+      params.push(q.cursor);
+    }
+    if (q.since !== null) {
+      sql += sinceClause("created_at");
+      params.push(q.since);
+    }
+    if (q.until !== null) {
+      sql += untilClause("created_at");
+      params.push(q.until);
+    }
+    if (q.user !== null) {
+      sql += " AND actor_user_id = ?";
+      params.push(q.user);
+    }
+    sql += " ORDER BY created_at DESC, id DESC LIMIT ?";
+    params.push(q.limit);
+    const rs = await c.env.DB.prepare(sql)
+      .bind(...params)
+      .all();
+    for (const raw of rs.results ?? []) {
+      const row = parseAuditLogRow(raw);
+      const kindParsed = AuditResourceKindSchema.safeParse(row.resource_kind);
+      const pill = kindParsed.success ? pillForResourceKind(kindParsed.data) : null;
+      // When a pill filter is active, only emit rows whose derived
+      // pill is in the active set. No-pill admin rows are emitted only
+      // in the unfiltered feed (matching "stays visible, matches no
+      // pill"). namespace filtering does not apply to audit rows.
+      if (q.pills !== null) {
+        if (pill === null || !q.pills.has(pill)) continue;
+      }
+      collected.push({
+        source: "audit",
+        id: row.id,
+        at: row.created_at,
+        action: row.action,
+        resource_kind: row.resource_kind,
+        resource_id: row.resource_id,
+        actor_user_id: row.actor_user_id,
+        pill,
+        created_at: row.created_at,
+      });
+    }
+  }
+
+  // ---- ingest_runs (`ingest` pill) ----
+  // Q-tl-5: render at the status-change time — finished_at when the run
+  // is terminal, else started_at. We order/cursor on `id` (UUIDv7,
+  // time-sortable) for stable pagination, and expose both timestamps in
+  // the payload so the island can label "started"/"finished".
+  if (wantsSource(q.pills, "ingest")) {
+    const params: unknown[] = [wsId];
+    let sql = `SELECT ir.id AS id, ir.room_id AS room_id, ir.triggered_by AS triggered_by,
+              ir.started_at AS started_at, ir.finished_at AS finished_at,
+              ir.last_message_id AS last_message_id, ir.status AS status,
+              ir.summary AS summary, ir.error AS error
+         FROM ingest_runs ir
+         JOIN rooms r ON r.id = ir.room_id
+        WHERE r.workspace_id = ?`;
+    if (q.cursor !== null) {
+      sql += " AND ir.id < ?";
+      params.push(q.cursor);
+    }
+    if (namespaceRoomId !== null) {
+      sql += " AND ir.room_id = ?";
+      params.push(namespaceRoomId);
+    }
+    // `since`/`until` apply to the render time. started_at is always
+    // populated and ≤ finished_at, so range-filter on started_at; the
+    // exact render-time is recomputed below.
+    if (q.since !== null) {
+      sql += " AND ir.started_at >= ?";
+      params.push(q.since);
+    }
+    if (q.until !== null) {
+      sql += " AND ir.started_at <= ?";
+      params.push(q.until);
+    }
+    if (q.user !== null) {
+      sql += " AND ir.triggered_by = ?";
+      params.push(q.user);
+    }
+    sql += " ORDER BY ir.started_at DESC, ir.id DESC LIMIT ?";
+    params.push(q.limit);
+    const rs = await c.env.DB.prepare(sql)
+      .bind(...params)
+      .all();
+    for (const raw of rs.results ?? []) {
+      const row = parseIngestRunRow(raw);
+      const terminal: IngestRunStatus[] = ["succeeded", "failed"];
+      const at =
+        row.finished_at !== null && terminal.includes(row.status)
+          ? row.finished_at
+          : row.started_at;
+      collected.push({
+        source: "ingest",
+        id: row.id,
+        at,
+        room_id: row.room_id,
+        status: row.status,
+        triggered_by: row.triggered_by,
+        summary: row.summary,
+        error: row.error,
+        started_at: row.started_at,
+        finished_at: row.finished_at,
+      });
+    }
+  }
+
+  // ---- scheduled_actions + issue_threads (tolerant) ----
+  const optional = await existingTables(c.env, ["scheduled_actions", "issue_threads"]);
+
+  // scheduled_actions (`scheduled` pill). Render at last_fired_at when
+  // it has fired, else next_fire_at (the upcoming fire). Q-tl-5-style.
+  if (wantsSource(q.pills, "scheduled") && optional.has("scheduled_actions")) {
+    const params: unknown[] = [wsId];
+    let sql = `SELECT id, workspace_id, room_id, created_by, kind, cron_expr, fire_at,
+              prompt, status, failure_count, last_fired_at, next_fire_at,
+              created_at, updated_at
+         FROM scheduled_actions
+        WHERE workspace_id = ?`;
+    if (q.cursor !== null) {
+      sql += " AND id < ?";
+      params.push(q.cursor);
+    }
+    if (namespaceRoomId !== null) {
+      sql += " AND room_id = ?";
+      params.push(namespaceRoomId);
+    }
+    if (q.user !== null) {
+      sql += " AND created_by = ?";
+      params.push(q.user);
+    }
+    sql += " ORDER BY created_at DESC, id DESC LIMIT ?";
+    params.push(q.limit);
+    const rs = await c.env.DB.prepare(sql)
+      .bind(...params)
+      .all();
+    for (const raw of rs.results ?? []) {
+      const row = parseScheduledActionRow(raw);
+      const at = row.last_fired_at ?? row.next_fire_at;
+      if (q.since !== null && at < q.since) continue;
+      if (q.until !== null && at > q.until) continue;
+      const status: ScheduledActionStatus = row.status;
+      collected.push({
+        source: "scheduled",
+        id: row.id,
+        at,
+        room_id: row.room_id,
+        kind: row.kind,
+        status,
+        prompt_preview: row.prompt.slice(0, 280),
+        next_fire_at: row.next_fire_at,
+        last_fired_at: row.last_fired_at,
+        created_at: row.created_at,
+      });
+    }
+  }
+
+  // issue_threads (#30) — table not built yet. Forward-declared shape;
+  // when #30 ships the table this block lights up with zero timeline
+  // code changes. Until then `optional` won't include it and we skip.
+  if (wantsSource(q.pills, "issue") && optional.has("issue_threads")) {
+    // TODO(#30): map issue_threads rows → IssueTimelineEntry once the
+    // table's exact columns are committed. Intentionally a no-op until
+    // then — the tolerant existence check above guarantees we never
+    // 500 on the absent table, and the empty `issue` filter renders
+    // the "lands with #30" empty state client-side.
+  }
+
+  // Merge → newest first → slice to limit. next_cursor is set whenever
+  // the page is full (== limit) — the same conservative contract
+  // admin-audit.ts uses: a full page *might* have more, so hand back a
+  // cursor; the caller's next request returns rows strictly older than
+  // the last id and pagination terminates because each page strictly
+  // advances the (monotonic) cursor. A final partial page yields null.
+  collected.sort(cmpDesc);
+  const page = collected.slice(0, q.limit);
+  const nextCursor = page.length === q.limit ? (page[page.length - 1]?.id ?? null) : null;
+
+  return c.json(apiOk({ entries: page, next_cursor: nextCursor }));
+});

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -655,3 +655,126 @@ export const PatchScheduledActionRequestSchema = z
     message: "at least one field required",
   });
 export type PatchScheduledActionRequest = z.infer<typeof PatchScheduledActionRequestSchema>;
+
+// ---------- Unified timeline (issue #32) ----------
+//
+// The timeline is a *view*, not a table — there is no `timeline`
+// migration. `/api/timeline` server-side-unions four data origins
+// (`audit_log`, `ingest_runs`, `scheduled_actions`, and the
+// not-yet-existing `issue_threads` from #30) into a single
+// chronological feed.
+//
+// `TimelineSource` is the data-origin discriminant the React island
+// switches on for rendering. It is distinct from the UI *filter pills*
+// (`chat | wiki | ingest | scheduled | issue`): the worker maps a
+// pill-name `sources` query param onto these origins (e.g. the `wiki`
+// pill selects `audit` rows whose `resource_kind` is vault-content).
+//
+// Every entry carries `id` (a UUIDv7 — the cursor token) and `at`
+// (unix epoch seconds — the timestamp the entry renders at; per
+// Q-tl-5 ingest/scheduled render at their status-change time, not
+// always `created_at`). Times stay unix-seconds on the wire; the
+// viewer converts to local TZ client-side (Q-tl-3).
+
+export const TimelineSourceSchema = z.enum(["audit", "ingest", "scheduled", "issue"]);
+export type TimelineSource = z.infer<typeof TimelineSourceSchema>;
+
+// The pill names the web UI shows. The worker accepts these in the
+// `sources` query param (comma-separated) and maps them onto origins.
+// `lint` is intentionally absent — Q-tl-1 resolved to "drop until a
+// producer exists" (no dead filters).
+export const TIMELINE_FILTER_PILLS = ["chat", "wiki", "ingest", "scheduled", "issue"] as const;
+export const TimelineFilterPillSchema = z.enum(TIMELINE_FILTER_PILLS);
+export type TimelineFilterPill = z.infer<typeof TimelineFilterPillSchema>;
+
+const TimelineEntryBase = {
+  // UUIDv7 of the originating row — also the pagination cursor token.
+  id: Uuidv7Schema,
+  // Unix epoch seconds. The instant this entry renders at on the feed.
+  at: EpochSeconds,
+};
+
+// `audit` — an `audit_log` row. `resource_kind` carries the original
+// audit taxonomy so the island can sub-label (proposal vs agentsmd vs
+// byok). `deep_link` points at the audit row's diff view.
+export const AuditTimelineEntrySchema = z.object({
+  ...TimelineEntryBase,
+  source: z.literal("audit"),
+  action: AuditActionSchema,
+  resource_kind: AuditResourceKindSchema,
+  resource_id: z.string().max(128).nullable(),
+  actor_user_id: Uuidv7Schema.nullable(),
+  // The pill this row surfaces under, derived server-side from
+  // resource_kind. `null` = no pill (admin-only actions like byok /
+  // workspace_settings stay in the unfiltered feed but match no pill).
+  pill: TimelineFilterPillSchema.nullable(),
+  created_at: EpochSeconds,
+});
+export type AuditTimelineEntry = z.infer<typeof AuditTimelineEntrySchema>;
+
+// `ingest` — an `ingest_runs` row. Renders at the status-change time
+// (`finished_at` when terminal, else `started_at` — Q-tl-5). Deep-links
+// to the originating room.
+export const IngestTimelineEntrySchema = z.object({
+  ...TimelineEntryBase,
+  source: z.literal("ingest"),
+  room_id: Uuidv7Schema,
+  status: IngestRunStatusSchema,
+  triggered_by: IngestRunTriggerSchema,
+  summary: z.string().max(280).nullable(),
+  error: z.string().max(2000).nullable(),
+  started_at: EpochSeconds,
+  finished_at: EpochSeconds.nullable(),
+});
+export type IngestTimelineEntry = z.infer<typeof IngestTimelineEntrySchema>;
+
+// `scheduled` — a `scheduled_actions` row (issue #33; the issue body's
+// `scheduled_prompts` name is stale — #33 shipped this as
+// `scheduled_actions`). Renders at `last_fired_at` if it has fired,
+// else `next_fire_at` (the upcoming fire). Deep-links to the room.
+export const ScheduledTimelineEntrySchema = z.object({
+  ...TimelineEntryBase,
+  source: z.literal("scheduled"),
+  room_id: Uuidv7Schema,
+  kind: ScheduledActionKindSchema,
+  status: ScheduledActionStatusSchema,
+  prompt_preview: z.string().max(280),
+  next_fire_at: EpochSeconds,
+  last_fired_at: EpochSeconds.nullable(),
+  created_at: EpochSeconds,
+});
+export type ScheduledTimelineEntry = z.infer<typeof ScheduledTimelineEntrySchema>;
+
+// `issue` — an `issue_threads` row (#30). The table does not exist yet;
+// this shape is forward-declared so the island + worker need no change
+// when #30 lands. Renders at `last_status_change` (Q-tl-5) but keeps
+// `created_at` so a future "full history" toggle can group on it.
+export const IssueTimelineStatusSchema = z.enum(["open", "in-progress", "blocked", "closed"]);
+export type IssueTimelineStatus = z.infer<typeof IssueTimelineStatusSchema>;
+
+export const IssueTimelineEntrySchema = z.object({
+  ...TimelineEntryBase,
+  source: z.literal("issue"),
+  issue_number: z.number().int().positive(),
+  repo: z.string().min(1).max(200),
+  status: IssueTimelineStatusSchema,
+  chat_room_id: Uuidv7Schema.nullable(),
+  wiki_slug: z.string().max(256).nullable(),
+  created_at: EpochSeconds,
+  last_status_change: EpochSeconds,
+});
+export type IssueTimelineEntry = z.infer<typeof IssueTimelineEntrySchema>;
+
+export const TimelineEntrySchema = z.discriminatedUnion("source", [
+  AuditTimelineEntrySchema,
+  IngestTimelineEntrySchema,
+  ScheduledTimelineEntrySchema,
+  IssueTimelineEntrySchema,
+]);
+export type TimelineEntry = z.infer<typeof TimelineEntrySchema>;
+
+export const TimelineResponseSchema = z.object({
+  entries: z.array(TimelineEntrySchema),
+  next_cursor: Uuidv7Schema.nullable(),
+});
+export type TimelineResponse = z.infer<typeof TimelineResponseSchema>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@astrojs/react':
         specifier: ^4.1.2
         version: 4.4.2(@types/node@25.6.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(tsx@4.21.0)(yaml@2.8.4)
+      '@loomwiki/schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
       '@loomwiki/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
Closes #32

The v0.1 follow-through to ADR-0007 §e ("JSON-only access in v0.0.1; no UI"). One owner-gated `/timeline` that server-side-unions the audit log + ingest runs into a single chronological feed, with graceful-empty handling for the scheduled / issue sources until their producers fully land.

## What shipped

- **`packages/schema`** — `TimelineSource` / `TimelineEntry` discriminated-union Zod schemas (`audit | ingest | scheduled | issue`) + `TimelineResponse`. The React island imports the same inferred types (`@loomwiki/schema` added as a `workspace:*` dep to `apps/web`).
- **`apps/worker/src/routes/timeline.ts`** — `GET /api/timeline?since=&until=&sources=&user=&namespace=&limit=&cursor=` → `ApiResult<{ entries; next_cursor }>`. Owner-gated via the `requireOwner` pattern from `admin-audit.ts`. UUIDv7 cursor pagination; per-source oversample at `limit`, merge in code by `(at DESC, id DESC)`. `sqlite_master` tolerant table-existence check so an absent optional table contributes zero rows instead of 500ing. Mounted in `index.ts` with `authMiddleware` on `/api/timeline`.
- **`apps/web`** — `timeline.astro` (SSR shell, owner-gated, mirrors `inbox/index.astro`) + `TimelineFeed.tsx` island (source pills `chat|wiki|ingest|scheduled|issue`, day/week/month + feed toggle, per-pill empty-state copy naming the upstream issue, deep-links). `/timeline` nav entry added via the existing `isOwner`→`AppShell` path (same path Settings uses, so it rides #28's plumbing rather than regressing it).
- **`apps/worker/src/__tests__/routes-timeline.test.ts`** — empty workspace, non-owner 403, source-pill filtering, cursor round-trip (no gaps/dupes), malformed-cursor 400, unknown-source 400, scheduled-row inclusion, and graceful handling when `scheduled_actions`/`issue_threads` are absent (drops the table to simulate).

## Verification (exact counts)

- `pnpm install` — success (lockfile updated; frozen-install safe)
- `pnpm test` — **686 passed, 1 skipped** (schema 75 · shared 54 · worker 418 +1 skipped/51 files · web 139/26 files); new `routes-timeline.test.ts` = **9/9**
- `pnpm typecheck` — **0 errors** (all 4 packages)
- `pnpm lint` — **0 errors / 0 warnings** (270 files, exit 0)
- `pnpm --filter @loomwiki/web build` — success (`TimelineFeed` island + `timeline.astro` compiled)

## Open-question defaults taken

- **Q-tl-1** — dropped `lint` (no producer; no dead filters).
- **Q-tl-2** — `chat`/`wiki` derived from `audit_log` by `resource_kind` (`proposal`+`agentsmd`→`wiki`; `byok`/`workspace_settings`→no pill, stay visible in the unfiltered feed). No `chat` producer exists yet, so the `chat` pill renders an empty state. `// TODO(Q-tl-2)` left in `timeline.ts`.
- **Q-tl-3** — server returns unix-epoch seconds; the island converts to the viewer's local TZ for grouping.
- **Q-tl-4** — page size 50 / MAX 200 (mirrors the audit log).
- **Q-tl-5** — ingest renders at `finished_at` when terminal else `started_at`; scheduled at `last_fired_at ?? next_fire_at`; issue at `last_status_change` with `created_at` kept in the payload for a future "full history" toggle.

## Assumptions / deviations (flagged for review)

- **`scheduled_prompts` → `scheduled_actions`**: the issue body's table name is stale — #33 already shipped this as `scheduled_actions`. The route reads `scheduled_actions` through the same tolerant table-existence helper, so it still survives either name being absent. The `scheduled` source is therefore *live*, not empty.
- **Non-owner UX is the 200 "Owner only" gate page, not a page-level 403** — this matches the established repo convention (`byok.astro`, `agentsmd.astro`). The acceptance criterion's "matches existing audit-log behavior" maps to the API, and `GET /api/timeline` correctly returns **403** for non-owners (covered by test).
- **`manual_ingest.trigger` audit row + its `ingest_runs` row are intentionally both shown** — distinct events at distinct times (the human's audited trigger vs. the run outcome). Collapsing them would lose the ADR-0007 forensic signal. Documented in `timeline.ts`.
- **`issue` source is a forward-declared no-op** until #30 commits the `issue_threads` columns — the schema + tolerant check mean zero timeline-code changes when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
