### PR TITLE
ci: drop /api/me from post-deploy smoke (service token is not a user)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,7 +143,9 @@ jobs:
   # blind 120s sleep against a non-deploy — issue #78). Asserts:
   #   1. /api/health is OK, fast (<5s), and reports the SHA we just shipped.
   #   2. Security headers are present on the front door (CSP, X-Frame-Options).
-  #   3. /api/me returns 200 + { user, workspace } when service-token auth is used.
+  # (A /api/me check was intentionally dropped — a CF Access service token
+  # is a machine identity with no email claim, so the worker auth cannot
+  # resolve it to a user by design; see the note above the issue-filer.)
   # On any failure, files/append to a single GitHub issue (de-duped).
   #
   # CF Access service-token secrets (provisioned via Cloudflare Zero Trust
@@ -239,17 +241,15 @@ jobs:
           grep -i '^Content-Security-Policy:' "$resp_headers" > /dev/null
           grep -i '^X-Frame-Options:[[:space:]]*DENY' "$resp_headers" > /dev/null
 
-      - name: Verify /api/me (authenticated)
-        id: me
-        if: steps.guard.outputs.skip != 'true'
-        run: |
-          set -euo pipefail
-          BODY=$(curl -fsS --max-time 5 \
-            -H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" \
-            -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}" \
-            "${BASE_URL}/api/me")
-          echo "$BODY" | jq -e '.data.user' > /dev/null
-          echo "$BODY" | jq -e '.data.workspace' > /dev/null
+      # Note: a /api/me check was intentionally removed. A Cloudflare
+      # Access *service token* (what CI uses) authenticates as a machine,
+      # not a person, so the verified Access JWT carries no `email` claim
+      # and the worker auth (apps/worker/src/lib/auth.ts) cannot resolve
+      # it to a user/workspace by design — /api/me would always 401 under
+      # service-token auth. The smoke proves the deploy shipped (health +
+      # matching commit) and the front door is hardened (security
+      # headers); authenticated *user* flows are covered by unit/route
+      # tests, not the live service-token smoke.
 
       - name: File issue on failure
         if: failure()
@@ -270,7 +270,6 @@ jobs:
               `Steps in \`.github/workflows/deploy.yml\` (smoke job):`,
               `- /api/health (200 + ok:true + matching commit, <5s)`,
               `- Security headers (Content-Security-Policy, X-Frame-Options: DENY)`,
-              `- /api/me (200 + JSON with user + workspace fields)`,
               ``,
               `Inspect the run logs above to identify which step failed.`,
               ``,


### PR DESCRIPTION
## Problem

The CD smoke's final step `Verify /api/me` fails by design. CI authenticates with a Cloudflare Access **service token** (machine identity); the verified Access JWT carries **no `email` claim**, and the worker auth (`apps/worker/src/lib/auth.ts:107-109`, `apps/worker/src/middleware/auth.ts:83-93`) requires `email` and has **no service-token→user mapping**. So `/api/me` always returns 401 under service-token auth. This check was inherited verbatim from the original `post-deploy.yml` and was never actually exercised (the verifier never reached it until now).

Everything else in the smoke is now verified green end-to-end: `deploy-api` ✅, `/api/health` ✅ (commit-tagged via #85), security headers ✅ (`X-Frame-Options: DENY` after the operator disabled the conflicting Cloudflare managed transform).

## Decision

Maintainer chose (2026-05-17) to **drop the `/api/me` assertion** rather than add a service-token→user mapping to the auth path (smallest change, zero auth-path risk). The smoke still proves: the deploy shipped and reports the right commit, and the front door is hardened (CSP + `X-Frame-Options: DENY`). Authenticated *user* flows remain covered by unit/route tests, not the live service-token smoke.

## Change

Remove the `Verify /api/me` step; update the job-header comment and the failure-issue body list so they no longer claim a check that doesn't exist. No app code change.

`Closes #83` — with this, a `deploy.yml` run goes `deploy-api → smoke` fully green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>