### PR TITLE
fix(ci): authenticate smoke security-headers check through Cloudflare Access

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -208,7 +208,19 @@ jobs:
         if: steps.guard.outputs.skip != 'true'
         run: |
           set -euo pipefail
-          HEADERS=$(curl -fsSI --max-time 10 "${BASE_URL}/")
+          # The whole origin is behind Cloudflare Access. Without the
+          # service-token headers this request gets Access's own login
+          # challenge — not our app — so the Astro middleware
+          # (apps/web/src/middleware.ts) that sets CSP / X-Frame-Options
+          # never runs and the headers are absent. Authenticate like the
+          # /api/health and /api/me steps. Also use a GET (not HEAD): the
+          # middleware only attaches these headers to text/html responses,
+          # so we need the real SSR HTML response. -D - dumps response
+          # headers, -o /dev/null discards the body.
+          HEADERS=$(curl -fsS -D - -o /dev/null --max-time 10 \
+            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
+            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
+            "${BASE_URL}/")
           echo "$HEADERS" | grep -i '^Content-Security-Policy:' > /dev/null
           echo "$HEADERS" | grep -i '^X-Frame-Options:[[:space:]]*DENY' > /dev/null
 


### PR DESCRIPTION
## Problem

After #85, the CD smoke gets further: `deploy-api` ✅ and `Verify /api/health` ✅ (run 25992126650). It now fails at `Verify security headers (CSP, X-Frame-Options)`.

Root cause: that step did `curl -fsSI "${BASE_URL}/"` with **no** CF-Access service-token headers. The entire origin is behind Cloudflare Access, so the request got Access's *login challenge*, not our app — the Astro middleware (`apps/web/src/middleware.ts:62,65`) that sets `Content-Security-Policy` / `X-Frame-Options: DENY` only runs inside the Worker and only on `text/html` responses, so the headers were absent. The check was testing Cloudflare's challenge page. It was inherited verbatim from the original `post-deploy.yml` and never actually exercised (the verifier never got past secrets/token/--tag/DNS before).

## Fix

Authenticate the headers request with the same service-token headers the `/api/health` and `/api/me` steps use (env-var, quoted — injection-safe, identical pattern to existing steps), and use a GET with `-D - -o /dev/null` instead of `-I`/HEAD so the response is the real SSR `text/html` and the middleware attaches the headers.

App code is correct and unchanged — this is purely the smoke check reaching the wrong surface.

Refs #83 (closes once a `deploy.yml` run goes `deploy-api → smoke` fully green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>