### PR TITLE
fix(ci): tag CD worker deploy with git SHA so /api/health smoke passes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,8 +89,21 @@ jobs:
       - name: Apply D1 migrations (forward-only)
         run: pnpm migrate:remote
 
-      - name: Deploy API Worker (loomwiki-api)
-        run: pnpm deploy:worker
+      # `pnpm deploy:worker` is just `wrangler deploy` (no tag). The
+      # /api/health endpoint reports CF_VERSION_METADATA.tag and the
+      # smoke job asserts it equals the deployed git SHA (see #65 /
+      # commit 792cfa7 and apps/worker/src/routes/health.ts). Without
+      # --tag, .tag is empty and health falls back to the deployment
+      # UUID (.id), which never equals github.sha → smoke fails forever.
+      # So CI deploys with --tag set to the commit SHA. github.sha is a
+      # trusted runner-provided value (a 40-char hex SHA, not
+      # attacker-controlled event text); passed via env + quoted per
+      # the workflow-injection-safe pattern. The manual `deploy:worker`
+      # script is intentionally left untouched (operator contract).
+      - name: Deploy API Worker (loomwiki-api, tagged with git SHA)
+        env:
+          DEPLOY_SHA: ${{ github.sha }}
+        run: pnpm --filter @loomwiki/worker exec wrangler deploy --config ../../wrangler.jsonc --tag "$DEPLOY_SHA"
 
   deploy-web:
     name: deploy loomwiki-web (gated)


### PR DESCRIPTION
## Problem

The CD pipeline from #82 now deploys successfully (D1 + `wrangler deploy` + route all green after the operator token fix), but the `smoke` job fails at `Verify /api/health (commit + ok flag)` on every run.

Root cause: `/api/health` reports `CF_VERSION_METADATA.tag || .id` (`apps/worker/src/routes/health.ts`), and the `smoke` job asserts `.data.commit == github.sha`. Per #65 / commit `792cfa7`, the tag is *only* the git SHA when CI deploys with `wrangler deploy --tag $SHA`. The #82 deploy step ran plain `pnpm deploy:worker` (= `wrangler deploy`, **no `--tag`**), so `.tag` is empty, health falls back to the deployment UUID (`.id`), which never equals `github.sha` → the commit assertion fails forever even though the deploy itself worked.

Verified: run 25991442876 — `deploy loomwiki-api` = success, `smoke` fails only at `Verify /api/health`.

## Fix

CI deploys the API worker with `--tag` set to `github.sha` (passed via `env: DEPLOY_SHA` and quoted — `github.sha` is a trusted 40-char runner value, not attacker-controlled event text; follows the workflow-injection-safe pattern). The manual `pnpm deploy:worker` script is intentionally left unchanged so the operator/local contract doesn't shift.

`wrangler deploy --tag` confirmed supported on wrangler 4.92. `deploy.yml` YAML validated.

This is the last mile of #82's pipeline. Refs #83 (CD-blocked tracker — this is the in-scope code fix its acceptance allows; #83 closes when a `deploy.yml` run goes `deploy-api → smoke` fully green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>