### PR TITLE
docs: reflect web CD is enabled (WEB_CD_ENABLED=true)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,5 +65,7 @@ GIT_COMMIT=
 #   CF_ACCESS_CLIENT_SECRET  # Access service-token client secret (post-deploy smoke).
 #
 # Repository variable:
-#   WEB_CD_ENABLED           # "true" enables the loomwiki-web CD job. Leave
-#                            # unset/"false" until the one-time Pages -> Worker cutover.
+#   WEB_CD_ENABLED           # "true" enables the loomwiki-web CD job.
+#                            # Set to "true" for the reference deploy (cutover complete).
+#                            # Operators forking pre-cutover: leave unset/"false" until
+#                            # the one-time Pages -> Worker cutover is done (DEPLOY.md).

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1041,7 +1041,7 @@ live smoke is gated to run only *after* a successful deploy
 | Job | Default | What it does |
 |---|---|---|
 | `deploy-api` | **on** | `pnpm migrate:remote` (D1 migrations, forward-only, idempotent) then `pnpm deploy:worker` (`wrangler deploy` of `loomwiki-api`). |
-| `deploy-web` | **off** | `pnpm deploy:web` (`astro build && wrangler deploy` of `loomwiki-web`). `needs: deploy-api`. Gated behind `WEB_CD_ENABLED` (see below). |
+| `deploy-web` | **on** | `pnpm deploy:web` (`astro build && wrangler deploy` of `loomwiki-web`). `needs: deploy-api`. Gated behind `WEB_CD_ENABLED` (variable is set to `"true"` — see below). |
 | `smoke` | on | The post-deploy live verifier. `needs: deploy-api`, so it runs only after a successful deploy and its `.data.commit == <merged SHA>` assertion can finally pass. Preserves the #74 CF Access secret-guard + the issue de-dupe. |
 
 `deploy-api` runs the D1 migrations as an explicit step **before**
@@ -1076,15 +1076,21 @@ Configure at **Settings → Secrets and variables → Actions →
 Variables**:
 
 - `WEB_CD_ENABLED` — set to the string `"true"` to enable the
-  `deploy-web` job. **Leave it unset (or `"false"`) until the one-time
-  Pages → Worker production cutover is complete.** The web app deploys
-  as a Worker post-#76, but an existing deploy must finish the cutover
-  *before* the first automated `wrangler deploy` of `loomwiki-web`,
-  otherwise the deploy collides on the name and the live site breaks.
-  See **One-time production cutover: Pages project → Worker** above for
-  the full procedure.
+  `deploy-web` job. The one-time Pages → Worker cutover is complete for
+  the reference deploy (`loomwiki.cortech.online`); this variable is
+  now set to `"true"` and web CD is active. Operators forking this repo
+  before the cutover should leave it unset (or `"false"`) until the
+  **One-time production cutover: Pages project → Worker** procedure
+  below is done.
 
 ### Enabling web CD after the cutover
+
+> **Reference deploy status:** the one-time cutover is complete and
+> `WEB_CD_ENABLED` is set to `"true"`. Web CD is active — every push
+> to `main` deploys `loomwiki-web` after `loomwiki-api`.
+
+For a new fork or a deploy that still has a Pages project, follow
+these steps in order:
 
 1. Complete the **One-time production cutover** (above): detach the
    custom domain from the retired Pages project, delete the Pages


### PR DESCRIPTION
## Summary

- Flips the `deploy-web` pipeline table entry from **off** → **on** in `DEPLOY.md`
- Updates the `WEB_CD_ENABLED` variable description to note the Pages → Worker cutover is complete for the reference deploy; operators forking pre-cutover still get the guidance they need
- Adds a "Reference deploy status: done" callout to the "Enabling web CD after the cutover" section so no one re-runs completed steps
- Mirrors the status update in `.env.example`'s `WEB_CD_ENABLED` comment

Closes #90

## Operator action required (not a code change)

The `if: vars.WEB_CD_ENABLED == 'true'` guard in `.github/workflows/deploy.yml` is intentionally unchanged — enabling is setting the repo variable, not removing the guard. To activate web CD:

1. Go to **GitHub repo → Settings → Secrets and variables → Actions → Variables**
2. Create (or update) variable `WEB_CD_ENABLED` with value `true`

The next push to `main` after that will run `deploy-web` automatically (after `deploy-api`, so the `API` service binding resolves).

## Test plan

- [x] `pnpm test` — 51 files, 418 passing, 1 skipped
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 270 files, no issues
- [ ] Operator sets `WEB_CD_ENABLED=true` in GitHub Settings → a push to `main` shows `deploy-web` = success (not skipped) in CI
- [ ] `https://loomwiki.cortech.online/login` returns 200 with CSP + `X-Frame-Options: DENY` after web deploy

## Acceptance deferred

None from the code side. The repo variable itself (`WEB_CD_ENABLED=true`) must be set in GitHub Settings by the operator — that is a settings action, not a code change, and cannot be performed from this PR.

https://claude.ai/code/session_0112LVCwpKjrbdwmwPP4Mazy

---
_Generated by [Claude Code](https://claude.ai/code/session_0112LVCwpKjrbdwmwPP4Mazy)_