### PR TITLE
ci: make smoke security-headers step diagnosable (print /login status+headers)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -221,12 +221,23 @@ jobs:
           # which has no text/html body so the middleware skips it. Use
           # GET (not HEAD); -D - dumps response headers, -o /dev/null
           # discards the body.
-          HEADERS=$(curl -fsS -D - -o /dev/null --max-time 10 \
+          # Diagnostic: capture status + response headers and PRINT them
+          # (response headers carry no secrets) so a failure shows what
+          # /login actually returns instead of failing opaquely. Drop -f
+          # so an HTTP error still yields headers to inspect; assert the
+          # status and the security headers explicitly afterwards.
+          resp_headers="$(mktemp)"
+          code="$(curl -sS -o /dev/null -D "$resp_headers" -w '%{http_code}' --max-time 10 \
             -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
             -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
-            "${BASE_URL}/login")
-          echo "$HEADERS" | grep -i '^Content-Security-Policy:' > /dev/null
-          echo "$HEADERS" | grep -i '^X-Frame-Options:[[:space:]]*DENY' > /dev/null
+            "${BASE_URL}/login")"
+          echo "GET ${BASE_URL}/login -> HTTP ${code}"
+          echo "--- response headers ---"
+          cat "$resp_headers"
+          echo "--- end response headers ---"
+          test "$code" = "200"
+          grep -i '^Content-Security-Policy:' "$resp_headers" > /dev/null
+          grep -i '^X-Frame-Options:[[:space:]]*DENY' "$resp_headers" > /dev/null
 
       - name: Verify /api/me (authenticated)
         id: me


### PR DESCRIPTION
## Problem

The security-headers smoke step has failed three runs (pre-auth, post-auth #86, /login #87) and fails **opaquely** — it captured response headers into a shell var but never printed them, so the actual cause of `/login` lacking CSP/X-Frame-Options is unknown. Continuing to hypothesize-and-PR is wasteful.

## Change

Instrument the step (debugging, not a behavior fix): drop `-f` so an HTTP error still yields inspectable headers; capture the HTTP status (`-w %{http_code}`) and response headers (`-D`); **print both** (response headers contain no secrets — the request headers hold the token, not the response); then assert `status == 200` and the two security headers explicitly.

Next `deploy.yml` run's `smoke` log will show exactly what `https://loomwiki.cortech.online/login` returns (status, content-type, whether it's the app HTML, the Access challenge, a 404, etc.), so the real fix is evidence-driven.

No app code change. Refs #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>