### PR TITLE
docs: update DEPLOY.md to reflect web CD enabled (WEB_CD_ENABLED=true)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1041,7 +1041,7 @@ live smoke is gated to run only *after* a successful deploy
 | Job | Default | What it does |
 |---|---|---|
 | `deploy-api` | **on** | `pnpm migrate:remote` (D1 migrations, forward-only, idempotent) then `pnpm deploy:worker` (`wrangler deploy` of `loomwiki-api`). |
-| `deploy-web` | **off** | `pnpm deploy:web` (`astro build && wrangler deploy` of `loomwiki-web`). `needs: deploy-api`. Gated behind `WEB_CD_ENABLED` (see below). |
+| `deploy-web` | **on** | `pnpm deploy:web` (`astro build && wrangler deploy` of `loomwiki-web`). `needs: deploy-api`. Controlled by `WEB_CD_ENABLED` (see below); set to `"true"` for the reference deploy. |
 | `smoke` | on | The post-deploy live verifier. `needs: deploy-api`, so it runs only after a successful deploy and its `.data.commit == <merged SHA>` assertion can finally pass. Preserves the #74 CF Access secret-guard + the issue de-dupe. |
 
 `deploy-api` runs the D1 migrations as an explicit step **before**
@@ -1076,24 +1076,32 @@ Configure at **Settings → Secrets and variables → Actions →
 Variables**:
 
 - `WEB_CD_ENABLED` — set to the string `"true"` to enable the
-  `deploy-web` job. **Leave it unset (or `"false"`) until the one-time
-  Pages → Worker production cutover is complete.** The web app deploys
-  as a Worker post-#76, but an existing deploy must finish the cutover
-  *before* the first automated `wrangler deploy` of `loomwiki-web`,
-  otherwise the deploy collides on the name and the live site breaks.
-  See **One-time production cutover: Pages project → Worker** above for
-  the full procedure.
+  `deploy-web` job. **Set to `"true"` for the reference deploy**
+  (`loomwiki.cortech.online`): the one-time Pages → Worker production
+  cutover is complete and the `loomwiki-web` Worker is live. On a fresh
+  fork that still has an existing Pages project, leave this unset (or
+  `"false"`) until you have completed the cutover — deploying before
+  cutover collides on the Worker name and breaks the live site. See
+  **One-time production cutover: Pages project → Worker** above.
 
 ### Enabling web CD after the cutover
+
+> **Reference deploy (`loomwiki.cortech.online`) — already done.** The
+> cutover completed and `WEB_CD_ENABLED=true` is set. Every push to
+> `main` now deploys `loomwiki-web` automatically (after `deploy-api`).
+
+For operators on a fresh fork that still has a `loomwiki-web` **Pages**
+project:
 
 1. Complete the **One-time production cutover** (above): detach the
    custom domain from the retired Pages project, delete the Pages
    project, run `pnpm deploy:web` once manually from a clean tree, and
    attach the custom domain to the new Worker.
-2. Verify the live site (`curl -s https://loomwiki.cortech.online/api/health`
+2. Verify the live site (`curl -s https://<your-domain>/api/health`
    and a browser sign-in).
-3. Then, and only then, set repo variable `WEB_CD_ENABLED=true`. The
-   next push to `main` will deploy `loomwiki-web` automatically (after
+3. Then, and only then, set repo variable `WEB_CD_ENABLED=true`
+   (Settings → Secrets and variables → Actions → Variables). The next
+   push to `main` will deploy `loomwiki-web` automatically (after
    `deploy-api`, so the `API` service binding resolves).
 
 A fresh deploy on a clean account that never had a Pages project can
@@ -1112,7 +1120,7 @@ attach the custom domain).
 - Without `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` the smoke
   **skips** (the #74 guard — a missing operator secret is not a deploy
   failure), so no noise issue is filed.
-- `deploy-web` stays skipped until `WEB_CD_ENABLED=true`.
+- `deploy-web` runs on every push for the reference deploy (`WEB_CD_ENABLED=true` is set). On a fresh fork, it stays skipped until you set `WEB_CD_ENABLED=true` after completing the cutover.
 
 Rollback automation / blue-green / canary are out of scope for the
 single-env v0.0.1 dogfood; tracked as future work in `docs/RELEASE.md`.


### PR DESCRIPTION
## Summary

- Marks `deploy-web` as **on** in the pipeline shape table (was **off**)
- Updates the `WEB_CD_ENABLED` variable description to note it is set for the reference deploy (`loomwiki.cortech.online`), while retaining the guard guidance for fresh forks with an existing Pages project
- Adds a callout to the "Enabling web CD after the cutover" section noting the reference deploy is done; keeps the full procedure for other operators
- Updates the "Operator action required" bullet to reflect that `deploy-web` now runs on every push

The `if: vars.WEB_CD_ENABLED == 'true'` guard in `.github/workflows/deploy.yml` is **unchanged** — operators forking pre-cutover still need the ability to gate the job off.

Closes #90

## Operator action required (not in this PR)

Setting a GitHub Actions repository variable requires admin access to GitHub Settings and cannot be done via a code PR. If `WEB_CD_ENABLED` is not already set:

1. GitHub repo → **Settings → Secrets and variables → Actions → Variables**
2. Create variable `WEB_CD_ENABLED` with value `true`

The next push to `main` after that will run `deploy-web` automatically (after `deploy-api`).

## Test plan

- [x] `pnpm test` — 51 test files passed, 418 tests passed / 1 skipped
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 270 files, no fixes needed
- [ ] Operator sets `WEB_CD_ENABLED=true` in GitHub Settings
- [ ] Next push to `main` confirms `deploy-web` = success (not skipped) in CI
- [ ] `https://loomwiki.cortech.online/login` returns 200 with CSP + `X-Frame-Options: DENY`

## Acceptance deferred

None — the DEPLOY.md acceptance item is fully shipped. Setting the repo variable is an operator action in GitHub Settings (not a code change); this PR documents the current state and instructs the operator on where to flip it.

https://claude.ai/code/session_01Y5dH1f8jPrupytiuuiPFoj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5dH1f8jPrupytiuuiPFoj)_