### PR TITLE
docs: reflect web CD enabled — WEB_CD_ENABLED=true cutover complete

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,5 +65,5 @@ GIT_COMMIT=
 #   CF_ACCESS_CLIENT_SECRET  # Access service-token client secret (post-deploy smoke).
 #
 # Repository variable:
-#   WEB_CD_ENABLED           # "true" enables the loomwiki-web CD job. Leave
-#                            # unset/"false" until the one-time Pages -> Worker cutover.
+#   WEB_CD_ENABLED           # "true" enables the loomwiki-web CD job (set on canonical deploy).
+#                            # Fork operators: leave unset/"false" until your own Pages -> Worker cutover.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1041,7 +1041,7 @@ live smoke is gated to run only *after* a successful deploy
 | Job | Default | What it does |
 |---|---|---|
 | `deploy-api` | **on** | `pnpm migrate:remote` (D1 migrations, forward-only, idempotent) then `pnpm deploy:worker` (`wrangler deploy` of `loomwiki-api`). |
-| `deploy-web` | **off** | `pnpm deploy:web` (`astro build && wrangler deploy` of `loomwiki-web`). `needs: deploy-api`. Gated behind `WEB_CD_ENABLED` (see below). |
+| `deploy-web` | **on** | `pnpm deploy:web` (`astro build && wrangler deploy` of `loomwiki-web`). `needs: deploy-api`. Gated behind `WEB_CD_ENABLED` (see below); enabled on the canonical deploy. |
 | `smoke` | on | The post-deploy live verifier. `needs: deploy-api`, so it runs only after a successful deploy and its `.data.commit == <merged SHA>` assertion can finally pass. Preserves the #74 CF Access secret-guard + the issue de-dupe. |
 
 `deploy-api` runs the D1 migrations as an explicit step **before**
@@ -1076,25 +1076,33 @@ Configure at **Settings → Secrets and variables → Actions →
 Variables**:
 
 - `WEB_CD_ENABLED` — set to the string `"true"` to enable the
-  `deploy-web` job. **Leave it unset (or `"false"`) until the one-time
-  Pages → Worker production cutover is complete.** The web app deploys
-  as a Worker post-#76, but an existing deploy must finish the cutover
-  *before* the first automated `wrangler deploy` of `loomwiki-web`,
-  otherwise the deploy collides on the name and the live site breaks.
-  See **One-time production cutover: Pages project → Worker** above for
-  the full procedure.
+  `deploy-web` job. **The canonical deploy has completed the one-time
+  Pages → Worker cutover; this variable is now `"true"` on
+  `loomwiki.cortech.online`.** Fork operators on an existing deploy:
+  leave it unset (or `"false"`) until you complete your own cutover —
+  see **One-time production cutover: Pages project → Worker** above.
+  Fresh deploys on a clean account (no prior Pages project) can set it
+  to `"true"` immediately after the first manual `pnpm deploy:web`.
 
-### Enabling web CD after the cutover
+### Web CD status: enabled (canonical deploy)
+
+The `loomwiki.cortech.online` deploy has completed the one-time Pages →
+Worker cutover. `WEB_CD_ENABLED=true` is set in the repo; `deploy-web`
+runs automatically on every push to `main` after `deploy-api` succeeds
+(so the `API` service binding resolves before the web Worker deploys).
+
+**Fork operators** who have not yet cut over should follow these steps
+before setting the variable:
 
 1. Complete the **One-time production cutover** (above): detach the
    custom domain from the retired Pages project, delete the Pages
    project, run `pnpm deploy:web` once manually from a clean tree, and
    attach the custom domain to the new Worker.
-2. Verify the live site (`curl -s https://loomwiki.cortech.online/api/health`
-   and a browser sign-in).
-3. Then, and only then, set repo variable `WEB_CD_ENABLED=true`. The
-   next push to `main` will deploy `loomwiki-web` automatically (after
-   `deploy-api`, so the `API` service binding resolves).
+2. Verify the live site (`curl -s https://your-domain/api/health` and
+   a browser sign-in).
+3. Then set repo variable `WEB_CD_ENABLED=true` (Settings → Secrets and
+   variables → Actions → Variables). The next push to `main` deploys
+   `loomwiki-web` automatically (after `deploy-api`).
 
 A fresh deploy on a clean account that never had a Pages project can
 skip the cutover and set `WEB_CD_ENABLED=true` immediately after the


### PR DESCRIPTION
## Summary

- Updates `DEPLOY.md` to reflect that the Pages → Worker production cutover for `loomwiki.cortech.online` is complete and `WEB_CD_ENABLED=true` is set.
- Renames the "Enabling web CD after the cutover" section to "Web CD status: enabled (canonical deploy)" — clarifies current state while preserving the fork-operator procedure.
- Updates the pipeline table: `deploy-web` listed as **on** (enabled for the canonical deploy).
- Updates `.env.example` `WEB_CD_ENABLED` comment: notes the canonical deploy has the variable set; preserves the cutover caveat for fork operators.
- The `if: vars.WEB_CD_ENABLED == 'true'` guard in `deploy.yml` is intentionally kept — fork operators who haven't completed the Pages → Worker cutover still need it off.

Closes #90

## Operator action still required

`WEB_CD_ENABLED=true` must be set in **GitHub Settings → Secrets and variables → Actions → Variables** if not already done. This docs PR reflects the intended post-cutover state; CI will not run `deploy-web` until the variable is live.

## Test plan

- [x] `pnpm test` — 51 files, 418 passing / 1 skipped, 0 failing
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — no issues
- [x] No code changes — docs and comment-only diff

## Deferred follow-ups

none

https://claude.ai/code/session_015YC9QaDJzUoU1sqngTqmh4

---
_Generated by [Claude Code](https://claude.ai/code/session_015YC9QaDJzUoU1sqngTqmh4)_