### PR TITLE
fix(web): align timeline.astro with @astrojs/cloudflare v13 ssr-api (red main)

### DIFF
--- a/apps/web/src/pages/timeline.astro
+++ b/apps/web/src/pages/timeline.astro
@@ -23,10 +23,9 @@ interface TimelinePayload {
   next_cursor: string | null;
 }
 
-const env = Astro.locals.runtime?.env;
 let me: CurrentUserPayload;
 try {
-  me = await ssrApiGet<CurrentUserPayload>(Astro.request, "/api/me", env);
+  me = await ssrApiGet<CurrentUserPayload>(Astro.request, "/api/me");
 } catch (err) {
   if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
   throw err;
@@ -40,7 +39,7 @@ const isOwner = me.workspace.owner_id === me.user.id;
 let timeline: TimelinePayload = { entries: [], next_cursor: null };
 if (isOwner) {
   try {
-    timeline = await ssrApiGet<TimelinePayload>(Astro.request, "/api/timeline", env);
+    timeline = await ssrApiGet<TimelinePayload>(Astro.request, "/api/timeline");
   } catch (err) {
     if (err instanceof SsrAuthRequiredError) return Astro.redirect("/login");
     // A 403 here would mean the owner check disagrees with /api/me;


### PR DESCRIPTION
## Problem

`main` is RED at `122bd7d` (CI run 25977684352). #75 (`/timeline`) and #76 (astro 5→6 / @astrojs/cloudflare v13) were each green against the pre-merge main but **collide once both are on main** — a semantic merge conflict per-PR CI cannot catch:

- #76 changed `ssrApiGet` to 2-arg (it resolves the `API` binding internally via `cloudflare:workers` `env`) and dropped `Astro.locals.runtime`.
- #75's `apps/web/src/pages/timeline.astro` still passed a third `env` arg and read `Astro.locals.runtime`.

3 `tsc` errors (`timeline.astro` lines 26/29/43).

## Fix

Align `timeline.astro` with the post-#76 pattern already used by `inbox/index.astro`: 2-arg `ssrApiGet`, drop the `Astro.locals.runtime` env plumbing. Behaviour is unchanged (the helper resolves the binding itself).

## Verification (in clean worktree off `origin/main`)

- `pnpm typecheck`: **0 errors, 0 warnings** (was 3 errors)
- `pnpm lint`: clean (270 files)
- `pnpm test`: pass (worker 418 passed / 1 skipped; suite exit 0)
- `pnpm --filter @loomwiki/web build`: Complete

Unblocks #79 (docs-only, whose required check was red purely from this pre-existing main breakage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>